### PR TITLE
feat: rewrite animation engine for cinematic map animations

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import * as turf from "@turf/turf";
+import mapboxgl from "mapbox-gl";
 import { MapProvider, useMap } from "./MapContext";
 import TopToolbar from "./TopToolbar";
 import LeftPanel from "./LeftPanel";
@@ -12,6 +14,8 @@ import ExportDialog from "./ExportDialog";
 import { AnimationEngine } from "@/engine/AnimationEngine";
 import { useProjectStore } from "@/stores/projectStore";
 import { useAnimationStore } from "@/stores/animationStore";
+
+const ANIM_ROUTE_SOURCE = "anim-route-src";
 
 function EditorContent() {
   const { map } = useMap();
@@ -41,7 +45,6 @@ function EditorContent() {
 
     if (!map || segments.length === 0) return;
 
-    // Only build engine if all segments have geometry
     const allReady = segments.every((s) => s.geometry !== null);
     if (!allReady) return;
 
@@ -60,6 +63,41 @@ function EditorContent() {
       } else {
         setVisiblePhotos([]);
       }
+    });
+
+    // Progressive route drawing
+    engine.on("routeDrawProgress", (e) => {
+      if (!map) return;
+      const seg = segments[e.segmentIndex];
+      if (!seg?.geometry || seg.geometry.coordinates.length < 2) return;
+
+      const src = map.getSource(ANIM_ROUTE_SOURCE) as
+        | mapboxgl.GeoJSONSource
+        | undefined;
+      if (!src) return;
+
+      const fraction = e.routeDrawFraction ?? 0;
+      if (fraction <= 0) {
+        src.setData({ type: "FeatureCollection", features: [] });
+        return;
+      }
+
+      const line = turf.lineString(seg.geometry.coordinates);
+      const totalLength = turf.length(line);
+      const sliceLength = fraction * totalLength;
+
+      const sliced = turf.lineSliceAlong(line, 0, sliceLength);
+
+      src.setData({
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: sliced.geometry,
+          },
+        ],
+      });
     });
 
     engine.on("complete", () => {
@@ -124,13 +162,49 @@ function EditorContent() {
             {currentCityLabel && (
               <motion.div
                 key={currentCityLabel}
-                initial={{ opacity: 0, y: 20, scale: 0.9 }}
-                animate={{ opacity: 1, y: 0, scale: 1 }}
-                exit={{ opacity: 0, y: -10, scale: 0.95 }}
-                transition={{ type: "spring", stiffness: 300, damping: 25 }}
+                initial={{
+                  opacity: 0,
+                  y: 20,
+                  scale: 0.8,
+                  filter: "blur(8px)",
+                }}
+                animate={{
+                  opacity: 1,
+                  y: 0,
+                  scale: 1,
+                  filter: "blur(0px)",
+                }}
+                exit={{
+                  opacity: 0,
+                  y: -10,
+                  scale: 0.95,
+                  filter: "blur(4px)",
+                }}
+                transition={{
+                  type: "spring",
+                  stiffness: 300,
+                  damping: 25,
+                }}
                 className="absolute top-6 left-1/2 -translate-x-1/2 z-10 rounded-lg bg-background/90 backdrop-blur-sm border shadow-lg px-5 py-2"
+                style={{
+                  textShadow:
+                    "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)",
+                }}
               >
-                <p className="text-lg font-semibold">{currentCityLabel}</p>
+                <p className="text-lg font-semibold flex items-center gap-2">
+                  <svg
+                    className="w-4 h-4 text-indigo-500 flex-shrink-0"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  {currentCityLabel}
+                </p>
               </motion.div>
             )}
           </AnimatePresence>

--- a/src/components/editor/MapCanvas.tsx
+++ b/src/components/editor/MapCanvas.tsx
@@ -5,6 +5,7 @@ import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useMap } from "./MapContext";
 import { useProjectStore } from "@/stores/projectStore";
+import { useAnimationStore } from "@/stores/animationStore";
 import { MAPBOX_TOKEN, getDefaultMapOptions } from "@/lib/mapbox";
 import { MAP_STYLES } from "@/lib/constants";
 import type { Segment, TransportMode } from "@/types";
@@ -13,6 +14,10 @@ mapboxgl.accessToken = MAPBOX_TOKEN;
 
 const SEGMENT_LAYER_PREFIX = "segment-";
 const SEGMENT_SOURCE_PREFIX = "segment-src-";
+const SEGMENT_GLOW_LAYER_PREFIX = "segment-glow-";
+const ANIM_ROUTE_SOURCE = "anim-route-src";
+const ANIM_ROUTE_LAYER = "anim-route-layer";
+const ANIM_ROUTE_GLOW_LAYER = "anim-route-glow-layer";
 
 const MODE_LINE_STYLES: Record<
   TransportMode,
@@ -32,11 +37,13 @@ export default function MapCanvas() {
   const mapInstanceRef = useRef<mapboxgl.Map | null>(null);
   const markersRef = useRef<Map<string, mapboxgl.Marker>>(new Map());
   const segmentLayersRef = useRef<Set<string>>(new Set());
+  const animRouteInitRef = useRef(false);
   const { setMap } = useMap();
   const addLocation = useProjectStore((s) => s.addLocation);
   const locations = useProjectStore((s) => s.locations);
   const segments = useProjectStore((s) => s.segments);
   const mapStyle = useProjectStore((s) => s.mapStyle);
+  const playbackState = useAnimationStore((s) => s.playbackState);
 
   // Initialize map
   useEffect(() => {
@@ -131,9 +138,13 @@ export default function MapCanvas() {
       // Remove stale layers/sources
       const activeIds = new Set(segments.map((s) => s.id));
       for (const layerId of segmentLayersRef.current) {
-        const segId = layerId.replace(SEGMENT_LAYER_PREFIX, "");
+        const segId = layerId
+          .replace(SEGMENT_GLOW_LAYER_PREFIX, "")
+          .replace(SEGMENT_LAYER_PREFIX, "");
         if (!activeIds.has(segId)) {
           if (map.getLayer(layerId)) map.removeLayer(layerId);
+          const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + segId;
+          if (map.getLayer(glowLayerId)) map.removeLayer(glowLayerId);
           const srcId = SEGMENT_SOURCE_PREFIX + segId;
           if (map.getSource(srcId)) map.removeSource(srcId);
           segmentLayersRef.current.delete(layerId);
@@ -144,6 +155,7 @@ export default function MapCanvas() {
       for (const seg of segments) {
         const srcId = SEGMENT_SOURCE_PREFIX + seg.id;
         const layerId = SEGMENT_LAYER_PREFIX + seg.id;
+        const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + seg.id;
         const lineStyle = MODE_LINE_STYLES[seg.transportMode];
 
         const geojsonData: GeoJSON.FeatureCollection = {
@@ -163,7 +175,6 @@ export default function MapCanvas() {
           (map.getSource(srcId) as mapboxgl.GeoJSONSource).setData(
             geojsonData
           );
-          // Update paint properties
           if (map.getLayer(layerId)) {
             map.setPaintProperty(layerId, "line-color", lineStyle.color);
             map.setPaintProperty(
@@ -174,13 +185,27 @@ export default function MapCanvas() {
           }
         } else {
           map.addSource(srcId, { type: "geojson", data: geojsonData });
+          // Glow layer (wider, blurred underneath)
+          map.addLayer({
+            id: glowLayerId,
+            type: "line",
+            source: srcId,
+            paint: {
+              "line-color": lineStyle.color,
+              "line-width": 10,
+              "line-opacity": 0.2,
+              "line-blur": 6,
+              "line-dasharray": lineStyle.dasharray || [1, 0],
+            },
+          });
+          // Main crisp line on top
           map.addLayer({
             id: layerId,
             type: "line",
             source: srcId,
             paint: {
               "line-color": lineStyle.color,
-              "line-width": 3,
+              "line-width": 4,
               "line-dasharray": lineStyle.dasharray || [1, 0],
             },
           });
@@ -196,6 +221,75 @@ export default function MapCanvas() {
     }
   }, [segments]);
 
+  // Setup animated route source/layers for progressive drawing
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+
+    const setupAnimRoute = () => {
+      if (animRouteInitRef.current) return;
+      if (!map.isStyleLoaded()) return;
+
+      const emptyGeoJSON: GeoJSON.FeatureCollection = {
+        type: "FeatureCollection",
+        features: [],
+      };
+
+      if (!map.getSource(ANIM_ROUTE_SOURCE)) {
+        map.addSource(ANIM_ROUTE_SOURCE, {
+          type: "geojson",
+          data: emptyGeoJSON,
+        });
+      }
+      if (!map.getLayer(ANIM_ROUTE_GLOW_LAYER)) {
+        map.addLayer({
+          id: ANIM_ROUTE_GLOW_LAYER,
+          type: "line",
+          source: ANIM_ROUTE_SOURCE,
+          paint: {
+            "line-color": "#6366f1",
+            "line-width": 12,
+            "line-opacity": 0.25,
+            "line-blur": 8,
+          },
+        });
+      }
+      if (!map.getLayer(ANIM_ROUTE_LAYER)) {
+        map.addLayer({
+          id: ANIM_ROUTE_LAYER,
+          type: "line",
+          source: ANIM_ROUTE_SOURCE,
+          paint: {
+            "line-color": "#6366f1",
+            "line-width": 4,
+            "line-opacity": 0.9,
+          },
+        });
+      }
+      animRouteInitRef.current = true;
+    };
+
+    if (map.isStyleLoaded()) {
+      setupAnimRoute();
+    } else {
+      map.once("style.load", setupAnimRoute);
+    }
+  }, []);
+
+  // Clear animated route when playback stops
+  useEffect(() => {
+    if (playbackState === "idle") {
+      const map = mapInstanceRef.current;
+      if (!map) return;
+      const src = map.getSource(ANIM_ROUTE_SOURCE) as
+        | mapboxgl.GeoJSONSource
+        | undefined;
+      if (src) {
+        src.setData({ type: "FeatureCollection", features: [] });
+      }
+    }
+  }, [playbackState]);
+
   // Sync map style — re-add layers after style change
   useEffect(() => {
     const map = mapInstanceRef.current;
@@ -204,14 +298,16 @@ export default function MapCanvas() {
     const styleUrl = MAP_STYLES[mapStyle];
     map.setStyle(styleUrl);
 
-    // After style loads, layers are cleared — we need to re-add them
     map.once("style.load", () => {
       segmentLayersRef.current.clear();
-      // Trigger segment re-render by reading current state
+      animRouteInitRef.current = false;
+
+      // Re-add segment layers
       const currentSegments = useProjectStore.getState().segments;
       for (const seg of currentSegments) {
         const srcId = SEGMENT_SOURCE_PREFIX + seg.id;
         const layerId = SEGMENT_LAYER_PREFIX + seg.id;
+        const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + seg.id;
         const lineStyle = MODE_LINE_STYLES[seg.transportMode];
 
         const geojsonData: GeoJSON.FeatureCollection = {
@@ -229,17 +325,61 @@ export default function MapCanvas() {
 
         map.addSource(srcId, { type: "geojson", data: geojsonData });
         map.addLayer({
+          id: glowLayerId,
+          type: "line",
+          source: srcId,
+          paint: {
+            "line-color": lineStyle.color,
+            "line-width": 10,
+            "line-opacity": 0.2,
+            "line-blur": 6,
+            "line-dasharray": lineStyle.dasharray || [1, 0],
+          },
+        });
+        map.addLayer({
           id: layerId,
           type: "line",
           source: srcId,
           paint: {
             "line-color": lineStyle.color,
-            "line-width": 3,
+            "line-width": 4,
             "line-dasharray": lineStyle.dasharray || [1, 0],
           },
         });
         segmentLayersRef.current.add(layerId);
       }
+
+      // Re-add animated route layers
+      const emptyGeoJSON: GeoJSON.FeatureCollection = {
+        type: "FeatureCollection",
+        features: [],
+      };
+      map.addSource(ANIM_ROUTE_SOURCE, {
+        type: "geojson",
+        data: emptyGeoJSON,
+      });
+      map.addLayer({
+        id: ANIM_ROUTE_GLOW_LAYER,
+        type: "line",
+        source: ANIM_ROUTE_SOURCE,
+        paint: {
+          "line-color": "#6366f1",
+          "line-width": 12,
+          "line-opacity": 0.25,
+          "line-blur": 8,
+        },
+      });
+      map.addLayer({
+        id: ANIM_ROUTE_LAYER,
+        type: "line",
+        source: ANIM_ROUTE_SOURCE,
+        paint: {
+          "line-color": "#6366f1",
+          "line-width": 4,
+          "line-opacity": 0.9,
+        },
+      });
+      animRouteInitRef.current = true;
     });
   }, [mapStyle]);
 

--- a/src/engine/AnimationEngine.ts
+++ b/src/engine/AnimationEngine.ts
@@ -1,12 +1,10 @@
 import * as turf from "@turf/turf";
-import BezierEasing from "bezier-easing";
 import type mapboxgl from "mapbox-gl";
 import type {
   Location,
   Segment,
   SegmentTiming,
   AnimationPhase,
-  CameraState,
 } from "@/types";
 import { CameraController } from "./CameraController";
 import { IconAnimator } from "./IconAnimator";
@@ -16,7 +14,8 @@ export type AnimationEventType =
   | "progress"
   | "phaseChange"
   | "segmentChange"
-  | "complete";
+  | "complete"
+  | "routeDrawProgress";
 
 export interface AnimationEvent {
   type: AnimationEventType;
@@ -26,11 +25,11 @@ export interface AnimationEvent {
   phase: AnimationPhase;
   cityLabel: string | null;
   showPhotos: boolean;
+  /** For routeDrawProgress: fraction of route drawn (0-1) */
+  routeDrawFraction?: number;
 }
 
 type AnimationListener = (event: AnimationEvent) => void;
-
-const easeInOut = BezierEasing(0.25, 0.1, 0.25, 1.0);
 
 export class AnimationEngine {
   private map: mapboxgl.Map;
@@ -66,13 +65,11 @@ export class AnimationEngine {
     const n = this.segments.length;
     if (n === 0) return [];
 
-    // Compute total target duration
     const totalTarget = Math.min(
       TARGET_DURATION.max,
       Math.max(TARGET_DURATION.min, n * 5)
     );
 
-    // Fixed times
     const hoverTime = PHASE_DURATIONS.HOVER;
     const arriveTime = PHASE_DURATIONS.ARRIVE;
     const photoTime = PHASE_DURATIONS.PHOTO_DISPLAY;
@@ -80,7 +77,6 @@ export class AnimationEngine {
     const timeline: SegmentTiming[] = [];
     let currentTime = 0;
 
-    // First, compute total fixed time
     let totalFixed = 0;
     for (let i = 0; i < n; i++) {
       totalFixed += hoverTime + arriveTime;
@@ -243,11 +239,11 @@ export class AnimationEngine {
     const fromLoc = this.locations.find((l) => l.id === seg.fromId)!;
     const toLoc = this.locations.find((l) => l.id === seg.toId)!;
 
-    // Camera
+    // Camera — easing is applied inside CameraController per-phase
     const cameraState = this.camera.getCameraState(
       segmentIndex,
       phase,
-      easeInOut(phaseProgress)
+      phaseProgress
     );
     this.map.jumpTo({
       center: cameraState.center,
@@ -256,7 +252,7 @@ export class AnimationEngine {
       pitch: cameraState.pitch,
     });
 
-    // Icon
+    // Icon — pass raw progress, IconAnimator handles its own smoothing
     this.iconAnimator.update(segmentIndex, phase, phaseProgress);
 
     // City label
@@ -277,6 +273,33 @@ export class AnimationEngine {
       cityLabel,
       showPhotos,
     });
+
+    // Emit route draw progress during FLY phase
+    if (phase === "FLY") {
+      const easing = this.camera.getEasing("FLY");
+      this.emit({
+        type: "routeDrawProgress",
+        time: clamped,
+        progress,
+        segmentIndex,
+        phase,
+        cityLabel: null,
+        showPhotos: false,
+        routeDrawFraction: easing(phaseProgress),
+      });
+    } else if (phase === "ZOOM_IN" || phase === "ARRIVE") {
+      // Route fully drawn after FLY completes
+      this.emit({
+        type: "routeDrawProgress",
+        time: clamped,
+        progress,
+        segmentIndex,
+        phase,
+        cityLabel: null,
+        showPhotos: false,
+        routeDrawFraction: 1,
+      });
+    }
   }
 
   private resolveTimePosition(time: number): {
@@ -298,13 +321,11 @@ export class AnimationEngine {
             };
           }
         }
-        // Fallback: last phase
         const lastPhase = st.phases[st.phases.length - 1];
         return { segmentIndex: i, phase: lastPhase.phase, phaseProgress: 1 };
       }
     }
 
-    // Past end — last segment ARRIVE
     if (this.timeline.length > 0) {
       return {
         segmentIndex: this.timeline.length - 1,

--- a/src/engine/CameraController.ts
+++ b/src/engine/CameraController.ts
@@ -1,5 +1,15 @@
 import * as turf from "@turf/turf";
+import BezierEasing from "bezier-easing";
 import type { Location, Segment, AnimationPhase, CameraState } from "@/types";
+
+// Per-phase easing curves
+const PHASE_EASINGS: Record<AnimationPhase, (t: number) => number> = {
+  HOVER: (t: number) => t, // linear
+  ZOOM_OUT: BezierEasing(0.0, 0.0, 0.2, 1.0), // ease-out
+  FLY: BezierEasing(0.42, 0.0, 0.58, 1.0), // ease-in-out
+  ZOOM_IN: BezierEasing(0.4, 0.0, 1.0, 1.0), // ease-in
+  ARRIVE: (t: number) => t, // linear
+};
 
 interface SegmentCamera {
   fromCenter: [number, number];
@@ -14,6 +24,7 @@ interface SegmentCamera {
 
 export class CameraController {
   private segmentCameras: SegmentCamera[];
+  private prevBearing: number = 0;
 
   constructor(locations: Location[], segments: Segment[]) {
     this.segmentCameras = segments.map((seg) => {
@@ -24,18 +35,10 @@ export class CameraController {
         turf.point(toLoc.coordinates)
       );
 
-      // Compute fly zoom from bounding box
-      const bbox = turf.bbox(
-        turf.featureCollection([
-          turf.point(fromLoc.coordinates),
-          turf.point(toLoc.coordinates),
-        ])
-      );
-      const bboxWidth = bbox[2] - bbox[0];
-      const bboxHeight = bbox[3] - bbox[1];
-      const maxSpan = Math.max(bboxWidth, bboxHeight);
-      const flyZoom = clamp(8.5 - Math.log2(Math.max(maxSpan, 0.1)), 1.5, 7);
-      const cityZoom = clamp(flyZoom + 4, 8, 13);
+      // Fly zoom based on distance: farther = more zoomed out
+      const flyZoom = clamp(7 - Math.log2(Math.max(distKm, 1) / 200), 1.5, 6);
+      // City zoom: close-up view
+      const cityZoom = clamp(flyZoom + 6, 12, 14);
 
       const routeLine = seg.geometry;
       const routeLength = routeLine
@@ -58,65 +61,133 @@ export class CameraController {
     });
   }
 
+  /** Get the per-phase easing function */
+  getEasing(phase: AnimationPhase): (t: number) => number {
+    return PHASE_EASINGS[phase];
+  }
+
   getCameraState(
     segmentIndex: number,
     phase: AnimationPhase,
-    progress: number
+    progress: number // raw progress (0-1), easing applied internally
   ): CameraState {
     const sc = this.segmentCameras[segmentIndex];
     if (!sc) {
       return { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 };
     }
 
-    // Bearing is ALWAYS 0 — north stays up
-    const bearing = 0;
+    const eased = PHASE_EASINGS[phase](progress);
 
     switch (phase) {
-      case "HOVER":
-        return { center: sc.fromCenter, zoom: sc.cityZoom, bearing, pitch: 0 };
+      case "HOVER": {
+        // Compute initial bearing toward route start direction
+        const bearing = this.getInitialBearing(sc);
+        this.prevBearing = bearing;
+        return {
+          center: sc.fromCenter,
+          zoom: sc.cityZoom,
+          bearing: 0,
+          pitch: 0,
+        };
+      }
 
       case "ZOOM_OUT": {
-        const center = lerp2d(sc.fromCenter, sc.midpoint, progress);
-        const zoom = lerp(sc.cityZoom, sc.flyZoom, progress);
-        const pitch = lerp(0, 45, progress);
+        // Ease from city to midpoint, zoom out, pitch up
+        const center = lerp2d(sc.fromCenter, sc.midpoint, eased * 0.3);
+        const zoom = lerp(sc.cityZoom, sc.flyZoom, eased);
+        const pitch = lerp(0, 60, eased);
+        // Start rotating bearing toward route direction
+        const targetBearing = this.getInitialBearing(sc);
+        const bearing = lerp(0, targetBearing, eased);
+        this.prevBearing = bearing;
         return { center, zoom, bearing, pitch };
       }
 
       case "FLY": {
         let center: [number, number];
+        let bearing: number;
 
         if (sc.routeLine && sc.routeLine.coordinates.length > 1) {
           const line = turf.lineString(sc.routeLine.coordinates);
-          const along = turf.along(line, progress * sc.routeLength);
+          const along = turf.along(line, eased * sc.routeLength);
           center = along.geometry.coordinates as [number, number];
+
+          // Dynamic bearing: look ahead along route
+          const lookAheadDist = Math.min(
+            (eased + 0.05) * sc.routeLength,
+            sc.routeLength
+          );
+          const ahead = turf.along(line, lookAheadDist);
+          const rawBearing = turf.bearing(along, ahead);
+          // Smooth bearing to avoid jerky rotation
+          bearing = smoothBearing(this.prevBearing, rawBearing, 0.15);
         } else {
-          center = lerp2d(sc.fromCenter, sc.toCenter, progress);
+          center = lerp2d(sc.fromCenter, sc.toCenter, eased);
+          bearing = turf.bearing(
+            turf.point(sc.fromCenter),
+            turf.point(sc.toCenter)
+          );
         }
 
+        this.prevBearing = bearing;
+
         // Gentle zoom pulse mid-flight
-        const zoomPulse = Math.sin(progress * Math.PI) * 0.6;
+        const zoomPulse = Math.sin(eased * Math.PI) * 0.4;
         const zoom = sc.flyZoom + zoomPulse;
-        const pitch = 45;
+        const pitch = 60;
 
         return { center, zoom, bearing, pitch };
       }
 
       case "ZOOM_IN": {
         const routeEnd = sc.routeLine
-          ? (sc.routeLine.coordinates[sc.routeLine.coordinates.length - 1] as [number, number])
+          ? (sc.routeLine.coordinates[
+              sc.routeLine.coordinates.length - 1
+            ] as [number, number])
           : sc.toCenter;
-        const center = lerp2d(routeEnd, sc.toCenter, progress);
-        const zoom = lerp(sc.flyZoom + 0.6, sc.cityZoom, progress);
-        const pitch = lerp(45, 0, progress);
+        const center = lerp2d(routeEnd, sc.toCenter, eased);
+        const zoom = lerp(sc.flyZoom + 0.4, sc.cityZoom, eased);
+        const pitch = lerp(60, 0, eased);
+        // Ease bearing back to 0
+        const bearing = lerp(this.prevBearing, 0, eased);
         return { center, zoom, bearing, pitch };
       }
 
       case "ARRIVE":
-        return { center: sc.toCenter, zoom: sc.cityZoom, bearing, pitch: 0 };
+        this.prevBearing = 0;
+        return {
+          center: sc.toCenter,
+          zoom: sc.cityZoom,
+          bearing: 0,
+          pitch: 0,
+        };
 
       default:
-        return { center: sc.fromCenter, zoom: sc.cityZoom, bearing, pitch: 0 };
+        return {
+          center: sc.fromCenter,
+          zoom: sc.cityZoom,
+          bearing: 0,
+          pitch: 0,
+        };
     }
+  }
+
+  /** Get the route length for a segment (used for progressive drawing) */
+  getRouteLength(segmentIndex: number): number {
+    return this.segmentCameras[segmentIndex]?.routeLength ?? 0;
+  }
+
+  private getInitialBearing(sc: SegmentCamera): number {
+    if (sc.routeLine && sc.routeLine.coordinates.length > 1) {
+      const start = sc.routeLine.coordinates[0] as [number, number];
+      const lookIdx = Math.min(10, sc.routeLine.coordinates.length - 1);
+      const lookPt = sc.routeLine.coordinates[lookIdx] as [number, number];
+      return turf.bearing(turf.point(start), turf.point(lookPt));
+    }
+    return turf.bearing(
+      turf.point(sc.fromCenter),
+      turf.point(sc.toCenter)
+    );
   }
 }
 
@@ -134,4 +205,17 @@ function lerp2d(
   t: number
 ): [number, number] {
   return [lerp(a[0], b[0], t), lerp(a[1], b[1], t)];
+}
+
+/** Smoothly interpolate between two bearings, handling the 360° wrap */
+function smoothBearing(
+  current: number,
+  target: number,
+  smoothing: number
+): number {
+  // Normalize both to [-180, 180]
+  let diff = target - current;
+  while (diff > 180) diff -= 360;
+  while (diff < -180) diff += 360;
+  return current + diff * smoothing;
 }

--- a/src/engine/IconAnimator.ts
+++ b/src/engine/IconAnimator.ts
@@ -45,12 +45,15 @@ const ICON_SVGS: Record<TransportMode, string> = {
   </svg>`,
 };
 
+const BASE_SIZE = 44;
+
 export class IconAnimator {
   private map: mapboxgl.Map;
   private segments: Segment[];
   private marker: mapboxgl.Marker | null = null;
   private iconEl: HTMLDivElement;
   private currentMode: string = "";
+  private prevBearing: number = 0;
 
   constructor(map: mapboxgl.Map, segments: Segment[]) {
     this.map = map;
@@ -58,7 +61,7 @@ export class IconAnimator {
 
     this.iconEl = document.createElement("div");
     this.iconEl.style.cssText =
-      "width:44px;height:44px;filter:drop-shadow(0 2px 6px rgba(0,0,0,0.35));pointer-events:none;";
+      "width:44px;height:44px;filter:drop-shadow(0 2px 6px rgba(0,0,0,0.35));pointer-events:none;transition:opacity 0.3s ease;";
   }
 
   private ensureMarker() {
@@ -66,8 +69,6 @@ export class IconAnimator {
       this.marker = new mapboxgl.Marker({
         element: this.iconEl,
         anchor: "center",
-        // rotationAlignment "map" makes the icon rotate with map bearing
-        // but since bearing is always 0, "viewport" also works
         rotationAlignment: "viewport",
         pitchAlignment: "viewport",
       })
@@ -102,17 +103,23 @@ export class IconAnimator {
     let position: [number, number];
     let bearing = 0;
     let showIcon = true;
+    let scale = 1.0;
+    let opacity = 1.0;
+    let glowIntensity = 0;
 
     switch (phase) {
       case "HOVER": {
         position = coords[0] as [number, number];
-        // Point toward next point on route
-        const nextPt = coords[Math.min(5, coords.length - 1)] as [number, number];
+        const nextPt = coords[Math.min(5, coords.length - 1)] as [
+          number,
+          number,
+        ];
         bearing = turf.bearing(turf.point(position), turf.point(nextPt));
+        // Subtle pulse at hover
+        glowIntensity = 0.3 + Math.sin(progress * Math.PI * 2) * 0.1;
         break;
       }
       case "ZOOM_OUT": {
-        // Move slightly along route
         const earlyProgress = progress * 0.05;
         const along = turf.along(line, earlyProgress * totalLength);
         position = along.geometry.coordinates as [number, number];
@@ -121,20 +128,34 @@ export class IconAnimator {
           Math.min(0.1, earlyProgress + 0.05) * totalLength
         );
         bearing = turf.bearing(along, lookAhead);
+        // Scale up as we zoom out
+        scale = lerp(1.0, 1.2, progress);
+        glowIntensity = lerp(0.3, 0.6, progress);
         break;
       }
       case "FLY": {
         const along = turf.along(line, progress * totalLength);
         position = along.geometry.coordinates as [number, number];
-        // Look ahead for smooth bearing
-        const aheadDist = Math.min((progress + 0.05) * totalLength, totalLength);
+        const aheadDist = Math.min(
+          (progress + 0.05) * totalLength,
+          totalLength
+        );
         const ahead = turf.along(line, aheadDist);
-        bearing = turf.bearing(along, ahead);
+        const rawBearing = turf.bearing(along, ahead);
+        // Smooth bearing
+        bearing = smoothBearing(this.prevBearing, rawBearing, 0.2);
+        // Larger during flight with subtle pulse
+        scale = 1.2 + Math.sin(progress * Math.PI * 4) * 0.05;
+        // Pulsing glow during movement
+        glowIntensity = 0.6 + Math.sin(progress * Math.PI * 6) * 0.2;
         break;
       }
       case "ZOOM_IN": {
         position = coords[coords.length - 1] as [number, number];
-        showIcon = progress < 0.5;
+        // Fade out smoothly over the full ZOOM_IN phase
+        opacity = lerp(1.0, 0.0, progress);
+        scale = lerp(1.2, 1.0, progress);
+        glowIntensity = lerp(0.6, 0.0, progress);
         break;
       }
       case "ARRIVE": {
@@ -146,11 +167,28 @@ export class IconAnimator {
         position = coords[0] as [number, number];
     }
 
+    this.prevBearing = bearing;
     this.marker!.setLngLat(position);
-    // setRotation: degrees clockwise from north
-    // Our SVG icons point NORTH by default, so bearing maps directly
     this.marker!.setRotation(bearing);
+
+    // Apply scale
+    const size = Math.round(BASE_SIZE * scale);
+    this.iconEl.style.width = `${size}px`;
+    this.iconEl.style.height = `${size}px`;
+
+    // Apply opacity
+    this.iconEl.style.opacity = showIcon ? String(opacity) : "0";
     this.iconEl.style.display = showIcon ? "block" : "none";
+
+    // Apply pulsing glow
+    if (glowIntensity > 0 && showIcon) {
+      const glowRadius = Math.round(6 + glowIntensity * 10);
+      const glowOpacity = (glowIntensity * 0.5).toFixed(2);
+      this.iconEl.style.filter = `drop-shadow(0 2px 6px rgba(0,0,0,0.35)) drop-shadow(0 0 ${glowRadius}px rgba(99,102,241,${glowOpacity}))`;
+    } else {
+      this.iconEl.style.filter =
+        "drop-shadow(0 2px 6px rgba(0,0,0,0.35))";
+    }
   }
 
   hide() {
@@ -163,4 +201,19 @@ export class IconAnimator {
       this.marker = null;
     }
   }
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function smoothBearing(
+  current: number,
+  target: number,
+  smoothing: number
+): number {
+  let diff = target - current;
+  while (diff > 180) diff -= 360;
+  while (diff < -180) diff += 360;
+  return current + diff * smoothing;
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,8 +1,8 @@
 import type { TransportMode, MapStyle } from "@/types";
 
 export const PHASE_DURATIONS = {
-  HOVER: 1.0,
-  ARRIVE: 1.2,
+  HOVER: 1.5,
+  ARRIVE: 1.5,
   PHOTO_DISPLAY: 2.0,
 } as const;
 
@@ -15,7 +15,7 @@ export const ZOOM_RANGE = {
 
 export const TARGET_DURATION = {
   min: 20,
-  max: 30,
+  max: 40,
 } as const;
 
 export const FPS = 30;


### PR DESCRIPTION
## Summary
- **CameraController**: Dynamic bearing that follows route direction, bigger zoom range (fly 1.5-6, city 12-14), 60° pitch during FLY, per-phase bezier easing (ease-out for ZOOM_OUT, ease-in-out for FLY, ease-in for ZOOM_IN), smooth bearing interpolation with 360° wrap handling
- **AnimationEngine**: Per-phase easing delegated to CameraController, new `routeDrawProgress` event for progressive line drawing, increased HOVER/ARRIVE durations to 1.5s, max target duration extended to 40s
- **IconAnimator**: Smooth scale transitions (1.0→1.2 during FLY), pulsing indigo glow during movement, gradual fade-out over full ZOOM_IN phase (was hard cutoff at 50%), smooth bearing interpolation
- **MapCanvas**: Progressive route drawing during FLY using `turf.lineSliceAlong()`, dual-layer glow effect (wider blurred line underneath + crisp 4px line on top), animated route layers with cleanup on playback stop
- **EditorLayout**: City label blur-to-sharp entrance, 0.8→1.0 spring scale, location pin icon, text shadow for readability, progressive route drawing integration

## Technical notes
- Still uses `map.jumpTo()` for frame-by-frame control (video export compatible)
- No store interface changes
- No API route changes
- `npx tsc --noEmit` passes cleanly

## Test plan
- [ ] Add 3+ cities, play animation — verify smooth camera transitions with bearing rotation
- [ ] Verify route draws progressively during FLY phase with glow underneath
- [ ] Verify icon scales up during FLY, pulses with glow, fades out smoothly during ZOOM_IN
- [ ] Verify city label appears with blur-to-sharp effect and location pin icon
- [ ] Verify pitch transitions: flat at HOVER → 60° at FLY → flat at ARRIVE
- [ ] Test video export still works correctly
- [ ] Test with different transport modes (flight, car, train)

🤖 Generated with [Claude Code](https://claude.com/claude-code)