### PR TITLE
feat: route editing UX overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "@turf/turf": "^7.3.4",
@@ -517,6 +520,59 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
     "@turf/turf": "^7.3.4",

--- a/src/components/editor/LocationCard.tsx
+++ b/src/components/editor/LocationCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { X, GripVertical, ChevronUp, ChevronDown } from "lucide-react";
+import { X, GripVertical } from "lucide-react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@/components/ui/button";
 import PhotoManager from "./PhotoManager";
 import type { Location } from "@/types";
@@ -10,8 +12,6 @@ interface LocationCardProps {
   index: number;
   total: number;
   onRemove: (id: string) => void;
-  onMoveUp: (index: number) => void;
-  onMoveDown: (index: number) => void;
   onToggleWaypoint: (id: string) => void;
 }
 
@@ -20,40 +20,42 @@ export default function LocationCard({
   index,
   total,
   onRemove,
-  onMoveUp,
-  onMoveDown,
   onToggleWaypoint,
 }: LocationCardProps) {
   const isFirstOrLast = index === 0 || index === total - 1;
   const isWaypoint = location.isWaypoint;
 
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: location.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 50 : undefined,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
   return (
     <div
+      ref={setNodeRef}
+      style={style}
       className={`rounded-lg border bg-card p-3 shadow-sm space-y-2 ${
         isWaypoint ? "opacity-60" : ""
-      }`}
+      } ${isDragging ? "shadow-lg" : ""}`}
     >
       <div className="flex items-center gap-2">
-        <div className="flex flex-col items-center gap-0.5">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-5 w-5"
-            disabled={index === 0}
-            onClick={() => onMoveUp(index)}
-          >
-            <ChevronUp className="h-3 w-3" />
-          </Button>
-          <GripVertical className="h-3 w-3 text-muted-foreground" />
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-5 w-5"
-            disabled={index === total - 1}
-            onClick={() => onMoveDown(index)}
-          >
-            <ChevronDown className="h-3 w-3" />
-          </Button>
+        <div
+          className="flex items-center cursor-grab active:cursor-grabbing touch-none"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-4 w-4 text-muted-foreground" />
         </div>
         <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
           {index + 1}
@@ -63,7 +65,7 @@ export default function LocationCard({
             <p className="text-sm font-medium truncate">{location.name}</p>
             {isWaypoint && (
               <span className="text-[10px] text-muted-foreground whitespace-nowrap">
-                fly-through
+                stop by
               </span>
             )}
           </div>
@@ -77,7 +79,7 @@ export default function LocationCard({
             variant="ghost"
             size="icon"
             className="h-7 w-7 shrink-0"
-            title={isWaypoint ? "Switch to destination" : "Switch to fly-through"}
+            title={isWaypoint ? "Switch to destination" : "Switch to stop by"}
             onClick={() => onToggleWaypoint(location.id)}
           >
             <span className="text-sm">{isWaypoint ? "\u2708\uFE0F" : "\uD83C\uDFE0"}</span>

--- a/src/components/editor/RouteList.tsx
+++ b/src/components/editor/RouteList.tsx
@@ -1,5 +1,20 @@
 "use client";
 
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { useProjectStore } from "@/stores/projectStore";
 import LocationCard from "./LocationCard";
 import TransportSelector from "./TransportSelector";
@@ -10,6 +25,29 @@ export default function RouteList() {
   const removeLocation = useProjectStore((s) => s.removeLocation);
   const reorderLocations = useProjectStore((s) => s.reorderLocations);
   const toggleWaypoint = useProjectStore((s) => s.toggleWaypoint);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 5 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = locations.findIndex((l) => l.id === active.id);
+    const newIndex = locations.findIndex((l) => l.id === over.id);
+    if (oldIndex !== -1 && newIndex !== -1) {
+      reorderLocations(oldIndex, newIndex);
+    }
+  };
 
   if (locations.length === 0) {
     return (
@@ -22,23 +60,32 @@ export default function RouteList() {
   }
 
   return (
-    <div className="flex flex-col gap-1 p-3">
-      {locations.map((loc, i) => (
-        <div key={loc.id}>
-          <LocationCard
-            location={loc}
-            index={i}
-            total={locations.length}
-            onRemove={removeLocation}
-            onMoveUp={(idx) => reorderLocations(idx, idx - 1)}
-            onMoveDown={(idx) => reorderLocations(idx, idx + 1)}
-            onToggleWaypoint={toggleWaypoint}
-          />
-          {i < segments.length && (
-            <TransportSelector segment={segments[i]} />
-          )}
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={locations.map((l) => l.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="flex flex-col gap-1 p-3">
+          {locations.map((loc, i) => (
+            <div key={loc.id}>
+              <LocationCard
+                location={loc}
+                index={i}
+                total={locations.length}
+                onRemove={removeLocation}
+                onToggleWaypoint={toggleWaypoint}
+              />
+              {i < segments.length && (
+                <TransportSelector segment={segments[i]} />
+              )}
+            </div>
+          ))}
         </div>
-      ))}
-    </div>
+      </SortableContext>
+    </DndContext>
   );
 }

--- a/src/components/editor/TransportSelector.tsx
+++ b/src/components/editor/TransportSelector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
+import * as turf from "@turf/turf";
 import { useProjectStore } from "@/stores/projectStore";
 import { TRANSPORT_MODES } from "@/lib/constants";
 import { generateRouteGeometry } from "@/engine/RouteGeometry";
@@ -45,10 +46,17 @@ const MODE_COLORS: Record<TransportMode, string> = {
   bicycle: "bg-teal-100 text-teal-700 border-teal-300",
 };
 
+function formatDistance(km: number): string {
+  if (km < 1) return `${Math.round(km * 1000)} m`;
+  if (km < 100) return `${km.toFixed(1)} km`;
+  return `${Math.round(km)} km`;
+}
+
 export default function TransportSelector({ segment }: TransportSelectorProps) {
   const setTransportMode = useProjectStore((s) => s.setTransportMode);
   const setSegmentGeometry = useProjectStore((s) => s.setSegmentGeometry);
   const locations = useProjectStore((s) => s.locations);
+  const [expanded, setExpanded] = useState(false);
 
   const fromLoc = locations.find((l) => l.id === segment.fromId);
   const toLoc = locations.find((l) => l.id === segment.toId);
@@ -80,31 +88,60 @@ export default function TransportSelector({ segment }: TransportSelectorProps) {
   const handleModeChange = (mode: TransportMode) => {
     setTransportMode(segment.id, mode);
     fetchGeometry(mode);
+    setExpanded(false);
   };
 
+  const ActiveIcon = MODE_ICONS[segment.transportMode];
+  const activeColor = MODE_COLORS[segment.transportMode];
+
+  // Compute distance from geometry
+  const distance =
+    segment.geometry && segment.geometry.coordinates.length > 1
+      ? turf.length(turf.lineString(segment.geometry.coordinates))
+      : null;
+
   return (
-    <div className="flex items-center justify-center gap-1 py-1">
-      {TRANSPORT_MODES.map((mode) => {
-        const isActive = segment.transportMode === mode.id;
-        const Icon = MODE_ICONS[mode.id];
-        return (
-          <Tooltip key={mode.id}>
-            <TooltipTrigger
-              className={`flex h-8 w-8 items-center justify-center rounded-md border transition-colors ${
-                isActive
-                  ? MODE_COLORS[mode.id]
-                  : "border-transparent text-muted-foreground hover:bg-accent"
-              }`}
-              onClick={() => handleModeChange(mode.id)}
-            >
-              <Icon className="h-4 w-4" />
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p>{mode.label}</p>
-            </TooltipContent>
-          </Tooltip>
-        );
-      })}
+    <div className="flex items-center justify-center py-1">
+      {/* Vertical connecting line + pill */}
+      <div className="flex items-center gap-2">
+        <div className="w-px h-4 bg-border" />
+        {expanded ? (
+          <div className="flex items-center gap-1 rounded-full border bg-card px-1.5 py-0.5 shadow-sm">
+            {TRANSPORT_MODES.map((mode) => {
+              const isActive = segment.transportMode === mode.id;
+              const Icon = MODE_ICONS[mode.id];
+              return (
+                <Tooltip key={mode.id}>
+                  <TooltipTrigger
+                    className={`flex h-7 w-7 items-center justify-center rounded-full transition-colors ${
+                      isActive
+                        ? MODE_COLORS[mode.id]
+                        : "text-muted-foreground hover:bg-accent"
+                    }`}
+                    onClick={() => handleModeChange(mode.id)}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p>{mode.label}</p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
+        ) : (
+          <button
+            className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:shadow-sm ${activeColor}`}
+            onClick={() => setExpanded(true)}
+          >
+            <ActiveIcon className="h-3.5 w-3.5" />
+            {distance !== null && (
+              <span className="tabular-nums">{formatDistance(distance)}</span>
+            )}
+          </button>
+        )}
+        <div className="w-px h-4 bg-border" />
+      </div>
     </div>
   );
 }

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -54,9 +54,18 @@ function rebuildSegments(
   for (let i = 0; i < locations.length - 1; i++) {
     const fromId = locations[i].id;
     const toId = locations[i + 1].id;
-    const existing = segmentMap.get(`${fromId}-${toId}`);
+    const forward = segmentMap.get(`${fromId}-${toId}`);
+    const reversed = segmentMap.get(`${toId}-${fromId}`);
+    const existing = forward || reversed;
     if (existing) {
-      segments.push(existing);
+      segments.push({
+        ...existing,
+        id: forward ? existing.id : generateId(),
+        fromId,
+        toId,
+        // Keep geometry only if direction unchanged; reversed needs re-fetch
+        geometry: forward ? existing.geometry : null,
+      });
     } else {
       segments.push({
         id: generateId(),


### PR DESCRIPTION
## Summary
- **Drag-and-drop reorder**: Replaced up/down arrow buttons with @dnd-kit sortable drag-and-drop (desktop pointer + mobile touch sensors, keyboard accessible)
- **Fix transport mode reset bug**: `rebuildSegments()` now checks both forward and reversed segment keys — preserves transport mode on reorder, nulls geometry for reversed segments to trigger re-fetch
- **Rename "fly-through" to "stop by"**: Updated label and tooltip text in LocationCard
- **Transport selector pill**: Restyled as a compact pill between cards showing active transport icon + distance (click to expand full mode selector)
- **Auto-regenerate geometry**: Segments with null geometry (from reorder/reversal) automatically re-fetch via existing TransportSelector useEffect

## Test plan
- [ ] Drag reorder works on desktop (pointer) and mobile (touch)
- [ ] Reordering preserves transport modes (not reset to flight)
- [ ] Reversed segments get new geometry fetched automatically
- [ ] "stop by" label appears instead of "fly-through"
- [ ] Transport pill shows distance and expands on click
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)