### PR TITLE
feat: add demo project and first-time onboarding hints

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,12 +10,20 @@ export default function Home() {
           minutes.
         </p>
       </div>
-      <Link
-        href="/editor"
-        className="inline-flex items-center justify-center rounded-lg bg-primary px-8 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
-      >
-        Create Video
-      </Link>
+      <div className="flex flex-col items-center gap-3">
+        <Link
+          href="/editor"
+          className="inline-flex items-center justify-center rounded-lg bg-primary px-8 py-3 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+        >
+          Create Video
+        </Link>
+        <Link
+          href="/editor?demo=true"
+          className="inline-flex items-center justify-center rounded-lg border border-border bg-secondary px-8 py-3 text-sm font-medium text-secondary-foreground shadow-sm transition-colors hover:bg-secondary/80"
+        >
+          Try Demo
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/components/editor/BottomSheet.tsx
+++ b/src/components/editor/BottomSheet.tsx
@@ -10,9 +10,16 @@ import RouteList from "./RouteList";
 interface BottomSheetProps {
   onLocationClick?: (index: number) => void;
   onEditLayout?: (locationId: string) => void;
+  searchHintMessage?: string;
+  onDismissSearchHint?: () => void;
 }
 
-export default function BottomSheet({ onLocationClick, onEditLayout }: BottomSheetProps) {
+export default function BottomSheet({
+  onLocationClick,
+  onEditLayout,
+  searchHintMessage,
+  onDismissSearchHint,
+}: BottomSheetProps) {
   const locations = useProjectStore((s) => s.locations);
   const expanded = useUIStore((s) => s.bottomSheetExpanded);
   const toggleBottomSheet = useUIStore((s) => s.toggleBottomSheet);
@@ -62,7 +69,10 @@ export default function BottomSheet({ onLocationClick, onEditLayout }: BottomShe
 
         {/* Expanded content */}
         <div className="flex flex-col overflow-hidden" style={{ height: "calc(60vh - 56px)" }}>
-          <CitySearch />
+          <CitySearch
+            hintMessage={searchHintMessage}
+            onHintDismiss={onDismissSearchHint}
+          />
           <ScrollArea className="flex-1 min-h-0">
             <RouteList onLocationClick={onLocationClick} onEditLayout={onEditLayout} />
           </ScrollArea>

--- a/src/components/editor/CitySearch.tsx
+++ b/src/components/editor/CitySearch.tsx
@@ -5,6 +5,7 @@ import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useProjectStore } from "@/stores/projectStore";
 import { useMap } from "./MapContext";
+import OnboardingHint from "./OnboardingHint";
 
 interface GeoResult {
   id: string;
@@ -13,7 +14,15 @@ interface GeoResult {
   center: [number, number];
 }
 
-export default function CitySearch() {
+interface CitySearchProps {
+  hintMessage?: string;
+  onHintDismiss?: () => void;
+}
+
+export default function CitySearch({
+  hintMessage,
+  onHintDismiss,
+}: CitySearchProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<GeoResult[]>([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -98,6 +107,14 @@ export default function CitySearch() {
           className="pl-9"
         />
       </div>
+      {hintMessage && onHintDismiss && (
+        <OnboardingHint
+          message={hintMessage}
+          onDismiss={onHintDismiss}
+          className="left-3 right-3 top-[calc(100%+0.25rem)] max-w-none"
+          arrowClassName="left-6 -top-[7px] border-b-0 border-r-0"
+        />
+      )}
       {isOpen && results.length > 0 && (
         <div className="absolute left-3 right-3 top-14 z-50 rounded-md border bg-popover shadow-lg">
           {results.map((r) => (

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -19,6 +19,7 @@ import {
 } from "./routeSegmentSources";
 import * as turf from "@turf/turf";
 import { AnimationEngine } from "@/engine/AnimationEngine";
+import { demoProject } from "@/lib/demoProject";
 import {
   initializeProjectPersistence,
   useProjectStore,
@@ -26,14 +27,71 @@ import {
 import { useAnimationStore } from "@/stores/animationStore";
 import { useUIStore } from "@/stores/uiStore";
 
+const ONBOARDING_STORAGE_KEY = "trace-recap-onboarded";
+
+type OnboardingHintKey =
+  | "searchStart"
+  | "searchSecondStop"
+  | "playPreview";
+
+type OnboardingState = Record<OnboardingHintKey, boolean>;
+
+const DEFAULT_ONBOARDING_STATE: OnboardingState = {
+  searchStart: false,
+  searchSecondStop: false,
+  playPreview: false,
+};
+
+function readOnboardingState(): OnboardingState {
+  if (typeof window === "undefined") {
+    return DEFAULT_ONBOARDING_STATE;
+  }
+
+  const saved = window.localStorage.getItem(ONBOARDING_STORAGE_KEY);
+  if (!saved) {
+    return DEFAULT_ONBOARDING_STATE;
+  }
+
+  if (saved === "true") {
+    return {
+      searchStart: true,
+      searchSecondStop: true,
+      playPreview: true,
+    };
+  }
+
+  try {
+    return {
+      ...DEFAULT_ONBOARDING_STATE,
+      ...(JSON.parse(saved) as Partial<OnboardingState>),
+    };
+  } catch {
+    return DEFAULT_ONBOARDING_STATE;
+  }
+}
+
+function persistOnboardingState(state: OnboardingState): void {
+  if (typeof window === "undefined") return;
+
+  window.localStorage.setItem(
+    ONBOARDING_STORAGE_KEY,
+    Object.values(state).every(Boolean) ? "true" : JSON.stringify(state),
+  );
+}
+
 function EditorContent() {
   const { map } = useMap();
   const locations = useProjectStore((s) => s.locations);
   const segments = useProjectStore((s) => s.segments);
+  const importRoute = useProjectStore((s) => s.importRoute);
+  const regenerateSegmentGeometries = useProjectStore(
+    (s) => s.regenerateSegmentGeometries,
+  );
   const segmentTimingOverrides = useProjectStore(
     (s) => s.segmentTimingOverrides,
   );
   const engineRef = useRef<AnimationEngine | null>(null);
+  const demoLoadedRef = useRef(false);
 
   const setPlaybackState = useAnimationStore((s) => s.setPlaybackState);
   const setCurrentTime = useAnimationStore((s) => s.setCurrentTime);
@@ -58,6 +116,7 @@ function EditorContent() {
 
   const cityLabelSize = useUIStore((s) => s.cityLabelSize);
   const cityLabelLang = useUIStore((s) => s.cityLabelLang);
+  const setBottomSheetExpanded = useUIStore((s) => s.setBottomSheetExpanded);
   const currentCityLabelEn = useAnimationStore((s) => s.currentCityLabel);
   const currentCityLabelZh = useAnimationStore((s) => s.currentCityLabelZh);
   const currentCityLabel =
@@ -78,10 +137,43 @@ function EditorContent() {
   >(null);
   const visiblePhotoLocation =
     locations.find((l) => l.id === visiblePhotoLocationId) ?? null;
+  const [shouldLoadDemo, setShouldLoadDemo] = useState(false);
+  const [demoQueryChecked, setDemoQueryChecked] = useState(false);
+  const [onboardingState, setOnboardingState] =
+    useState<OnboardingState | null>(null);
 
   useEffect(() => {
-    initializeProjectPersistence();
+    const nextShouldLoadDemo =
+      new URL(window.location.href).searchParams.get("demo") === "true";
+    setShouldLoadDemo(nextShouldLoadDemo);
+    setDemoQueryChecked(true);
+    initializeProjectPersistence({ skipRestore: nextShouldLoadDemo });
   }, []);
+
+  useEffect(() => {
+    setOnboardingState(readOnboardingState());
+  }, []);
+
+  useEffect(() => {
+    if (!demoQueryChecked || !shouldLoadDemo || demoLoadedRef.current) return;
+
+    demoLoadedRef.current = true;
+
+    const loadDemoProject = async () => {
+      importRoute(demoProject);
+      await regenerateSegmentGeometries();
+
+      const nextUrl = new URL(window.location.href);
+      nextUrl.searchParams.delete("demo");
+      window.history.replaceState(
+        {},
+        "",
+        `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`,
+      );
+    };
+
+    void loadDemoProject();
+  }, [demoQueryChecked, importRoute, regenerateSegmentGeometries, shouldLoadDemo]);
 
   // Rebuild engine when project changes
   useEffect(() => {
@@ -372,6 +464,61 @@ function EditorContent() {
   const isPlaying = playbackState === "playing";
   const hasSegments = segments.length > 0;
 
+  const dismissHint = useCallback((hintKey: OnboardingHintKey) => {
+    setOnboardingState((current) => {
+      if (!current || current[hintKey]) {
+        return current;
+      }
+
+      const nextState = {
+        ...current,
+        [hintKey]: true,
+      };
+      persistOnboardingState(nextState);
+      return nextState;
+    });
+  }, []);
+
+  const searchHintMessage =
+    onboardingState && !onboardingState.searchStart && locations.length === 0
+      ? "Search for a city above to start building your route"
+      : onboardingState &&
+          !onboardingState.searchSecondStop &&
+          locations.length === 1
+        ? "Add one more city above to create your first route segment"
+        : undefined;
+
+  const handleSearchHintDismiss = useCallback(() => {
+    if (!onboardingState) return;
+
+    if (!onboardingState.searchStart && locations.length === 0) {
+      dismissHint("searchStart");
+      return;
+    }
+
+    if (!onboardingState.searchSecondStop && locations.length === 1) {
+      dismissHint("searchSecondStop");
+    }
+  }, [dismissHint, locations.length, onboardingState]);
+
+  const playHintMessage =
+    onboardingState &&
+    !onboardingState.playPreview &&
+    locations.length >= 2 &&
+    hasSegments
+      ? "Press Play to preview your route animation"
+      : undefined;
+
+  useEffect(() => {
+    if (
+      searchHintMessage &&
+      typeof window !== "undefined" &&
+      window.innerWidth < 768
+    ) {
+      setBottomSheetExpanded(true);
+    }
+  }, [searchHintMessage, setBottomSheetExpanded]);
+
   return (
     <div className="flex h-screen flex-col">
       <TopToolbar />
@@ -379,6 +526,8 @@ function EditorContent() {
         <LeftPanel
           onLocationClick={handleLocationClick}
           onEditLayout={handleEditLayout}
+          searchHintMessage={searchHintMessage}
+          onDismissSearchHint={handleSearchHintDismiss}
         />
         {/* Map area: full width on mobile, flex-1 on desktop */}
         <div className="flex-1 relative">
@@ -458,6 +607,8 @@ function EditorContent() {
               onPause={handlePause}
               onReset={handleReset}
               onSeek={handleSeek}
+              hintMessage={playHintMessage}
+              onHintDismiss={() => dismissHint("playPreview")}
             />
           )}
         </div>
@@ -468,6 +619,8 @@ function EditorContent() {
           <BottomSheet
             onLocationClick={handleLocationClick}
             onEditLayout={handleEditLayout}
+            searchHintMessage={searchHintMessage}
+            onDismissSearchHint={handleSearchHintDismiss}
           />
         </div>
       )}

--- a/src/components/editor/LeftPanel.tsx
+++ b/src/components/editor/LeftPanel.tsx
@@ -12,11 +12,15 @@ import RouteList from "./RouteList";
 interface LeftPanelProps {
   onLocationClick?: (index: number) => void;
   onEditLayout?: (locationId: string) => void;
+  searchHintMessage?: string;
+  onDismissSearchHint?: () => void;
 }
 
 export default function LeftPanel({
   onLocationClick,
   onEditLayout,
+  searchHintMessage,
+  onDismissSearchHint,
 }: LeftPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const loadRouteData = useProjectStore((s) => s.loadRouteData);
@@ -64,7 +68,10 @@ export default function LeftPanel({
       <div className="border-b px-3 py-2">
         <h2 className="text-sm font-semibold">Route</h2>
       </div>
-      <CitySearch />
+      <CitySearch
+        hintMessage={searchHintMessage}
+        onHintDismiss={onDismissSearchHint}
+      />
       <div className="px-3 py-2">
         <div className="flex gap-2">
           <Button

--- a/src/components/editor/OnboardingHint.tsx
+++ b/src/components/editor/OnboardingHint.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface OnboardingHintProps {
+  message: string;
+  onDismiss: () => void;
+  className?: string;
+  arrowClassName?: string;
+}
+
+export default function OnboardingHint({
+  message,
+  onDismiss,
+  className,
+  arrowClassName,
+}: OnboardingHintProps) {
+  return (
+    <button
+      type="button"
+      onClick={onDismiss}
+      className={cn(
+        "absolute z-[80] max-w-xs rounded-lg border bg-background px-3 py-2 text-left shadow-lg",
+        className,
+      )}
+    >
+      <span className="block text-xs font-medium leading-relaxed">
+        {message}
+      </span>
+      <span className="mt-1 block text-[11px] text-muted-foreground">
+        Click to dismiss
+      </span>
+      <span
+        className={cn(
+          "absolute h-3 w-3 rotate-45 border bg-background",
+          arrowClassName,
+        )}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -5,12 +5,15 @@ import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { useAnimationStore } from "@/stores/animationStore";
 import { useUIStore } from "@/stores/uiStore";
+import OnboardingHint from "./OnboardingHint";
 
 interface PlaybackControlsProps {
   onPlay: () => void;
   onPause: () => void;
   onReset: () => void;
   onSeek: (progress: number) => void;
+  hintMessage?: string;
+  onHintDismiss?: () => void;
 }
 
 function formatTime(seconds: number): string {
@@ -25,6 +28,8 @@ export default function PlaybackControls({
   onPause,
   onReset,
   onSeek,
+  hintMessage,
+  onHintDismiss,
 }: PlaybackControlsProps) {
   const playbackState = useAnimationStore((s) => s.playbackState);
   const currentTime = useAnimationStore((s) => s.currentTime);
@@ -54,19 +59,29 @@ export default function PlaybackControls({
       >
         <RotateCcw className="h-4 w-4" />
       </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-11 w-11 md:h-8 md:w-8 min-w-[44px] md:min-w-0"
-        onClick={isPlaying ? onPause : onPlay}
-        aria-label={isPlaying ? "Pause" : "Play"}
-      >
-        {isPlaying ? (
-          <Pause className="h-4 w-4" />
-        ) : (
-          <Play className="h-4 w-4" />
+      <div className="relative">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-11 w-11 md:h-8 md:w-8 min-w-[44px] md:min-w-0"
+          onClick={isPlaying ? onPause : onPlay}
+          aria-label={isPlaying ? "Pause" : "Play"}
+        >
+          {isPlaying ? (
+            <Pause className="h-4 w-4" />
+          ) : (
+            <Play className="h-4 w-4" />
+          )}
+        </Button>
+        {hintMessage && onHintDismiss && (
+          <OnboardingHint
+            message={hintMessage}
+            onDismiss={onHintDismiss}
+            className="bottom-[calc(100%+0.75rem)] left-1/2 w-56 -translate-x-1/2"
+            arrowClassName="left-1/2 -bottom-[7px] -translate-x-1/2 border-l-0 border-t-0"
+          />
         )}
-      </Button>
+      </div>
       <div className="flex-1 md:flex-none md:w-48">
         <Slider
           value={[progress]}

--- a/src/lib/demoProject.ts
+++ b/src/lib/demoProject.ts
@@ -1,0 +1,45 @@
+import type { ImportRouteData } from "@/stores/projectStore";
+
+export const demoProject: ImportRouteData = {
+  name: "Taiwan Ring Tour",
+  mapStyle: "light",
+  locations: [
+    {
+      name: "Taipei",
+      nameZh: "台北",
+      coordinates: [121.5654, 25.033],
+    },
+    {
+      name: "Taichung",
+      nameZh: "台中",
+      coordinates: [120.6736, 24.1477],
+    },
+    {
+      name: "Tainan",
+      nameZh: "台南",
+      coordinates: [120.227, 22.9998],
+    },
+    {
+      name: "Chiayi",
+      nameZh: "嘉義",
+      coordinates: [120.4491, 23.48],
+    },
+    {
+      name: "Alishan",
+      nameZh: "阿里山",
+      coordinates: [120.7, 23.51],
+    },
+    {
+      name: "Taipei",
+      nameZh: "台北",
+      coordinates: [121.5654, 25.033],
+    },
+  ],
+  segments: [
+    { fromIndex: 0, toIndex: 1, transportMode: "train" },
+    { fromIndex: 1, toIndex: 2, transportMode: "train" },
+    { fromIndex: 2, toIndex: 3, transportMode: "bus" },
+    { fromIndex: 3, toIndex: 4, transportMode: "bus" },
+    { fromIndex: 4, toIndex: 5, transportMode: "flight" },
+  ],
+};

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -592,7 +592,13 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   },
 }));
 
-export function initializeProjectPersistence(): void {
+interface ProjectPersistenceOptions {
+  skipRestore?: boolean;
+}
+
+export function initializeProjectPersistence(
+  options: ProjectPersistenceOptions = {},
+): void {
   if (!isBrowser() || persistenceInitialized) return;
 
   persistenceInitialized = true;
@@ -627,5 +633,7 @@ export function initializeProjectPersistence(): void {
     }, PROJECT_SAVE_DEBOUNCE_MS);
   });
 
-  void useProjectStore.getState().restorePersistedProject();
+  if (!options.skipRestore) {
+    void useProjectStore.getState().restorePersistedProject();
+  }
 }


### PR DESCRIPTION
## Summary
- add a hardcoded Taiwan Ring Tour demo route and a Try Demo CTA on the landing page
- auto-import the demo route from /editor?demo=true and clear the query param after loading
- add simple localStorage-backed onboarding hints for search and playback

## Testing
- npx tsc --noEmit
- npm run build