### PR TITLE
feat: add localStorage persistence for project data

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -19,7 +19,10 @@ import {
 } from "./routeSegmentSources";
 import * as turf from "@turf/turf";
 import { AnimationEngine } from "@/engine/AnimationEngine";
-import { useProjectStore } from "@/stores/projectStore";
+import {
+  initializeProjectPersistence,
+  useProjectStore,
+} from "@/stores/projectStore";
 import { useAnimationStore } from "@/stores/animationStore";
 import { useUIStore } from "@/stores/uiStore";
 
@@ -27,19 +30,29 @@ function EditorContent() {
   const { map } = useMap();
   const locations = useProjectStore((s) => s.locations);
   const segments = useProjectStore((s) => s.segments);
-  const segmentTimingOverrides = useProjectStore((s) => s.segmentTimingOverrides);
+  const segmentTimingOverrides = useProjectStore(
+    (s) => s.segmentTimingOverrides,
+  );
   const engineRef = useRef<AnimationEngine | null>(null);
 
   const setPlaybackState = useAnimationStore((s) => s.setPlaybackState);
   const setCurrentTime = useAnimationStore((s) => s.setCurrentTime);
   const setTotalDuration = useAnimationStore((s) => s.setTotalDuration);
   const setCurrentCityLabel = useAnimationStore((s) => s.setCurrentCityLabel);
-  const setCurrentCityLabelZh = useAnimationStore((s) => s.setCurrentCityLabelZh);
+  const setCurrentCityLabelZh = useAnimationStore(
+    (s) => s.setCurrentCityLabelZh,
+  );
   const setVisiblePhotos = useAnimationStore((s) => s.setVisiblePhotos);
   const setShowPhotoOverlay = useAnimationStore((s) => s.setShowPhotoOverlay);
-  const setPhotoOverlayOpacity = useAnimationStore((s) => s.setPhotoOverlayOpacity);
-  const setCurrentSegmentIndex = useAnimationStore((s) => s.setCurrentSegmentIndex);
-  const setCurrentGroupSegmentIndices = useAnimationStore((s) => s.setCurrentGroupSegmentIndices);
+  const setPhotoOverlayOpacity = useAnimationStore(
+    (s) => s.setPhotoOverlayOpacity,
+  );
+  const setCurrentSegmentIndex = useAnimationStore(
+    (s) => s.setCurrentSegmentIndex,
+  );
+  const setCurrentGroupSegmentIndices = useAnimationStore(
+    (s) => s.setCurrentGroupSegmentIndices,
+  );
   const setTimeline = useAnimationStore((s) => s.setTimeline);
   const reset = useAnimationStore((s) => s.reset);
 
@@ -47,17 +60,28 @@ function EditorContent() {
   const cityLabelLang = useUIStore((s) => s.cityLabelLang);
   const currentCityLabelEn = useAnimationStore((s) => s.currentCityLabel);
   const currentCityLabelZh = useAnimationStore((s) => s.currentCityLabelZh);
-  const currentCityLabel = cityLabelLang === "zh"
-    ? (currentCityLabelZh || currentCityLabelEn)
-    : currentCityLabelEn;
+  const currentCityLabel =
+    cityLabelLang === "zh"
+      ? currentCityLabelZh || currentCityLabelEn
+      : currentCityLabelEn;
   const visiblePhotos = useAnimationStore((s) => s.visiblePhotos);
   const showPhotoOverlay = useAnimationStore((s) => s.showPhotoOverlay);
   const photoOverlayOpacity = useAnimationStore((s) => s.photoOverlayOpacity);
 
-  const [editingLocationId, setEditingLocationId] = useState<string | null>(null);
-  const editingLocation = locations.find((l) => l.id === editingLocationId) ?? null;
-  const [visiblePhotoLocationId, setVisiblePhotoLocationId] = useState<string | null>(null);
-  const visiblePhotoLocation = locations.find((l) => l.id === visiblePhotoLocationId) ?? null;
+  const [editingLocationId, setEditingLocationId] = useState<string | null>(
+    null,
+  );
+  const editingLocation =
+    locations.find((l) => l.id === editingLocationId) ?? null;
+  const [visiblePhotoLocationId, setVisiblePhotoLocationId] = useState<
+    string | null
+  >(null);
+  const visiblePhotoLocation =
+    locations.find((l) => l.id === visiblePhotoLocationId) ?? null;
+
+  useEffect(() => {
+    initializeProjectPersistence();
+  }, []);
 
   // Rebuild engine when project changes
   useEffect(() => {
@@ -72,7 +96,12 @@ function EditorContent() {
     const allReady = segments.every((s) => s.geometry !== null);
     if (!allReady) return;
 
-    const engine = new AnimationEngine(map, locations, segments, segmentTimingOverrides);
+    const engine = new AnimationEngine(
+      map,
+      locations,
+      segments,
+      segmentTimingOverrides,
+    );
     engineRef.current = engine;
     setTotalDuration(engine.getTotalDuration());
     setTimeline(engine.getTimeline());
@@ -113,8 +142,10 @@ function EditorContent() {
         const pastSeg = segments[i];
         const pastLid = SEGMENT_LAYER_PREFIX + pastSeg.id;
         const pastGlid = SEGMENT_GLOW_LAYER_PREFIX + pastSeg.id;
-        if (map.getLayer(pastLid)) map.setLayoutProperty(pastLid, "visibility", "visible");
-        if (map.getLayer(pastGlid)) map.setLayoutProperty(pastGlid, "visibility", "visible");
+        if (map.getLayer(pastLid))
+          map.setLayoutProperty(pastLid, "visibility", "visible");
+        if (map.getLayer(pastGlid))
+          map.setLayoutProperty(pastGlid, "visibility", "visible");
         setSegmentSourceData(map, pastSeg.id, pastSeg.geometry);
       }
 
@@ -122,9 +153,10 @@ function EditorContent() {
       const group = engine.getGroups()[e.groupIndex];
       if (!group) return;
       const mergedGeom = group.mergedGeometry;
-      const mergedLength = mergedGeom && mergedGeom.coordinates.length > 1
-        ? turf.length(turf.lineString(mergedGeom.coordinates))
-        : 0;
+      const mergedLength =
+        mergedGeom && mergedGeom.coordinates.length > 1
+          ? turf.length(turf.lineString(mergedGeom.coordinates))
+          : 0;
 
       let accumulatedLength = 0;
       const drawnDistance = fraction * mergedLength;
@@ -135,7 +167,9 @@ function EditorContent() {
         if (!seg?.geometry || seg.geometry.coordinates.length < 2) continue;
         if (!map.getSource(`${SEGMENT_SOURCE_PREFIX}${seg.id}`)) continue;
 
-        const segLength = turf.length(turf.lineString(seg.geometry.coordinates));
+        const segLength = turf.length(
+          turf.lineString(seg.geometry.coordinates),
+        );
         const segStart = accumulatedLength;
         const segEnd = accumulatedLength + segLength;
         accumulatedLength = segEnd;
@@ -143,8 +177,10 @@ function EditorContent() {
         // Make layers visible
         const layerId = SEGMENT_LAYER_PREFIX + seg.id;
         const glowLayerId = SEGMENT_GLOW_LAYER_PREFIX + seg.id;
-        if (map.getLayer(layerId)) map.setLayoutProperty(layerId, "visibility", "visible");
-        if (map.getLayer(glowLayerId)) map.setLayoutProperty(glowLayerId, "visibility", "visible");
+        if (map.getLayer(layerId))
+          map.setLayoutProperty(layerId, "visibility", "visible");
+        if (map.getLayer(glowLayerId))
+          map.setLayoutProperty(glowLayerId, "visibility", "visible");
 
         if (drawnDistance >= segEnd) {
           // This segment is fully drawn
@@ -176,7 +212,10 @@ function EditorContent() {
       const style = map.getStyle();
       if (style?.layers) {
         style.layers.forEach((layer: { id: string }) => {
-          if (layer.id.startsWith("segment-") || layer.id.startsWith("segment-glow-")) {
+          if (
+            layer.id.startsWith("segment-") ||
+            layer.id.startsWith("segment-glow-")
+          ) {
             map.setLayoutProperty(layer.id, "visibility", "none");
           }
         });
@@ -196,19 +235,13 @@ function EditorContent() {
     reset();
   }, [reset]);
 
-  const handleSeek = useCallback(
-    (progress: number) => {
-      engineRef.current?.seekTo(progress);
-    },
-    []
-  );
+  const handleSeek = useCallback((progress: number) => {
+    engineRef.current?.seekTo(progress);
+  }, []);
 
-  const handleEditLayout = useCallback(
-    (locationId: string) => {
-      setEditingLocationId(locationId);
-    },
-    []
-  );
+  const handleEditLayout = useCallback((locationId: string) => {
+    setEditingLocationId(locationId);
+  }, []);
 
   const handleLocationClick = useCallback(
     (index: number) => {
@@ -230,7 +263,9 @@ function EditorContent() {
       if (index === 0) {
         // First location: seek to HOVER phase start of first group
         if (timeline.length > 0) {
-          const hoverPhase = timeline[0].phases.find((p) => p.phase === "HOVER");
+          const hoverPhase = timeline[0].phases.find(
+            (p) => p.phase === "HOVER",
+          );
           seekTime = hoverPhase ? hoverPhase.startTime : timeline[0].startTime;
         }
       } else {
@@ -241,7 +276,9 @@ function EditorContent() {
             const group = groups[gi];
             if (group.toLoc.id === targetLoc.id) {
               // Exact match on toLoc — seek to ARRIVE phase
-              const arrivePhase = timeline[gi]?.phases.find((p) => p.phase === "ARRIVE");
+              const arrivePhase = timeline[gi]?.phases.find(
+                (p) => p.phase === "ARRIVE",
+              );
               if (arrivePhase) {
                 seekTime = arrivePhase.startTime;
               } else if (timeline[gi]) {
@@ -250,22 +287,34 @@ function EditorContent() {
               break;
             }
             // Check if this is an intermediate waypoint within the group
-            const locIdx = group.allLocations.findIndex((l) => l.id === targetLoc.id);
+            const locIdx = group.allLocations.findIndex(
+              (l) => l.id === targetLoc.id,
+            );
             if (locIdx > 0 && locIdx < group.allLocations.length - 1) {
               // Waypoint found — seek proportionally by accumulated route distance within FLY phase
-              const flyPhase = timeline[gi]?.phases.find((p) => p.phase === "FLY");
-              if (flyPhase && group.mergedGeometry && group.mergedGeometry.coordinates.length >= 2) {
+              const flyPhase = timeline[gi]?.phases.find(
+                (p) => p.phase === "FLY",
+              );
+              if (
+                flyPhase &&
+                group.mergedGeometry &&
+                group.mergedGeometry.coordinates.length >= 2
+              ) {
                 // Compute accumulated segment lengths to find distance-based fraction
                 let accumulatedDist = 0;
                 let totalDist = 0;
                 try {
-                  const mergedLine = turf.lineString(group.mergedGeometry.coordinates);
+                  const mergedLine = turf.lineString(
+                    group.mergedGeometry.coordinates,
+                  );
                   totalDist = turf.length(mergedLine);
                   // Sum segment distances up to the waypoint (locIdx segments from start)
                   for (let si = 0; si < group.segments.length; si++) {
                     const seg = group.segments[si];
                     if (seg.geometry && seg.geometry.coordinates.length >= 2) {
-                      const segLen = turf.length(turf.lineString(seg.geometry.coordinates));
+                      const segLen = turf.length(
+                        turf.lineString(seg.geometry.coordinates),
+                      );
                       if (si < locIdx) {
                         accumulatedDist += segLen;
                       }
@@ -276,7 +325,10 @@ function EditorContent() {
                   totalDist = 1;
                   accumulatedDist = locIdx / (group.allLocations.length - 1);
                 }
-                const fraction = totalDist > 0 ? accumulatedDist / totalDist : locIdx / (group.allLocations.length - 1);
+                const fraction =
+                  totalDist > 0
+                    ? accumulatedDist / totalDist
+                    : locIdx / (group.allLocations.length - 1);
                 seekTime = flyPhase.startTime + flyPhase.duration * fraction;
               } else if (flyPhase) {
                 const fraction = locIdx / (group.allLocations.length - 1);
@@ -292,13 +344,17 @@ function EditorContent() {
       engine.pause();
       setPlaybackState("paused");
     },
-    [locations, setPlaybackState]
+    [locations, setPlaybackState],
   );
 
   // Keyboard shortcuts
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
       if (e.code === "Space") {
         e.preventDefault();
         const state = useAnimationStore.getState().playbackState;
@@ -320,7 +376,10 @@ function EditorContent() {
     <div className="flex h-screen flex-col">
       <TopToolbar />
       <div className="flex flex-1 overflow-hidden">
-        <LeftPanel onLocationClick={handleLocationClick} onEditLayout={handleEditLayout} />
+        <LeftPanel
+          onLocationClick={handleLocationClick}
+          onEditLayout={handleEditLayout}
+        />
         {/* Map area: full width on mobile, flex-1 on desktop */}
         <div className="flex-1 relative">
           <MapCanvas />
@@ -358,7 +417,10 @@ function EditorContent() {
                     "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)",
                 }}
               >
-                <p className="font-semibold flex items-center gap-2" style={{ fontSize: `${cityLabelSize}px` }}>
+                <p
+                  className="font-semibold flex items-center gap-2"
+                  style={{ fontSize: `${cityLabelSize}px` }}
+                >
                   <svg
                     className="w-4 h-4 text-indigo-500 flex-shrink-0"
                     viewBox="0 0 20 20"
@@ -376,7 +438,12 @@ function EditorContent() {
             )}
           </AnimatePresence>
           {/* Photo overlay */}
-          <PhotoOverlay photos={visiblePhotos} visible={showPhotoOverlay} photoLayout={visiblePhotoLocation?.photoLayout} opacity={photoOverlayOpacity} />
+          <PhotoOverlay
+            photos={visiblePhotos}
+            visible={showPhotoOverlay}
+            photoLayout={visiblePhotoLocation?.photoLayout}
+            opacity={photoOverlayOpacity}
+          />
           {/* Photo layout editor */}
           {editingLocation && editingLocation.photos.length > 0 && (
             <PhotoLayoutEditor
@@ -398,7 +465,10 @@ function EditorContent() {
       {/* Mobile bottom sheet — hidden during playback */}
       {!isPlaying && (
         <div className="md:hidden">
-          <BottomSheet onLocationClick={handleLocationClick} onEditLayout={handleEditLayout} />
+          <BottomSheet
+            onLocationClick={handleLocationClick}
+            onEditLayout={handleEditLayout}
+          />
         </div>
       )}
     </div>

--- a/src/components/editor/LeftPanel.tsx
+++ b/src/components/editor/LeftPanel.tsx
@@ -6,7 +6,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { useProjectStore, type ImportRouteData } from "@/stores/projectStore";
 import { useUIStore } from "@/stores/uiStore";
-import { generateRouteGeometry } from "@/engine/RouteGeometry";
 import CitySearch from "./CitySearch";
 import RouteList from "./RouteList";
 
@@ -15,16 +14,20 @@ interface LeftPanelProps {
   onEditLayout?: (locationId: string) => void;
 }
 
-export default function LeftPanel({ onLocationClick, onEditLayout }: LeftPanelProps) {
+export default function LeftPanel({
+  onLocationClick,
+  onEditLayout,
+}: LeftPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const importRoute = useProjectStore((s) => s.importRoute);
+  const loadRouteData = useProjectStore((s) => s.loadRouteData);
   const enrichChineseNames = useProjectStore((s) => s.enrichChineseNames);
   const exportRoute = useProjectStore((s) => s.exportRoute);
-  const setSegmentGeometry = useProjectStore((s) => s.setSegmentGeometry);
 
   const handleExportRoute = async () => {
     const data = await exportRoute();
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -40,28 +43,8 @@ export default function LeftPanel({ onLocationClick, onEditLayout }: LeftPanelPr
     try {
       const text = await file.text();
       const data: ImportRouteData = JSON.parse(text);
-      importRoute(data);
-      // Fetch Chinese names for imported locations (non-blocking)
-      enrichChineseNames();
-
-      // Generate geometry for each segment
-      const state = useProjectStore.getState();
-      for (const seg of state.segments) {
-        const fromLoc = state.locations.find((l) => l.id === seg.fromId);
-        const toLoc = state.locations.find((l) => l.id === seg.toId);
-        if (fromLoc && toLoc) {
-          try {
-            const geometry = await generateRouteGeometry(
-              fromLoc.coordinates,
-              toLoc.coordinates,
-              seg.transportMode
-            );
-            setSegmentGeometry(seg.id, geometry);
-          } catch {
-            // Geometry generation failed; segment keeps null geometry
-          }
-        }
-      }
+      await loadRouteData(data);
+      void enrichChineseNames();
     } catch {
       // Invalid JSON or file read error
     }
@@ -112,7 +95,10 @@ export default function LeftPanel({ onLocationClick, onEditLayout }: LeftPanelPr
         />
       </div>
       <ScrollArea className="flex-1 min-h-0">
-        <RouteList onLocationClick={onLocationClick} onEditLayout={onEditLayout} />
+        <RouteList
+          onLocationClick={onLocationClick}
+          onEditLayout={onEditLayout}
+        />
       </ScrollArea>
     </div>
   );

--- a/src/components/editor/TopToolbar.tsx
+++ b/src/components/editor/TopToolbar.tsx
@@ -1,23 +1,39 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
-import { Download, Save, Upload, PanelLeftClose, PanelLeft } from "lucide-react";
+import {
+  Download,
+  Save,
+  Upload,
+  PanelLeftClose,
+  PanelLeft,
+  Trash2,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import MapStyleSelector from "./MapStyleSelector";
 import { useUIStore } from "@/stores/uiStore";
 import { useProjectStore, type ImportRouteData } from "@/stores/projectStore";
-import { generateRouteGeometry } from "@/engine/RouteGeometry";
 
 export default function TopToolbar() {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [clearDialogOpen, setClearDialogOpen] = useState(false);
   const setExportDialogOpen = useUIStore((s) => s.setExportDialogOpen);
   const leftPanelOpen = useUIStore((s) => s.leftPanelOpen);
   const setLeftPanelOpen = useUIStore((s) => s.setLeftPanelOpen);
   const exportRoute = useProjectStore((s) => s.exportRoute);
-  const importRoute = useProjectStore((s) => s.importRoute);
+  const loadRouteData = useProjectStore((s) => s.loadRouteData);
   const enrichChineseNames = useProjectStore((s) => s.enrichChineseNames);
-  const setSegmentGeometry = useProjectStore((s) => s.setSegmentGeometry);
+  const clearRoute = useProjectStore((s) => s.clearRoute);
 
   const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -25,26 +41,19 @@ export default function TopToolbar() {
     try {
       const text = await file.text();
       const data: ImportRouteData = JSON.parse(text);
-      importRoute(data);
-      enrichChineseNames();
-      const state = useProjectStore.getState();
-      for (const seg of state.segments) {
-        const fromLoc = state.locations.find((l) => l.id === seg.fromId);
-        const toLoc = state.locations.find((l) => l.id === seg.toId);
-        if (fromLoc && toLoc) {
-          try {
-            const geometry = await generateRouteGeometry(fromLoc.coordinates, toLoc.coordinates, seg.transportMode);
-            setSegmentGeometry(seg.id, geometry);
-          } catch { /* geometry failed */ }
-        }
-      }
-    } catch { /* invalid file */ }
+      await loadRouteData(data);
+      void enrichChineseNames();
+    } catch {
+      // Invalid JSON or file read error.
+    }
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
   const handleExportRoute = async () => {
     const data = await exportRoute();
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -54,65 +63,104 @@ export default function TopToolbar() {
   };
 
   return (
-    <div className="flex h-10 md:h-12 items-center justify-between border-b bg-background px-3 md:px-4">
-      <div className="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="hidden md:inline-flex h-8 w-8"
-          onClick={() => setLeftPanelOpen(!leftPanelOpen)}
-          aria-label={leftPanelOpen ? "Collapse sidebar" : "Expand sidebar"}
-        >
-          {leftPanelOpen ? (
-            <PanelLeftClose className="h-4 w-4" />
-          ) : (
-            <PanelLeft className="h-4 w-4" />
-          )}
-        </Button>
-        <Link href="/" className="text-sm md:text-lg font-bold tracking-tight">
-          TraceRecap
-        </Link>
+    <>
+      <div className="flex h-10 md:h-12 items-center justify-between border-b bg-background px-3 md:px-4">
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="hidden md:inline-flex h-8 w-8"
+            onClick={() => setLeftPanelOpen(!leftPanelOpen)}
+            aria-label={leftPanelOpen ? "Collapse sidebar" : "Expand sidebar"}
+          >
+            {leftPanelOpen ? (
+              <PanelLeftClose className="h-4 w-4" />
+            ) : (
+              <PanelLeft className="h-4 w-4" />
+            )}
+          </Button>
+          <Link
+            href="/"
+            className="text-sm md:text-lg font-bold tracking-tight"
+          >
+            TraceRecap
+          </Link>
+        </div>
+        <div className="flex items-center gap-1.5 md:gap-2">
+          <MapStyleSelector />
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
+            onClick={() => fileInputRef.current?.click()}
+            aria-label="Import route"
+          >
+            <Upload className="h-3.5 w-3.5" />
+            <span className="hidden md:inline">Import</span>
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json"
+            className="hidden"
+            onChange={handleImport}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
+            onClick={handleExportRoute}
+            aria-label="Export route"
+          >
+            <Save className="h-3.5 w-3.5" />
+            <span className="hidden md:inline">Save Route</span>
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
+            onClick={() => setClearDialogOpen(true)}
+            aria-label="Clear route"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            <span className="hidden md:inline">Clear Route</span>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
+            onClick={() => setExportDialogOpen(true)}
+            aria-label="Export video"
+          >
+            <Download className="h-3.5 w-3.5" />
+            <span className="hidden md:inline">Export</span>
+          </Button>
+        </div>
       </div>
-      <div className="flex items-center gap-1.5 md:gap-2">
-        <MapStyleSelector />
-        <Button
-          variant="outline"
-          size="sm"
-          className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
-          onClick={() => fileInputRef.current?.click()}
-          aria-label="Import route"
-        >
-          <Upload className="h-3.5 w-3.5" />
-          <span className="hidden md:inline">Import</span>
-        </Button>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json"
-          className="hidden"
-          onChange={handleImport}
-        />
-        <Button
-          variant="outline"
-          size="sm"
-          className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
-          onClick={handleExportRoute}
-          aria-label="Export route"
-        >
-          <Save className="h-3.5 w-3.5" />
-          <span className="hidden md:inline">Save Route</span>
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
-          onClick={() => setExportDialogOpen(true)}
-          aria-label="Export video"
-        >
-          <Download className="h-3.5 w-3.5" />
-          <span className="hidden md:inline">Export</span>
-        </Button>
-      </div>
-    </div>
+      <Dialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Clear Route</DialogTitle>
+            <DialogDescription>
+              Are you sure? This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose render={<Button variant="outline" />}>
+              Cancel
+            </DialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                clearRoute();
+                setClearDialogOpen(false);
+              }}
+            >
+              Clear Route
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { generateRouteGeometry } from "@/engine/RouteGeometry";
 import type {
   Location,
   Segment,
@@ -15,12 +16,28 @@ export interface ImportRouteData {
     nameZh?: string;
     coordinates: [number, number];
     isWaypoint?: boolean;
-    photos?: { url: string; caption?: string; focalPoint?: { x: number; y: number } }[];
+    photos?: {
+      url: string;
+      caption?: string;
+      focalPoint?: { x: number; y: number };
+    }[];
     photoLayout?: PhotoLayout;
   }[];
-  segments: { fromIndex: number; toIndex: number; transportMode: TransportMode }[];
+  segments: {
+    fromIndex: number;
+    toIndex: number;
+    transportMode: TransportMode;
+  }[];
   timingOverrides?: Record<string, number>;
+  mapStyle?: MapStyle;
 }
+
+type PersistedProjectData = ImportRouteData;
+
+const DEFAULT_ROUTE_NAME = "My Trip";
+const DEFAULT_MAP_STYLE: MapStyle = "light";
+const PROJECT_STORAGE_KEY = "trace-recap-project";
+const PROJECT_SAVE_DEBOUNCE_MS = 500;
 
 interface ProjectState {
   locations: Location[];
@@ -28,10 +45,15 @@ interface ProjectState {
   mapStyle: MapStyle;
   segmentTimingOverrides: Record<string, number>;
 
-  addLocation: (location: Omit<Location, "id" | "photos" | "isWaypoint">) => void;
+  addLocation: (
+    location: Omit<Location, "id" | "photos" | "isWaypoint">,
+  ) => void;
   removeLocation: (id: string) => void;
   reorderLocations: (fromIndex: number, toIndex: number) => void;
-  updateLocation: (id: string, updates: Partial<Pick<Location, "name" | "nameZh" | "coordinates">>) => void;
+  updateLocation: (
+    id: string,
+    updates: Partial<Pick<Location, "name" | "nameZh" | "coordinates">>,
+  ) => void;
   toggleWaypoint: (locationId: string) => void;
 
   setTransportMode: (segmentId: string, mode: TransportMode) => void;
@@ -40,24 +62,108 @@ interface ProjectState {
   setSegmentTiming: (segmentId: string, duration: number | null) => void;
   clearAllTimingOverrides: () => void;
 
-  addPhoto: (locationId: string, photo: Omit<Photo, "id" | "locationId">) => void;
+  addPhoto: (
+    locationId: string,
+    photo: Omit<Photo, "id" | "locationId">,
+  ) => void;
   removePhoto: (locationId: string, photoId: string) => void;
   setPhotoLayout: (locationId: string, layout: PhotoLayout) => void;
-  setPhotoFocalPoint: (locationId: string, photoId: string, point: { x: number; y: number }) => void;
+  setPhotoFocalPoint: (
+    locationId: string,
+    photoId: string,
+    point: { x: number; y: number },
+  ) => void;
 
   setMapStyle: (style: MapStyle) => void;
   clearRoute: () => void;
   importRoute: (data: ImportRouteData) => void;
+  loadRouteData: (data: ImportRouteData) => Promise<void>;
+  regenerateSegmentGeometries: () => Promise<void>;
+  restorePersistedProject: () => Promise<void>;
   enrichChineseNames: () => Promise<void>;
   exportRoute: () => Promise<ImportRouteData>;
 }
 
 let nextId = 1;
+let persistTimeout: ReturnType<typeof setTimeout> | null = null;
+let persistenceInitialized = false;
+let skipNextPersist = false;
+let lastSavedProjectJson = "";
+
 const generateId = () => String(nextId++);
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+function serializeProjectState(
+  locations: Location[],
+  segments: Segment[],
+  mapStyle: MapStyle,
+  segmentTimingOverrides: Record<string, number>,
+): PersistedProjectData {
+  const exportedLocations = locations.map((loc) => ({
+    name: loc.name,
+    nameZh: loc.nameZh,
+    coordinates: loc.coordinates as [number, number],
+    isWaypoint: loc.isWaypoint ?? false,
+    ...(loc.photos.length > 0
+      ? {
+          photos: loc.photos.map((photo) => ({
+            url: photo.url,
+            caption: photo.caption,
+            ...(photo.focalPoint ? { focalPoint: photo.focalPoint } : {}),
+          })),
+        }
+      : {}),
+    ...(loc.photoLayout
+      ? {
+          photoLayout: {
+            ...loc.photoLayout,
+            order: loc.photoLayout.order
+              ? loc.photoLayout.order
+                  .map((photoId) =>
+                    loc.photos.findIndex((photo) => photo.id === photoId),
+                  )
+                  .filter((index) => index >= 0)
+                  .map(String)
+              : undefined,
+          },
+        }
+      : {}),
+  }));
+
+  return {
+    name: DEFAULT_ROUTE_NAME,
+    mapStyle,
+    locations: exportedLocations,
+    segments: segments.map((segment) => ({
+      fromIndex: locations.findIndex(
+        (location) => location.id === segment.fromId,
+      ),
+      toIndex: locations.findIndex((location) => location.id === segment.toId),
+      transportMode: segment.transportMode,
+    })),
+    ...(Object.keys(segmentTimingOverrides).length > 0
+      ? {
+          timingOverrides: Object.fromEntries(
+            Object.entries(segmentTimingOverrides)
+              .map(([segmentId, duration]) => {
+                const index = segments.findIndex(
+                  (segment) => segment.id === segmentId,
+                );
+                return index >= 0 ? [String(index), duration] : null;
+              })
+              .filter(Boolean) as [string, number][],
+          ),
+        }
+      : {}),
+  };
+}
 
 function rebuildSegments(
   locations: Location[],
-  oldSegments: Segment[]
+  oldSegments: Segment[],
 ): Segment[] {
   if (locations.length < 2) return [];
 
@@ -98,7 +204,7 @@ function rebuildSegments(
 export const useProjectStore = create<ProjectState>((set, get) => ({
   locations: [],
   segments: [],
-  mapStyle: "light",
+  mapStyle: DEFAULT_MAP_STYLE,
   segmentTimingOverrides: {},
 
   addLocation: (loc) =>
@@ -149,7 +255,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   updateLocation: (id, updates) =>
     set((state) => ({
       locations: state.locations.map((l) =>
-        l.id === id ? { ...l, ...updates } : l
+        l.id === id ? { ...l, ...updates } : l,
       ),
     })),
 
@@ -160,7 +266,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       if (idx <= 0 || idx >= state.locations.length - 1) return state;
       return {
         locations: state.locations.map((l) =>
-          l.id === locationId ? { ...l, isWaypoint: !l.isWaypoint } : l
+          l.id === locationId ? { ...l, isWaypoint: !l.isWaypoint } : l,
         ),
       };
     }),
@@ -168,16 +274,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   setTransportMode: (segmentId, mode) =>
     set((state) => ({
       segments: state.segments.map((s) =>
-        s.id === segmentId
-          ? { ...s, transportMode: mode, geometry: null }
-          : s
+        s.id === segmentId ? { ...s, transportMode: mode, geometry: null } : s,
       ),
     })),
 
   setSegmentGeometry: (segmentId, geometry) =>
     set((state) => ({
       segments: state.segments.map((s) =>
-        s.id === segmentId ? { ...s, geometry } : s
+        s.id === segmentId ? { ...s, geometry } : s,
       ),
     })),
 
@@ -200,12 +304,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         l.id === locationId
           ? {
               ...l,
-              photos: [
-                ...l.photos,
-                { ...photo, id: generateId(), locationId },
-              ],
+              photos: [...l.photos, { ...photo, id: generateId(), locationId }],
             }
-          : l
+          : l,
       ),
     })),
 
@@ -214,14 +315,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       locations: state.locations.map((l) =>
         l.id === locationId
           ? { ...l, photos: l.photos.filter((p) => p.id !== photoId) }
-          : l
+          : l,
       ),
     })),
 
   setPhotoLayout: (locationId, layout) =>
     set((state) => ({
       locations: state.locations.map((l) =>
-        l.id === locationId ? { ...l, photoLayout: layout } : l
+        l.id === locationId ? { ...l, photoLayout: layout } : l,
       ),
     })),
 
@@ -232,19 +333,36 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           ? {
               ...l,
               photos: l.photos.map((p) =>
-                p.id === photoId ? { ...p, focalPoint: point } : p
+                p.id === photoId ? { ...p, focalPoint: point } : p,
               ),
             }
-          : l
+          : l,
       ),
     })),
 
   setMapStyle: (style) => set({ mapStyle: style }),
 
-  clearRoute: () => set({ locations: [], segments: [], segmentTimingOverrides: {} }),
+  clearRoute: () => {
+    if (isBrowser()) {
+      if (persistTimeout) {
+        clearTimeout(persistTimeout);
+        persistTimeout = null;
+      }
+      skipNextPersist = true;
+      window.localStorage.removeItem(PROJECT_STORAGE_KEY);
+      lastSavedProjectJson = "";
+    }
+
+    set({
+      locations: [],
+      segments: [],
+      mapStyle: DEFAULT_MAP_STYLE,
+      segmentTimingOverrides: {},
+    });
+  },
 
   exportRoute: async () => {
-    const { locations, segments, segmentTimingOverrides } = get();
+    const { locations, segments, mapStyle, segmentTimingOverrides } = get();
 
     // Convert blob URLs to base64 data URLs for persistence
     const toDataURL = async (url: string): Promise<string> => {
@@ -269,7 +387,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
             url: await toDataURL(p.url),
             caption: p.caption,
             ...(p.focalPoint ? { focalPoint: p.focalPoint } : {}),
-          }))
+          })),
         );
         return {
           name: loc.name,
@@ -277,24 +395,27 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           coordinates: loc.coordinates as [number, number],
           isWaypoint: loc.isWaypoint ?? false,
           ...(photos.length > 0 ? { photos } : {}),
-          ...(loc.photoLayout ? {
-            photoLayout: {
-              ...loc.photoLayout,
-              // Convert order from photo IDs to indices for portable serialization
-              order: loc.photoLayout.order
-                ? loc.photoLayout.order
-                    .map((id) => loc.photos.findIndex((p) => p.id === id))
-                    .filter((idx) => idx >= 0)
-                    .map(String)
-                : undefined,
-            },
-          } : {}),
+          ...(loc.photoLayout
+            ? {
+                photoLayout: {
+                  ...loc.photoLayout,
+                  // Convert order from photo IDs to indices for portable serialization
+                  order: loc.photoLayout.order
+                    ? loc.photoLayout.order
+                        .map((id) => loc.photos.findIndex((p) => p.id === id))
+                        .filter((idx) => idx >= 0)
+                        .map(String)
+                    : undefined,
+                },
+              }
+            : {}),
         };
-      })
+      }),
     );
 
     return {
-      name: "My Trip",
+      name: DEFAULT_ROUTE_NAME,
+      mapStyle,
       locations: exportedLocations,
       segments: segments.map((seg) => ({
         fromIndex: locations.findIndex((l) => l.id === seg.fromId),
@@ -309,7 +430,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
                   const idx = segments.findIndex((s) => s.id === segId);
                   return idx >= 0 ? [String(idx), duration] : null;
                 })
-                .filter(Boolean) as [string, number][]
+                .filter(Boolean) as [string, number][],
             ),
           }
         : {}),
@@ -333,18 +454,21 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           nameZh: loc.nameZh,
           coordinates: loc.coordinates,
           photos,
-          isWaypoint: i > 0 && i < data.locations.length - 1 && (loc.isWaypoint ?? false),
-          ...(loc.photoLayout ? {
-            photoLayout: {
-              ...loc.photoLayout,
-              // Order was exported as index strings — remap to new photo IDs
-              order: loc.photoLayout.order
-                ? loc.photoLayout.order
-                    .map((idxStr) => photos[parseInt(idxStr)]?.id)
-                    .filter(Boolean)
-                : undefined,
-            },
-          } : {}),
+          isWaypoint:
+            i > 0 && i < data.locations.length - 1 && (loc.isWaypoint ?? false),
+          ...(loc.photoLayout
+            ? {
+                photoLayout: {
+                  ...loc.photoLayout,
+                  // Order was exported as index strings — remap to new photo IDs
+                  order: loc.photoLayout.order
+                    ? loc.photoLayout.order
+                        .map((idxStr) => photos[parseInt(idxStr, 10)]?.id)
+                        .filter(Boolean)
+                    : undefined,
+                },
+              }
+            : {}),
         };
       });
 
@@ -360,7 +484,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       const segmentTimingOverrides: Record<string, number> = {};
       if (data.timingOverrides) {
         for (const [key, duration] of Object.entries(data.timingOverrides)) {
-          const idx = parseInt(key);
+          const idx = parseInt(key, 10);
           if (!isNaN(idx) && idx >= 0 && idx < segments.length) {
             segmentTimingOverrides[segments[idx].id] = duration;
           }
@@ -370,9 +494,69 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       return {
         locations,
         segments,
+        mapStyle: data.mapStyle ?? DEFAULT_MAP_STYLE,
         segmentTimingOverrides,
       };
     }),
+
+  loadRouteData: async (data) => {
+    get().importRoute(data);
+    await get().regenerateSegmentGeometries();
+  },
+
+  regenerateSegmentGeometries: async () => {
+    const { locations, segments } = get();
+
+    const geometries = await Promise.all(
+      segments.map(async (segment) => {
+        const fromLocation = locations.find(
+          (location) => location.id === segment.fromId,
+        );
+        const toLocation = locations.find(
+          (location) => location.id === segment.toId,
+        );
+
+        if (!fromLocation || !toLocation) {
+          return { segmentId: segment.id, geometry: null };
+        }
+
+        try {
+          const geometry = await generateRouteGeometry(
+            fromLocation.coordinates,
+            toLocation.coordinates,
+            segment.transportMode,
+          );
+          return { segmentId: segment.id, geometry };
+        } catch {
+          return { segmentId: segment.id, geometry: null };
+        }
+      }),
+    );
+
+    set((state) => ({
+      segments: state.segments.map((segment) => {
+        const match = geometries.find(
+          (entry) => entry.segmentId === segment.id,
+        );
+        return match ? { ...segment, geometry: match.geometry } : segment;
+      }),
+    }));
+  },
+
+  restorePersistedProject: async () => {
+    if (!isBrowser()) return;
+
+    const savedProject = window.localStorage.getItem(PROJECT_STORAGE_KEY);
+    if (!savedProject) return;
+
+    try {
+      const data = JSON.parse(savedProject) as PersistedProjectData;
+      await get().loadRouteData(data);
+    } catch {
+      window.localStorage.removeItem(PROJECT_STORAGE_KEY);
+      lastSavedProjectJson = "";
+    }
+  },
 
   enrichChineseNames: async () => {
     const { locations } = get();
@@ -384,14 +568,19 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         try {
           // Forward geocode English name → Chinese: more reliable than reverse geocode
           // which returns the nearest place at a finer granularity (e.g. district instead of city)
-          const res = await fetch(`/api/geocode?q=${encodeURIComponent(loc.name)}&language=zh`);
+          const res = await fetch(
+            `/api/geocode?q=${encodeURIComponent(loc.name)}&language=zh`,
+          );
           const data = await res.json();
-          const nameZh = data.features?.[0]?.text || data.features?.[0]?.place_name || undefined;
+          const nameZh =
+            data.features?.[0]?.text ||
+            data.features?.[0]?.place_name ||
+            undefined;
           return { id: loc.id, nameZh };
         } catch {
           return { id: loc.id, nameZh: undefined };
         }
-      })
+      }),
     );
 
     set((state) => ({
@@ -402,3 +591,41 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     }));
   },
 }));
+
+export function initializeProjectPersistence(): void {
+  if (!isBrowser() || persistenceInitialized) return;
+
+  persistenceInitialized = true;
+  lastSavedProjectJson = window.localStorage.getItem(PROJECT_STORAGE_KEY) ?? "";
+
+  useProjectStore.subscribe((state) => {
+    if (skipNextPersist) {
+      skipNextPersist = false;
+      return;
+    }
+
+    if (persistTimeout) {
+      clearTimeout(persistTimeout);
+    }
+
+    persistTimeout = setTimeout(() => {
+      const nextProjectJson = JSON.stringify(
+        serializeProjectState(
+          state.locations,
+          state.segments,
+          state.mapStyle,
+          state.segmentTimingOverrides,
+        ),
+      );
+
+      if (nextProjectJson === lastSavedProjectJson) {
+        return;
+      }
+
+      window.localStorage.setItem(PROJECT_STORAGE_KEY, nextProjectJson);
+      lastSavedProjectJson = nextProjectJson;
+    }, PROJECT_SAVE_DEBOUNCE_MS);
+  });
+
+  void useProjectStore.getState().restorePersistedProject();
+}


### PR DESCRIPTION
## Summary
- add debounced localStorage persistence and restore for project data
- regenerate segment geometry after import/restore through a shared store loader
- add a clear route confirmation action in the top toolbar

## Verification
- npx tsc --noEmit
- npm run build