### PR TITLE
feat: add undo/redo for route editing

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/stores/projectStore";
 import { useAnimationStore } from "@/stores/animationStore";
 import { useUIStore } from "@/stores/uiStore";
+import { useHistoryStore } from "@/stores/historyStore";
 
 function EditorContent() {
   const { map } = useMap();
@@ -355,6 +356,19 @@ function EditorContent() {
         e.target instanceof HTMLTextAreaElement
       )
         return;
+
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        useHistoryStore.getState().undo();
+        return;
+      }
+      if (mod && e.key === "z" && e.shiftKey) {
+        e.preventDefault();
+        useHistoryStore.getState().redo();
+        return;
+      }
+
       if (e.code === "Space") {
         e.preventDefault();
         const state = useAnimationStore.getState().playbackState;

--- a/src/components/editor/TopToolbar.tsx
+++ b/src/components/editor/TopToolbar.tsx
@@ -9,6 +9,8 @@ import {
   PanelLeftClose,
   PanelLeft,
   Trash2,
+  Undo2,
+  Redo2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,6 +25,7 @@ import {
 import MapStyleSelector from "./MapStyleSelector";
 import { useUIStore } from "@/stores/uiStore";
 import { useProjectStore, type ImportRouteData } from "@/stores/projectStore";
+import { useHistoryStore } from "@/stores/historyStore";
 
 export default function TopToolbar() {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -34,6 +37,10 @@ export default function TopToolbar() {
   const loadRouteData = useProjectStore((s) => s.loadRouteData);
   const enrichChineseNames = useProjectStore((s) => s.enrichChineseNames);
   const clearRoute = useProjectStore((s) => s.clearRoute);
+  const undo = useHistoryStore((s) => s.undo);
+  const redo = useHistoryStore((s) => s.redo);
+  const canUndo = useHistoryStore((s) => s.canUndo);
+  const canRedo = useHistoryStore((s) => s.canRedo);
 
   const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -87,6 +94,26 @@ export default function TopToolbar() {
           </Link>
         </div>
         <div className="flex items-center gap-1.5 md:gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={undo}
+            disabled={!canUndo}
+            aria-label="Undo"
+          >
+            <Undo2 className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={redo}
+            disabled={!canRedo}
+            aria-label="Redo"
+          >
+            <Redo2 className="h-4 w-4" />
+          </Button>
           <MapStyleSelector />
           <Button
             variant="outline"

--- a/src/stores/historyStore.ts
+++ b/src/stores/historyStore.ts
@@ -1,0 +1,97 @@
+import { create } from "zustand";
+import { useProjectStore } from "./projectStore";
+import type { Location, Segment, MapStyle } from "@/types";
+
+interface HistorySnapshot {
+  locations: Location[];
+  segments: Segment[];
+  mapStyle: MapStyle;
+  segmentTimingOverrides: Record<string, number>;
+}
+
+const MAX_HISTORY = 50;
+
+interface HistoryState {
+  undoStack: HistorySnapshot[];
+  redoStack: HistorySnapshot[];
+  canUndo: boolean;
+  canRedo: boolean;
+  pushState: () => void;
+  undo: () => void;
+  redo: () => void;
+}
+
+function captureSnapshot(): HistorySnapshot {
+  const { locations, segments, mapStyle, segmentTimingOverrides } =
+    useProjectStore.getState();
+  return {
+    locations: structuredClone(locations),
+    segments: structuredClone(segments),
+    mapStyle,
+    segmentTimingOverrides: { ...segmentTimingOverrides },
+  };
+}
+
+function restoreSnapshot(snapshot: HistorySnapshot): void {
+  useProjectStore.setState({
+    locations: snapshot.locations,
+    segments: snapshot.segments,
+    mapStyle: snapshot.mapStyle,
+    segmentTimingOverrides: snapshot.segmentTimingOverrides,
+  });
+}
+
+export const useHistoryStore = create<HistoryState>((set) => ({
+  undoStack: [],
+  redoStack: [],
+  canUndo: false,
+  canRedo: false,
+
+  pushState: () => {
+    const snapshot = captureSnapshot();
+    set((state) => {
+      const undoStack = [...state.undoStack, snapshot].slice(-MAX_HISTORY);
+      return { undoStack, redoStack: [], canUndo: true, canRedo: false };
+    });
+  },
+
+  undo: () => {
+    set((state) => {
+      if (state.undoStack.length === 0) return state;
+
+      const current = captureSnapshot();
+      const undoStack = [...state.undoStack];
+      const snapshot = undoStack.pop()!;
+      const redoStack = [...state.redoStack, current];
+
+      restoreSnapshot(snapshot);
+
+      return {
+        undoStack,
+        redoStack,
+        canUndo: undoStack.length > 0,
+        canRedo: true,
+      };
+    });
+  },
+
+  redo: () => {
+    set((state) => {
+      if (state.redoStack.length === 0) return state;
+
+      const current = captureSnapshot();
+      const redoStack = [...state.redoStack];
+      const snapshot = redoStack.pop()!;
+      const undoStack = [...state.undoStack, current];
+
+      restoreSnapshot(snapshot);
+
+      return {
+        undoStack,
+        redoStack,
+        canUndo: true,
+        canRedo: redoStack.length > 0,
+      };
+    });
+  },
+}));

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -8,6 +8,7 @@ import type {
   TransportMode,
   MapStyle,
 } from "@/types";
+import { useHistoryStore } from "./historyStore";
 
 export interface ImportRouteData {
   name: string;
@@ -207,8 +208,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   mapStyle: DEFAULT_MAP_STYLE,
   segmentTimingOverrides: {},
 
-  addLocation: (loc) =>
-    set((state) => {
+  addLocation: (loc) => {
+    useHistoryStore.getState().pushState();
+    return set((state) => {
       const newLocation: Location = {
         id: generateId(),
         name: loc.name,
@@ -222,10 +224,12 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         locations,
         segments: rebuildSegments(locations, state.segments),
       };
-    }),
+    });
+  },
 
-  removeLocation: (id) =>
-    set((state) => {
+  removeLocation: (id) => {
+    useHistoryStore.getState().pushState();
+    return set((state) => {
       const locations = state.locations.filter((l) => l.id !== id);
       // Ensure first and last locations are never waypoints
       if (locations.length > 0) {
@@ -235,10 +239,12 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         locations,
         segments: rebuildSegments(locations, state.segments),
       };
-    }),
+    });
+  },
 
-  reorderLocations: (fromIndex, toIndex) =>
-    set((state) => {
+  reorderLocations: (fromIndex, toIndex) => {
+    useHistoryStore.getState().pushState();
+    return set((state) => {
       const locations = [...state.locations];
       const [moved] = locations.splice(fromIndex, 1);
       locations.splice(toIndex, 0, moved);
@@ -250,7 +256,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         locations,
         segments: rebuildSegments(locations, state.segments),
       };
-    }),
+    });
+  },
 
   updateLocation: (id, updates) =>
     set((state) => ({
@@ -259,8 +266,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       ),
     })),
 
-  toggleWaypoint: (locationId) =>
-    set((state) => {
+  toggleWaypoint: (locationId) => {
+    useHistoryStore.getState().pushState();
+    return set((state) => {
       const idx = state.locations.findIndex((l) => l.id === locationId);
       // First and last locations can never be waypoints
       if (idx <= 0 || idx >= state.locations.length - 1) return state;
@@ -269,14 +277,17 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
           l.id === locationId ? { ...l, isWaypoint: !l.isWaypoint } : l,
         ),
       };
-    }),
+    });
+  },
 
-  setTransportMode: (segmentId, mode) =>
-    set((state) => ({
+  setTransportMode: (segmentId, mode) => {
+    useHistoryStore.getState().pushState();
+    return set((state) => ({
       segments: state.segments.map((s) =>
         s.id === segmentId ? { ...s, transportMode: mode, geometry: null } : s,
       ),
-    })),
+    }));
+  },
 
   setSegmentGeometry: (segmentId, geometry) =>
     set((state) => ({
@@ -285,8 +296,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       ),
     })),
 
-  setSegmentTiming: (segmentId, duration) =>
-    set((state) => {
+  setSegmentTiming: (segmentId, duration) => {
+    useHistoryStore.getState().pushState();
+    return set((state) => {
       const overrides = { ...state.segmentTimingOverrides };
       if (duration === null) {
         delete overrides[segmentId];
@@ -294,12 +306,14 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         overrides[segmentId] = duration;
       }
       return { segmentTimingOverrides: overrides };
-    }),
+    });
+  },
 
   clearAllTimingOverrides: () => set({ segmentTimingOverrides: {} }),
 
-  addPhoto: (locationId, photo) =>
-    set((state) => ({
+  addPhoto: (locationId, photo) => {
+    useHistoryStore.getState().pushState();
+    return set((state) => ({
       locations: state.locations.map((l) =>
         l.id === locationId
           ? {
@@ -308,16 +322,19 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
             }
           : l,
       ),
-    })),
+    }));
+  },
 
-  removePhoto: (locationId, photoId) =>
-    set((state) => ({
+  removePhoto: (locationId, photoId) => {
+    useHistoryStore.getState().pushState();
+    return set((state) => ({
       locations: state.locations.map((l) =>
         l.id === locationId
           ? { ...l, photos: l.photos.filter((p) => p.id !== photoId) }
           : l,
       ),
-    })),
+    }));
+  },
 
   setPhotoLayout: (locationId, layout) =>
     set((state) => ({
@@ -343,6 +360,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   setMapStyle: (style) => set({ mapStyle: style }),
 
   clearRoute: () => {
+    useHistoryStore.getState().pushState();
     if (isBrowser()) {
       if (persistTimeout) {
         clearTimeout(persistTimeout);
@@ -437,8 +455,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     };
   },
 
-  importRoute: (data) =>
-    set(() => {
+  importRoute: (data) => {
+    useHistoryStore.getState().pushState();
+    return set(() => {
       const locations: Location[] = data.locations.map((loc, i) => {
         const locId = generateId();
         const photos = (loc.photos ?? []).map((p) => ({
@@ -497,7 +516,8 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         mapStyle: data.mapStyle ?? DEFAULT_MAP_STYLE,
         segmentTimingOverrides,
       };
-    }),
+    });
+  },
 
   loadRouteData: async (data) => {
     get().importRoute(data);


### PR DESCRIPTION
## Summary
- Add `historyStore.ts` — Zustand store tracking undo/redo stacks (max 50 snapshots of locations, segments, mapStyle, segmentTimingOverrides)
- Integrate with projectStore: snapshot state before every route-editing mutation (addLocation, removeLocation, reorderLocations, setTransportMode, toggleWaypoint, addPhoto, removePhoto, setSegmentTiming, clearRoute, importRoute)
- Add Cmd/Ctrl+Z (undo) and Cmd/Ctrl+Shift+Z (redo) keyboard shortcuts in EditorLayout
- Add undo/redo buttons (Undo2/Redo2 icons) in TopToolbar, disabled when stack is empty

## Test plan
- [ ] Add several locations, then Cmd+Z to undo each — locations should revert one by one
- [ ] After undoing, Cmd+Shift+Z to redo — locations should reappear
- [ ] Verify undo/redo buttons in toolbar enable/disable correctly
- [ ] After undoing and making a new change, redo stack should be cleared
- [ ] Verify keyboard shortcuts don't fire when typing in input fields
- [ ] Verify no more than 50 snapshots are retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)