### PR TITLE
feat: camera overhaul v2 — north-up, smart zoom, persistent routes

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -65,7 +65,7 @@ function EditorContent() {
       }
     });
 
-    // Progressive route drawing
+    // Progressive route drawing + segment completion tracking
     engine.on("routeDrawProgress", (e) => {
       if (!map) return;
       const seg = segments[e.segmentIndex];
@@ -77,6 +77,15 @@ function EditorContent() {
       if (!src) return;
 
       const fraction = e.routeDrawFraction ?? 0;
+
+      // When segment enters ARRIVE phase, mark it as completed
+      // so its static layer becomes visible again
+      if (fraction >= 1 && (e.phase === "ZOOM_IN" || e.phase === "ARRIVE")) {
+        window.dispatchEvent(
+          new CustomEvent("segment-complete", { detail: { segmentId: seg.id } })
+        );
+      }
+
       if (fraction <= 0) {
         src.setData({ type: "FeatureCollection", features: [] });
         return;

--- a/src/components/editor/LeftPanel.tsx
+++ b/src/components/editor/LeftPanel.tsx
@@ -53,7 +53,7 @@ export default function LeftPanel() {
   };
 
   return (
-    <div className="flex h-full w-80 flex-col border-r bg-background">
+    <div className="flex h-full w-80 flex-col overflow-hidden border-r bg-background">
       <div className="border-b px-3 py-2">
         <h2 className="text-sm font-semibold">Route</h2>
       </div>
@@ -77,7 +77,7 @@ export default function LeftPanel() {
           onChange={handleImport}
         />
       </div>
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 min-h-0">
         <RouteList />
       </ScrollArea>
     </div>

--- a/src/components/editor/MapCanvas.tsx
+++ b/src/components/editor/MapCanvas.tsx
@@ -8,7 +8,7 @@ import { useProjectStore } from "@/stores/projectStore";
 import { useAnimationStore } from "@/stores/animationStore";
 import { MAPBOX_TOKEN, getDefaultMapOptions } from "@/lib/mapbox";
 import { MAP_STYLES } from "@/lib/constants";
-import type { Segment, TransportMode } from "@/types";
+import type { TransportMode } from "@/types";
 
 mapboxgl.accessToken = MAPBOX_TOKEN;
 
@@ -44,6 +44,7 @@ export default function MapCanvas() {
   const segments = useProjectStore((s) => s.segments);
   const mapStyle = useProjectStore((s) => s.mapStyle);
   const playbackState = useAnimationStore((s) => s.playbackState);
+  const completedSegmentsRef = useRef<Set<string>>(new Set());
 
   // Initialize map
   useEffect(() => {
@@ -276,34 +277,76 @@ export default function MapCanvas() {
     }
   }, []);
 
-  // Hide static segment layers during playback, show when idle
+  // Manage static segment layer visibility during playback
+  // On play: hide all static layers (completed ones get shown back as segments finish)
+  // On idle: show all static layers and clear animated route
   useEffect(() => {
     const map = mapInstanceRef.current;
     if (!map) return;
 
-    const visibility = playbackState === "playing" ? "none" : "visible";
-    for (const layerId of segmentLayersRef.current) {
-      if (map.getLayer(layerId)) {
-        map.setLayoutProperty(layerId, "visibility", visibility);
+    if (playbackState === "playing") {
+      // Hide all static layers; completed ones will be re-shown via segmentChange events
+      completedSegmentsRef.current.clear();
+      for (const layerId of segmentLayersRef.current) {
+        if (map.getLayer(layerId)) {
+          map.setLayoutProperty(layerId, "visibility", "none");
+        }
+        const segId = layerId.replace(SEGMENT_LAYER_PREFIX, "");
+        const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + segId;
+        if (map.getLayer(glowLayerId)) {
+          map.setLayoutProperty(glowLayerId, "visibility", "none");
+        }
       }
-      // Also hide/show glow layer
-      const segId = layerId.replace(SEGMENT_LAYER_PREFIX, "");
-      const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + segId;
-      if (map.getLayer(glowLayerId)) {
-        map.setLayoutProperty(glowLayerId, "visibility", visibility);
+    } else {
+      // Show all static layers when idle/paused
+      completedSegmentsRef.current.clear();
+      for (const layerId of segmentLayersRef.current) {
+        if (map.getLayer(layerId)) {
+          map.setLayoutProperty(layerId, "visibility", "visible");
+        }
+        const segId = layerId.replace(SEGMENT_LAYER_PREFIX, "");
+        const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + segId;
+        if (map.getLayer(glowLayerId)) {
+          map.setLayoutProperty(glowLayerId, "visibility", "visible");
+        }
       }
-    }
 
-    // Clear animated route when playback stops
-    if (playbackState === "idle") {
-      const src = map.getSource(ANIM_ROUTE_SOURCE) as
-        | mapboxgl.GeoJSONSource
-        | undefined;
-      if (src) {
-        src.setData({ type: "FeatureCollection", features: [] });
+      // Clear animated route when playback stops
+      if (playbackState === "idle") {
+        const src = map.getSource(ANIM_ROUTE_SOURCE) as
+          | mapboxgl.GeoJSONSource
+          | undefined;
+        if (src) {
+          src.setData({ type: "FeatureCollection", features: [] });
+        }
       }
     }
   }, [playbackState]);
+
+  // Expose a method for AnimationEngine to mark segments as completed
+  // This is called from the animation event listener in the parent
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+
+    const handleSegmentComplete = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { segmentId: string };
+      completedSegmentsRef.current.add(detail.segmentId);
+      const layerId = SEGMENT_LAYER_PREFIX + detail.segmentId;
+      const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + detail.segmentId;
+      if (map.getLayer(layerId)) {
+        map.setLayoutProperty(layerId, "visibility", "visible");
+      }
+      if (map.getLayer(glowLayerId)) {
+        map.setLayoutProperty(glowLayerId, "visibility", "visible");
+      }
+    };
+
+    window.addEventListener("segment-complete", handleSegmentComplete);
+    return () => {
+      window.removeEventListener("segment-complete", handleSegmentComplete);
+    };
+  }, []);
 
   // Sync map style — re-add layers after style change
   useEffect(() => {

--- a/src/engine/AnimationEngine.ts
+++ b/src/engine/AnimationEngine.ts
@@ -70,7 +70,6 @@ export class AnimationEngine {
       Math.max(TARGET_DURATION.min, n * 5)
     );
 
-    const hoverTime = PHASE_DURATIONS.HOVER;
     const arriveTime = PHASE_DURATIONS.ARRIVE;
     const photoTime = PHASE_DURATIONS.PHOTO_DISPLAY;
 
@@ -79,6 +78,7 @@ export class AnimationEngine {
 
     let totalFixed = 0;
     for (let i = 0; i < n; i++) {
+      const hoverTime = this.camera.getHoverDuration(i);
       totalFixed += hoverTime + arriveTime;
       const toLoc = this.locations.find(
         (l) => l.id === this.segments[i].toId
@@ -96,6 +96,7 @@ export class AnimationEngine {
       const toLoc = this.locations.find((l) => l.id === seg.toId);
       const hasPhotos = toLoc && toLoc.photos.length > 0;
 
+      const hoverTime = this.camera.getHoverDuration(i);
       const zoomOutDur = variablePerSegment * 0.25;
       const flyDur = variablePerSegment * 0.45;
       const zoomInDur = variablePerSegment * 0.3;

--- a/src/engine/CameraController.ts
+++ b/src/engine/CameraController.ts
@@ -16,7 +16,7 @@ interface SegmentCamera {
   toCenter: [number, number];
   midpoint: [number, number];
   flyZoom: number;
-  cityZoom: number;
+  arriveZoom: number;
   routeLine: GeoJSON.LineString | null;
   routeLength: number;
   distanceKm: number;
@@ -24,10 +24,10 @@ interface SegmentCamera {
 
 export class CameraController {
   private segmentCameras: SegmentCamera[];
-  private prevBearing: number = 0;
 
   constructor(locations: Location[], segments: Segment[]) {
-    this.segmentCameras = segments.map((seg) => {
+    // First pass: compute basic segment data
+    const basicData = segments.map((seg) => {
       const fromLoc = locations.find((l) => l.id === seg.fromId)!;
       const toLoc = locations.find((l) => l.id === seg.toId)!;
       const distKm = turf.distance(
@@ -35,10 +35,21 @@ export class CameraController {
         turf.point(toLoc.coordinates)
       );
 
-      // Fly zoom based on distance: farther = more zoomed out
-      const flyZoom = clamp(7 - Math.log2(Math.max(distKm, 1) / 200), 1.5, 6);
-      // City zoom: close-up view
-      const cityZoom = clamp(flyZoom + 6, 12, 14);
+      // Fly zoom: fit both endpoints in view using bbox
+      const bbox = turf.bbox(
+        turf.featureCollection([
+          turf.point(fromLoc.coordinates),
+          turf.point(toLoc.coordinates),
+        ])
+      );
+      const bboxWidth = Math.abs(bbox[2] - bbox[0]);
+      const bboxHeight = Math.abs(bbox[3] - bbox[1]);
+      const maxSpan = Math.max(bboxWidth, bboxHeight, 0.01);
+      const flyZoom = clamp(
+        Math.log2(360 / maxSpan) - 1,
+        1.5,
+        8
+      );
 
       const routeLine = seg.geometry;
       const routeLength = routeLine
@@ -53,11 +64,47 @@ export class CameraController {
           (fromLoc.coordinates[1] + toLoc.coordinates[1]) / 2,
         ] as [number, number],
         flyZoom,
-        cityZoom,
+        arriveZoom: 12, // placeholder, computed in second pass
         routeLine,
         routeLength,
         distanceKm: distKm,
       };
+    });
+
+    // Second pass: compute arriveZoom using look-ahead to NEXT segment
+    this.segmentCameras = basicData.map((cam, i) => {
+      const isLast = i === basicData.length - 1;
+
+      if (isLast) {
+        // Last destination: zoom to city level
+        cam.arriveZoom = clamp(cam.flyZoom + 5, 12, 13);
+      } else {
+        const nextDist = basicData[i + 1].distanceKm;
+
+        if (nextDist < 100) {
+          // Short next segment: zoom to fit current + next destination
+          const nextCam = basicData[i + 1];
+          const bbox = turf.bbox(
+            turf.featureCollection([
+              turf.point(cam.toCenter),
+              turf.point(nextCam.toCenter),
+            ])
+          );
+          const bboxWidth = Math.abs(bbox[2] - bbox[0]);
+          const bboxHeight = Math.abs(bbox[3] - bbox[1]);
+          const maxSpan = Math.max(bboxWidth, bboxHeight, 0.01);
+          const fitZoom = Math.log2(360 / maxSpan) - 1;
+          cam.arriveZoom = clamp(fitZoom, 9, 13);
+        } else if (nextDist >= 1000) {
+          // Very long next segment: barely zoom in
+          cam.arriveZoom = clamp(cam.flyZoom + 2, 6, 7);
+        } else {
+          // Medium next segment (100-1000km): moderate zoom
+          cam.arriveZoom = clamp(cam.flyZoom + 3, 9, 10);
+        }
+      }
+
+      return cam;
     });
   }
 
@@ -66,10 +113,23 @@ export class CameraController {
     return PHASE_EASINGS[phase];
   }
 
+  /** Get the look-ahead hover duration for a segment */
+  getHoverDuration(segmentIndex: number): number {
+    const n = this.segmentCameras.length;
+    const isLast = segmentIndex === n - 1;
+
+    if (isLast) return 2.0;
+
+    const nextDist = this.segmentCameras[segmentIndex + 1]?.distanceKm ?? 0;
+    if (nextDist < 100) return 1.5;
+    if (nextDist >= 1000) return 0.8;
+    return 1.0;
+  }
+
   getCameraState(
     segmentIndex: number,
     phase: AnimationPhase,
-    progress: number // raw progress (0-1), easing applied internally
+    progress: number
   ): CameraState {
     const sc = this.segmentCameras[segmentIndex];
     if (!sc) {
@@ -78,75 +138,41 @@ export class CameraController {
 
     const eased = PHASE_EASINGS[phase](progress);
 
+    // Get the arrive zoom of the previous segment (or this segment's arrive zoom for first)
+    const prevArriveZoom =
+      segmentIndex > 0
+        ? this.segmentCameras[segmentIndex - 1].arriveZoom
+        : sc.arriveZoom;
+
     switch (phase) {
       case "HOVER": {
-        // Compute initial bearing toward route start direction
-        const bearing = this.getInitialBearing(sc);
-        this.prevBearing = bearing;
         return {
           center: sc.fromCenter,
-          zoom: sc.cityZoom,
+          zoom: prevArriveZoom,
           bearing: 0,
           pitch: 0,
         };
       }
 
       case "ZOOM_OUT": {
-        // Zoom out from city, keeping center at fromCenter so FLY starts seamlessly
-        const center = sc.fromCenter;
-        const zoom = lerp(sc.cityZoom, sc.flyZoom, eased);
-        const pitch = lerp(0, 60, eased);
-        // Start rotating bearing toward route direction
-        const targetBearing = this.getInitialBearing(sc);
-        const bearing = lerp(0, targetBearing, eased);
-        this.prevBearing = bearing;
-        return { center, zoom, bearing, pitch };
+        const center = lerp2d(sc.fromCenter, sc.midpoint, eased);
+        const zoom = lerp(prevArriveZoom, sc.flyZoom, eased);
+        return { center, zoom, bearing: 0, pitch: 0 };
       }
 
       case "FLY": {
         let center: [number, number];
-        let bearing: number;
 
         if (sc.routeLine && sc.routeLine.coordinates.length > 1) {
           const line = turf.lineString(sc.routeLine.coordinates);
           const along = turf.along(line, eased * sc.routeLength);
           center = along.geometry.coordinates as [number, number];
-
-          // Dynamic bearing: look ahead along route
-          const lookAheadDist = Math.min(
-            (eased + 0.05) * sc.routeLength,
-            sc.routeLength
-          );
-          const ahead = turf.along(line, lookAheadDist);
-          const aCoord = along.geometry.coordinates;
-          const bCoord = ahead.geometry.coordinates;
-          // When look-ahead equals current (at route end), reuse cached bearing
-          if (
-            Math.abs(aCoord[0] - bCoord[0]) < 1e-9 &&
-            Math.abs(aCoord[1] - bCoord[1]) < 1e-9
-          ) {
-            bearing = this.prevBearing;
-          } else {
-            const rawBearing = turf.bearing(along, ahead);
-            // Smooth bearing to avoid jerky rotation
-            bearing = smoothBearing(this.prevBearing, rawBearing, 0.15);
-          }
         } else {
           center = lerp2d(sc.fromCenter, sc.toCenter, eased);
-          bearing = turf.bearing(
-            turf.point(sc.fromCenter),
-            turf.point(sc.toCenter)
-          );
         }
 
-        this.prevBearing = bearing;
-
-        // Gentle zoom pulse mid-flight
-        const zoomPulse = Math.sin(eased * Math.PI) * 0.4;
-        const zoom = sc.flyZoom + zoomPulse;
-        const pitch = 60;
-
-        return { center, zoom, bearing, pitch };
+        const zoom = sc.flyZoom;
+        return { center, zoom, bearing: 0, pitch: 0 };
       }
 
       case "ZOOM_IN": {
@@ -156,18 +182,14 @@ export class CameraController {
             ] as [number, number])
           : sc.toCenter;
         const center = lerp2d(routeEnd, sc.toCenter, eased);
-        const zoom = lerp(sc.flyZoom + 0.4, sc.cityZoom, eased);
-        const pitch = lerp(60, 0, eased);
-        // Ease bearing back to 0
-        const bearing = lerp(this.prevBearing, 0, eased);
-        return { center, zoom, bearing, pitch };
+        const zoom = lerp(sc.flyZoom, sc.arriveZoom, eased);
+        return { center, zoom, bearing: 0, pitch: 0 };
       }
 
       case "ARRIVE":
-        this.prevBearing = 0;
         return {
           center: sc.toCenter,
-          zoom: sc.cityZoom,
+          zoom: sc.arriveZoom,
           bearing: 0,
           pitch: 0,
         };
@@ -175,7 +197,7 @@ export class CameraController {
       default:
         return {
           center: sc.fromCenter,
-          zoom: sc.cityZoom,
+          zoom: sc.arriveZoom,
           bearing: 0,
           pitch: 0,
         };
@@ -185,19 +207,6 @@ export class CameraController {
   /** Get the route length for a segment (used for progressive drawing) */
   getRouteLength(segmentIndex: number): number {
     return this.segmentCameras[segmentIndex]?.routeLength ?? 0;
-  }
-
-  private getInitialBearing(sc: SegmentCamera): number {
-    if (sc.routeLine && sc.routeLine.coordinates.length > 1) {
-      const start = sc.routeLine.coordinates[0] as [number, number];
-      const lookIdx = Math.min(10, sc.routeLine.coordinates.length - 1);
-      const lookPt = sc.routeLine.coordinates[lookIdx] as [number, number];
-      return turf.bearing(turf.point(start), turf.point(lookPt));
-    }
-    return turf.bearing(
-      turf.point(sc.fromCenter),
-      turf.point(sc.toCenter)
-    );
   }
 }
 
@@ -215,17 +224,4 @@ function lerp2d(
   t: number
 ): [number, number] {
   return [lerp(a[0], b[0], t), lerp(a[1], b[1], t)];
-}
-
-/** Smoothly interpolate between two bearings, handling the 360° wrap */
-function smoothBearing(
-  current: number,
-  target: number,
-  smoothing: number
-): number {
-  // Normalize both to [-180, 180]
-  let diff = target - current;
-  while (diff > 180) diff -= 360;
-  while (diff < -180) diff += 360;
-  return current + diff * smoothing;
 }


### PR DESCRIPTION
## Summary
- **Bearing = 0 always**: Map stays north-up at all times. Removed all dynamic bearing rotation and smoothing from CameraController.
- **Pitch = 0 always**: No more 60° tilt during fly phase. Map stays flat (2D, no terrain).
- **Smart look-ahead zoom**: Arrive zoom at each destination is based on the *next* segment's distance — final stop gets city-level zoom (12-13), short next hops get moderate zoom, long hops barely zoom in (6-7). HOVER duration also scales (2s→0.8s).
- **Persistent route lines**: Completed segment route lines stay visible during animation. Only not-yet-started segments are hidden. As each segment completes (enters ARRIVE), its static layer is re-shown.
- **Left panel scroll fix**: Added `overflow-hidden` to parent container and `min-h-0` to ScrollArea for proper flex scroll behavior.

## Files changed
- `src/engine/CameraController.ts` — Major rewrite: removed bearing/pitch logic, added arriveZoom look-ahead computation, added `getHoverDuration()`
- `src/engine/AnimationEngine.ts` — HOVER duration now uses `camera.getHoverDuration()` per segment
- `src/components/editor/MapCanvas.tsx` — Route visibility: tracks completed segments, re-shows their static layers during playback
- `src/components/editor/EditorLayout.tsx` — Dispatches `segment-complete` custom event when segments finish
- `src/components/editor/LeftPanel.tsx` — Scroll fix with flex constraints

## Test plan
- [ ] `npx tsc --noEmit` passes ✅
- [ ] Import taiwan-trip.json (8 cities) and verify:
  - Map stays north-up at all times (bearing=0)
  - No pitch tilt during any phase
  - Transit hubs get quick pauses, final destination gets deep zoom
  - All completed route lines remain visible throughout playback
- [ ] Verify left panel scrolls with many locations
- [ ] Test play/pause/reset cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)