### PR TITLE
fix: re-validate export config when resolution/aspect changes

### DIFF
--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -38,6 +38,17 @@ export default function ExportDialog() {
 
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>("16:9");
   const [resolution, setResolution] = useState("720");
+
+  // Re-validate support when export settings change
+  const [exportSupported, setExportSupported] = useState<boolean | null>(null);
+  useEffect(() => {
+    const height = parseInt(resolution);
+    const width = aspectRatio === "16:9"
+      ? Math.round(height * (16 / 9))
+      : Math.round(height * (9 / 16));
+    VideoExporter.isConfigSupported({ width, height, fps: FPS })
+      .then(setExportSupported);
+  }, [aspectRatio, resolution]);
   const [isExporting, setIsExporting] = useState(false);
   const [progress, setProgress] = useState<ExportProgress | null>(null);
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
@@ -141,6 +152,15 @@ export default function ExportDialog() {
             </div>
           )}
 
+          {isSupported === true && exportSupported === false && (
+            <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>
+                Your browser doesn&apos;t support this resolution. Try 720p instead.
+              </span>
+            </div>
+          )}
+
           {isExporting && progress && (
             <div className="space-y-2">
               <div className="flex justify-between text-sm">
@@ -189,7 +209,7 @@ export default function ExportDialog() {
               <Button
                 className="flex-1"
                 onClick={handleExport}
-                disabled={segments.length === 0 || isSupported !== true}
+                disabled={segments.length === 0 || isSupported !== true || exportSupported === false}
               >
                 <Loader2 className="h-4 w-4 mr-2 animate-spin hidden" />
                 Start Export


### PR DESCRIPTION
## What

ExportDialog now re-validates `isConfigSupported()` with the actual export dimensions whenever the user changes resolution or aspect ratio. Shows a targeted warning if the selected config isn't supported by the browser.

## Why

Follow-up from PR #14 review feedback: the support probe was only checking on dialog mount with no params (default 720p). If the user selected 1080p and the browser couldn't encode at that resolution, the export would fail at `encoder.configure()` instead of showing a warning upfront.

## Changes

- **ExportDialog.tsx**: Add `exportSupported` state that re-checks on resolution/aspect change; show resolution-specific warning; disable export button if config not supported