### PR TITLE
feat: fix animation issues and add JSON import

### DIFF
--- a/src/components/editor/LeftPanel.tsx
+++ b/src/components/editor/LeftPanel.tsx
@@ -1,11 +1,57 @@
 "use client";
 
+import { useRef } from "react";
+import { Upload } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/components/ui/button";
+import { useProjectStore, type ImportRouteData } from "@/stores/projectStore";
+import { generateRouteGeometry } from "@/engine/RouteGeometry";
 import AIRouteGenerator from "./AIRouteGenerator";
 import CitySearch from "./CitySearch";
 import RouteList from "./RouteList";
 
 export default function LeftPanel() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const importRoute = useProjectStore((s) => s.importRoute);
+  const setSegmentGeometry = useProjectStore((s) => s.setSegmentGeometry);
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const data: ImportRouteData = JSON.parse(text);
+      importRoute(data);
+
+      // Generate geometry for each segment
+      const state = useProjectStore.getState();
+      for (const seg of state.segments) {
+        const fromLoc = state.locations.find((l) => l.id === seg.fromId);
+        const toLoc = state.locations.find((l) => l.id === seg.toId);
+        if (fromLoc && toLoc) {
+          try {
+            const geometry = await generateRouteGeometry(
+              fromLoc.coordinates,
+              toLoc.coordinates,
+              seg.transportMode
+            );
+            setSegmentGeometry(seg.id, geometry);
+          } catch {
+            // Geometry generation failed; segment keeps null geometry
+          }
+        }
+      }
+    } catch {
+      // Invalid JSON or file read error
+    }
+
+    // Reset input so same file can be re-imported
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
   return (
     <div className="flex h-full w-80 flex-col border-r bg-background">
       <div className="border-b px-3 py-2">
@@ -13,6 +59,24 @@ export default function LeftPanel() {
       </div>
       <AIRouteGenerator />
       <CitySearch />
+      <div className="px-3 py-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Upload className="mr-2 h-4 w-4" />
+          Import
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json"
+          className="hidden"
+          onChange={handleImport}
+        />
+      </div>
       <ScrollArea className="flex-1">
         <RouteList />
       </ScrollArea>

--- a/src/components/editor/MapCanvas.tsx
+++ b/src/components/editor/MapCanvas.tsx
@@ -276,11 +276,26 @@ export default function MapCanvas() {
     }
   }, []);
 
-  // Clear animated route when playback stops
+  // Hide static segment layers during playback, show when idle
   useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+
+    const visibility = playbackState === "playing" ? "none" : "visible";
+    for (const layerId of segmentLayersRef.current) {
+      if (map.getLayer(layerId)) {
+        map.setLayoutProperty(layerId, "visibility", visibility);
+      }
+      // Also hide/show glow layer
+      const segId = layerId.replace(SEGMENT_LAYER_PREFIX, "");
+      const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + segId;
+      if (map.getLayer(glowLayerId)) {
+        map.setLayoutProperty(glowLayerId, "visibility", visibility);
+      }
+    }
+
+    // Clear animated route when playback stops
     if (playbackState === "idle") {
-      const map = mapInstanceRef.current;
-      if (!map) return;
       const src = map.getSource(ANIM_ROUTE_SOURCE) as
         | mapboxgl.GeoJSONSource
         | undefined;

--- a/src/engine/AnimationEngine.ts
+++ b/src/engine/AnimationEngine.ts
@@ -274,6 +274,20 @@ export class AnimationEngine {
       showPhotos,
     });
 
+    // Reset animated route at start of each new segment (HOVER/ZOOM_OUT)
+    if (phase === "HOVER" || phase === "ZOOM_OUT") {
+      this.emit({
+        type: "routeDrawProgress",
+        time: clamped,
+        progress,
+        segmentIndex,
+        phase,
+        cityLabel: null,
+        showPhotos: false,
+        routeDrawFraction: 0,
+      });
+    }
+
     // Emit route draw progress during FLY phase
     if (phase === "FLY") {
       const easing = this.camera.getEasing("FLY");

--- a/src/engine/CameraController.ts
+++ b/src/engine/CameraController.ts
@@ -92,8 +92,8 @@ export class CameraController {
       }
 
       case "ZOOM_OUT": {
-        // Ease from city to midpoint, zoom out, pitch up
-        const center = lerp2d(sc.fromCenter, sc.midpoint, eased * 0.3);
+        // Zoom out from city, keeping center at fromCenter so FLY starts seamlessly
+        const center = sc.fromCenter;
         const zoom = lerp(sc.cityZoom, sc.flyZoom, eased);
         const pitch = lerp(0, 60, eased);
         // Start rotating bearing toward route direction
@@ -118,9 +118,19 @@ export class CameraController {
             sc.routeLength
           );
           const ahead = turf.along(line, lookAheadDist);
-          const rawBearing = turf.bearing(along, ahead);
-          // Smooth bearing to avoid jerky rotation
-          bearing = smoothBearing(this.prevBearing, rawBearing, 0.15);
+          const aCoord = along.geometry.coordinates;
+          const bCoord = ahead.geometry.coordinates;
+          // When look-ahead equals current (at route end), reuse cached bearing
+          if (
+            Math.abs(aCoord[0] - bCoord[0]) < 1e-9 &&
+            Math.abs(aCoord[1] - bCoord[1]) < 1e-9
+          ) {
+            bearing = this.prevBearing;
+          } else {
+            const rawBearing = turf.bearing(along, ahead);
+            // Smooth bearing to avoid jerky rotation
+            bearing = smoothBearing(this.prevBearing, rawBearing, 0.15);
+          }
         } else {
           center = lerp2d(sc.fromCenter, sc.toCenter, eased);
           bearing = turf.bearing(

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -7,6 +7,12 @@ import type {
   MapStyle,
 } from "@/types";
 
+export interface ImportRouteData {
+  name: string;
+  locations: { name: string; coordinates: [number, number] }[];
+  segments: { fromIndex: number; toIndex: number; transportMode: TransportMode }[];
+}
+
 interface ProjectState {
   locations: Location[];
   segments: Segment[];
@@ -25,6 +31,7 @@ interface ProjectState {
 
   setMapStyle: (style: MapStyle) => void;
   clearRoute: () => void;
+  importRoute: (data: ImportRouteData) => void;
 }
 
 let nextId = 1;
@@ -151,4 +158,24 @@ export const useProjectStore = create<ProjectState>((set) => ({
   setMapStyle: (style) => set({ mapStyle: style }),
 
   clearRoute: () => set({ locations: [], segments: [] }),
+
+  importRoute: (data) =>
+    set(() => {
+      const locations: Location[] = data.locations.map((loc) => ({
+        id: generateId(),
+        name: loc.name,
+        coordinates: loc.coordinates,
+        photos: [],
+      }));
+
+      const segments: Segment[] = data.segments.map((seg) => ({
+        id: generateId(),
+        fromId: locations[seg.fromIndex].id,
+        toId: locations[seg.toIndex].id,
+        transportMode: seg.transportMode,
+        geometry: null,
+      }));
+
+      return { locations, segments };
+    }),
 }));


### PR DESCRIPTION
## Summary
- **Fix progressive route drawing**: Hide static segment route layers during playback so only the animated overlay draws progressively. Layers are restored when playback stops.
- **Fix ZOOM_OUT → FLY camera jump**: Keep camera center at `fromCenter` during ZOOM_OUT so it matches FLY phase start position at progress=0, eliminating the snap-back.
- **Fix bearing snap at route end**: Cache last valid bearing during FLY phase. When look-ahead point equals current point (at route end), reuse cached bearing instead of getting 0 from `turf.bearing`.
- **Fix animated route between segments**: Emit `routeDrawProgress` with fraction 0 during HOVER and ZOOM_OUT phases to clear the previous segment's animated route.
- **Add JSON import feature**: New `importRoute` action in projectStore + Import button in LeftPanel that reads `.json` files and generates route geometry for each segment.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Import `fixtures/taiwan-trip.json` — all locations and segments appear
- [ ] Play animation — route draws progressively, static lines hidden
- [ ] No camera jump on ZOOM_OUT → FLY transition
- [ ] Bearing stays smooth at route end (no snap to north)
- [ ] Animated route clears between segments during HOVER/ZOOM_OUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)