### PR TITLE
feat: UI redesign phase 1 — toolbar, panel, styling overhaul

### DIFF
--- a/src/components/editor/CitySearch.tsx
+++ b/src/components/editor/CitySearch.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useProjectStore } from "@/stores/projectStore";
@@ -19,118 +19,162 @@ interface CitySearchProps {
   onHintDismiss?: () => void;
 }
 
-export default function CitySearch({
-  hintMessage,
-  onHintDismiss,
-}: CitySearchProps) {
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<GeoResult[]>([]);
-  const [isOpen, setIsOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const addLocation = useProjectStore((s) => s.addLocation);
-  const { map } = useMap();
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const containerRef = useRef<HTMLDivElement>(null);
+export interface CitySearchHandle {
+  focus: () => void;
+}
 
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
+const PLACEHOLDER_CITIES = [
+  "Search Tokyo...",
+  "Search Paris...",
+  "Search New York...",
+  "Search Sydney...",
+];
 
-  const search = (q: string) => {
-    setQuery(q);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
+const CitySearch = forwardRef<CitySearchHandle, CitySearchProps>(
+  function CitySearch({ hintMessage, onHintDismiss }, ref) {
+    const [query, setQuery] = useState("");
+    const [results, setResults] = useState<GeoResult[]>([]);
+    const [isOpen, setIsOpen] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [placeholderIndex, setPlaceholderIndex] = useState(0);
+    const [placeholderVisible, setPlaceholderVisible] = useState(true);
+    const addLocation = useProjectStore((s) => s.addLocation);
+    const { map } = useMap();
+    const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
 
-    if (q.trim().length < 2) {
-      setResults([]);
-      setIsOpen(false);
-      return;
-    }
+    useImperativeHandle(ref, () => ({
+      focus: () => inputRef.current?.focus(),
+    }));
 
-    debounceRef.current = setTimeout(async () => {
-      setIsLoading(true);
+    // Animated placeholder cycling
+    useEffect(() => {
+      const interval = setInterval(() => {
+        setPlaceholderVisible(false);
+        setTimeout(() => {
+          setPlaceholderIndex((prev) => (prev + 1) % PLACEHOLDER_CITIES.length);
+          setPlaceholderVisible(true);
+        }, 200);
+      }, 3000);
+      return () => clearInterval(interval);
+    }, []);
+
+    useEffect(() => {
+      const handler = (e: MouseEvent) => {
+        if (
+          containerRef.current &&
+          !containerRef.current.contains(e.target as Node)
+        ) {
+          setIsOpen(false);
+        }
+      };
+      document.addEventListener("mousedown", handler);
+      return () => document.removeEventListener("mousedown", handler);
+    }, []);
+
+    const search = useCallback(
+      (q: string) => {
+        setQuery(q);
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+
+        if (q.trim().length < 2) {
+          setResults([]);
+          setIsOpen(false);
+          return;
+        }
+
+        debounceRef.current = setTimeout(async () => {
+          setIsLoading(true);
+          try {
+            const res = await fetch(
+              `/api/geocode?q=${encodeURIComponent(q)}`
+            );
+            const data = await res.json();
+            setResults(data.features || []);
+            setIsOpen(true);
+          } catch {
+            setResults([]);
+          } finally {
+            setIsLoading(false);
+          }
+        }, 300);
+      },
+      []
+    );
+
+    const selectResult = async (result: GeoResult) => {
+      let nameZh: string | undefined;
       try {
+        const name = result.text || result.place_name;
         const res = await fetch(
-          `/api/geocode?q=${encodeURIComponent(q)}`
+          `/api/geocode?q=${encodeURIComponent(name)}&language=zh`
         );
         const data = await res.json();
-        setResults(data.features || []);
-        setIsOpen(true);
+        nameZh =
+          data.features?.[0]?.text ||
+          data.features?.[0]?.place_name ||
+          undefined;
       } catch {
-        setResults([]);
-      } finally {
-        setIsLoading(false);
+        // Non-critical, proceed without Chinese name
       }
-    }, 300);
-  };
+      addLocation({
+        name: result.text || result.place_name,
+        nameZh,
+        coordinates: result.center,
+      });
+      if (map) {
+        map.flyTo({ center: result.center, zoom: 6 });
+      }
+      setQuery("");
+      setResults([]);
+      setIsOpen(false);
+    };
 
-  const selectResult = async (result: GeoResult) => {
-    // Forward geocode English name → Chinese (more reliable than reverse geocode)
-    let nameZh: string | undefined;
-    try {
-      const name = result.text || result.place_name;
-      const res = await fetch(`/api/geocode?q=${encodeURIComponent(name)}&language=zh`);
-      const data = await res.json();
-      nameZh = data.features?.[0]?.text || data.features?.[0]?.place_name || undefined;
-    } catch {
-      // Non-critical, proceed without Chinese name
-    }
-    addLocation({
-      name: result.text || result.place_name,
-      nameZh,
-      coordinates: result.center,
-    });
-    if (map) {
-      map.flyTo({ center: result.center, zoom: 6 });
-    }
-    setQuery("");
-    setResults([]);
-    setIsOpen(false);
-  };
-
-  return (
-    <div ref={containerRef} className="relative p-3">
-      <div className="relative">
-        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Search city..."
-          value={query}
-          onChange={(e) => search(e.target.value)}
-          className="pl-9"
-        />
-      </div>
-      {hintMessage && onHintDismiss && (
-        <OnboardingHint
-          message={hintMessage}
-          onDismiss={onHintDismiss}
-          className="left-3 right-3 top-[calc(100%+0.25rem)] max-w-none"
-          arrowClassName="left-6 -top-[7px] border-b-0 border-r-0"
-        />
-      )}
-      {isOpen && results.length > 0 && (
-        <div className="absolute left-3 right-3 top-14 z-50 rounded-md border bg-popover shadow-lg">
-          {results.map((r) => (
-            <button
-              key={r.id}
-              className="w-full px-3 py-2 text-left text-sm hover:bg-accent truncate"
-              onClick={() => selectResult(r)}
-            >
-              {r.place_name}
-            </button>
-          ))}
+    return (
+      <div ref={containerRef} className="relative p-3">
+        <div className="relative">
+          <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+          <Input
+            ref={inputRef}
+            placeholder={PLACEHOLDER_CITIES[placeholderIndex]}
+            value={query}
+            onChange={(e) => search(e.target.value)}
+            className={[
+              "pl-9 h-11 text-base transition-opacity duration-200",
+              !query && !placeholderVisible ? "placeholder:opacity-0" : "placeholder:opacity-100",
+            ].join(" ")}
+          />
         </div>
-      )}
-      {isLoading && (
-        <p className="mt-1 text-xs text-muted-foreground px-1">Searching...</p>
-      )}
-    </div>
-  );
-}
+        {hintMessage && onHintDismiss && (
+          <OnboardingHint
+            message={hintMessage}
+            onDismiss={onHintDismiss}
+            className="left-3 right-3 top-[calc(100%+0.25rem)] max-w-none"
+            arrowClassName="left-6 -top-[7px] border-b-0 border-r-0"
+          />
+        )}
+        {isOpen && results.length > 0 && (
+          <div className="absolute left-3 right-3 top-[60px] z-50 rounded-xl border bg-popover shadow-lg">
+            {results.map((r) => (
+              <button
+                key={r.id}
+                className="w-full px-3 py-2 text-left text-sm hover:bg-accent truncate first:rounded-t-xl last:rounded-b-xl"
+                onClick={() => selectResult(r)}
+              >
+                {r.place_name}
+              </button>
+            ))}
+          </div>
+        )}
+        {isLoading && (
+          <p className="mt-1 text-xs text-muted-foreground px-1">
+            Searching...
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+export default CitySearch;

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { MapProvider, useMap } from "./MapContext";
 import TopToolbar from "./TopToolbar";
@@ -11,6 +11,8 @@ import PlaybackControls from "./PlaybackControls";
 import PhotoOverlay from "./PhotoOverlay";
 import PhotoLayoutEditor from "./PhotoLayoutEditor";
 import ExportDialog from "./ExportDialog";
+import MapEmptyState from "./MapEmptyState";
+import type { CitySearchHandle } from "./CitySearch";
 import {
   SEGMENT_LAYER_PREFIX,
   SEGMENT_GLOW_LAYER_PREFIX,
@@ -127,6 +129,8 @@ function EditorContent() {
   const visiblePhotos = useAnimationStore((s) => s.visiblePhotos);
   const showPhotoOverlay = useAnimationStore((s) => s.showPhotoOverlay);
   const photoOverlayOpacity = useAnimationStore((s) => s.photoOverlayOpacity);
+
+  const searchRef = useRef<CitySearchHandle>(null);
 
   const [editingLocationId, setEditingLocationId] = useState<string | null>(
     null,
@@ -533,8 +537,16 @@ function EditorContent() {
     }
   }, [searchHintMessage, setBottomSheetExpanded]);
 
+  const handleFocusSearch = useCallback(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  const handleLoadDemo = useCallback(() => {
+    window.location.href = "?demo=true";
+  }, []);
+
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-screen flex-col bg-[#FAFAFA]">
       <TopToolbar />
       <div className="flex flex-1 overflow-hidden">
         <LeftPanel
@@ -542,10 +554,18 @@ function EditorContent() {
           onEditLayout={handleEditLayout}
           searchHintMessage={searchHintMessage}
           onDismissSearchHint={handleSearchHintDismiss}
+          searchRef={searchRef}
         />
         {/* Map area: full width on mobile, flex-1 on desktop */}
         <div className="flex-1 relative">
           <MapCanvas />
+          {/* Empty state overlay */}
+          {locations.length === 0 && (
+            <MapEmptyState
+              onSearchClick={handleFocusSearch}
+              onLoadDemo={handleLoadDemo}
+            />
+          )}
           {/* City label overlay */}
           <AnimatePresence>
             {currentCityLabel && (

--- a/src/components/editor/LeftPanel.tsx
+++ b/src/components/editor/LeftPanel.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { useRef } from "react";
-import { Upload, Save } from "lucide-react";
+import type { RefObject } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Button } from "@/components/ui/button";
-import { useProjectStore, type ImportRouteData } from "@/stores/projectStore";
 import { useUIStore } from "@/stores/uiStore";
-import CitySearch from "./CitySearch";
+import CitySearch, { type CitySearchHandle } from "./CitySearch";
 import RouteList from "./RouteList";
 
 interface LeftPanelProps {
@@ -14,6 +11,7 @@ interface LeftPanelProps {
   onEditLayout?: (locationId: string) => void;
   searchHintMessage?: string;
   onDismissSearchHint?: () => void;
+  searchRef?: RefObject<CitySearchHandle | null>;
 }
 
 export default function LeftPanel({
@@ -21,86 +19,19 @@ export default function LeftPanel({
   onEditLayout,
   searchHintMessage,
   onDismissSearchHint,
+  searchRef,
 }: LeftPanelProps) {
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const loadRouteData = useProjectStore((s) => s.loadRouteData);
-  const enrichChineseNames = useProjectStore((s) => s.enrichChineseNames);
-  const exportRoute = useProjectStore((s) => s.exportRoute);
-
-  const handleExportRoute = async () => {
-    const data = await exportRoute();
-    const blob = new Blob([JSON.stringify(data, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "trace-recap-route.json";
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    try {
-      const text = await file.text();
-      const data: ImportRouteData = JSON.parse(text);
-      await loadRouteData(data);
-      void enrichChineseNames();
-    } catch {
-      // Invalid JSON or file read error
-    }
-
-    // Reset input so same file can be re-imported
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  };
-
   const leftPanelOpen = useUIStore((s) => s.leftPanelOpen);
 
   if (!leftPanelOpen) return null;
 
   return (
-    <div className="hidden md:flex h-full w-80 flex-col overflow-hidden border-r bg-background">
-      <div className="border-b px-3 py-2">
-        <h2 className="text-sm font-semibold">Route</h2>
-      </div>
+    <div className="hidden md:flex h-full w-[360px] flex-col overflow-hidden border-r bg-background">
       <CitySearch
+        ref={searchRef}
         hintMessage={searchHintMessage}
         onHintDismiss={onDismissSearchHint}
       />
-      <div className="px-3 py-2">
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="flex-1"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <Upload className="mr-2 h-4 w-4" />
-            Import
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="flex-1"
-            onClick={handleExportRoute}
-          >
-            <Save className="mr-2 h-4 w-4" />
-            Save Route
-          </Button>
-        </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json"
-          className="hidden"
-          onChange={handleImport}
-        />
-      </div>
       <ScrollArea className="flex-1 min-h-0">
         <RouteList
           onLocationClick={onLocationClick}

--- a/src/components/editor/LocationCard.tsx
+++ b/src/components/editor/LocationCard.tsx
@@ -118,7 +118,7 @@ export default function LocationCard({
       ref={setNodeRef}
       style={style}
       {...dropProps}
-      className={`rounded-lg border bg-card p-3 shadow-sm space-y-2 ${
+      className={`rounded-xl border bg-card p-3 md:p-4 shadow-sm space-y-2 ${
         isWaypoint ? "opacity-60" : ""
       } ${isDragging ? "shadow-lg" : ""} ${
         isDragOver ? "ring-2 ring-primary ring-offset-1 bg-primary/5" : ""

--- a/src/components/editor/MapEmptyState.tsx
+++ b/src/components/editor/MapEmptyState.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { MapPin } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface MapEmptyStateProps {
+  onSearchClick: () => void;
+  onLoadDemo: () => void;
+}
+
+export default function MapEmptyState({
+  onSearchClick,
+  onLoadDemo,
+}: MapEmptyStateProps) {
+  return (
+    <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
+      <div className="bg-background/80 backdrop-blur-sm rounded-2xl border shadow-lg p-8 max-w-sm w-full mx-4 flex flex-col items-center gap-4 pointer-events-auto">
+        <MapPin className="h-12 w-12 text-muted-foreground/50" />
+        <p className="text-base font-medium text-muted-foreground text-center">
+          Start by searching for a city
+        </p>
+        <div className="flex gap-3 w-full">
+          <Button
+            variant="outline"
+            className="flex-1 rounded-lg"
+            onClick={onSearchClick}
+          >
+            Search a city
+          </Button>
+          <Button
+            className="flex-1 rounded-lg"
+            onClick={onLoadDemo}
+          >
+            Load Demo
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -47,7 +47,7 @@ export default function PlaybackControls({
         "fixed left-0 right-0 z-[60] rounded-none transition-[bottom] duration-300 ease-out",
         bottomSheetExpanded ? "bottom-[60vh]" : "bottom-14",
         // Desktop: override to absolute, centered floating pill
-        "md:absolute md:z-10 md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:right-auto md:rounded-xl md:w-auto",
+        "md:absolute md:z-10 md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:right-auto md:rounded-2xl md:w-auto",
       ].join(" ")}
     >
       <Button

--- a/src/components/editor/RouteList.tsx
+++ b/src/components/editor/RouteList.tsx
@@ -74,7 +74,7 @@ export default function RouteList({ onLocationClick, onEditLayout }: RouteListPr
         items={locations.map((l) => l.id)}
         strategy={verticalListSortingStrategy}
       >
-        <div className="flex flex-col gap-1 p-3">
+        <div className="flex flex-col gap-4 p-3">
           {locations.map((loc, i) => (
             <div key={loc.id}>
               <LocationCard

--- a/src/components/editor/TopToolbar.tsx
+++ b/src/components/editor/TopToolbar.tsx
@@ -11,6 +11,8 @@ import {
   Trash2,
   Undo2,
   Redo2,
+  MoreVertical,
+  Map,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,10 +24,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import MapStyleSelector from "./MapStyleSelector";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuTrigger,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+} from "@/components/ui/dropdown-menu";
 import { useUIStore } from "@/stores/uiStore";
 import { useProjectStore, type ImportRouteData } from "@/stores/projectStore";
 import { useHistoryStore } from "@/stores/historyStore";
+import type { MapStyle } from "@/types";
 
 export default function TopToolbar() {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -37,6 +51,8 @@ export default function TopToolbar() {
   const loadRouteData = useProjectStore((s) => s.loadRouteData);
   const enrichChineseNames = useProjectStore((s) => s.enrichChineseNames);
   const clearRoute = useProjectStore((s) => s.clearRoute);
+  const mapStyle = useProjectStore((s) => s.mapStyle);
+  const setMapStyle = useProjectStore((s) => s.setMapStyle);
   const undo = useHistoryStore((s) => s.undo);
   const redo = useHistoryStore((s) => s.redo);
   const canUndo = useHistoryStore((s) => s.canUndo);
@@ -71,7 +87,8 @@ export default function TopToolbar() {
 
   return (
     <>
-      <div className="flex h-10 md:h-12 items-center justify-between border-b bg-background px-3 md:px-4">
+      <div className="flex h-12 items-center justify-between border-b bg-background px-3 md:px-4">
+        {/* Left: panel toggle + logo */}
         <div className="flex items-center gap-2">
           <Button
             variant="ghost"
@@ -93,6 +110,8 @@ export default function TopToolbar() {
             TraceRecap
           </Link>
         </div>
+
+        {/* Right: undo/redo + more menu */}
         <div className="flex items-center gap-1.5 md:gap-2">
           <Button
             variant="ghost"
@@ -114,17 +133,69 @@ export default function TopToolbar() {
           >
             <Redo2 className="h-4 w-4" />
           </Button>
-          <MapStyleSelector />
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
-            onClick={() => fileInputRef.current?.click()}
-            aria-label="Import route"
-          >
-            <Upload className="h-3.5 w-3.5" />
-            <span className="hidden md:inline">Import</span>
-          </Button>
+
+          {/* More menu */}
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  aria-label="More options"
+                >
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end" sideOffset={4}>
+              <DropdownMenuItem onClick={() => fileInputRef.current?.click()}>
+                <Upload className="h-4 w-4" />
+                Import Route
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleExportRoute}>
+                <Save className="h-4 w-4" />
+                Save Route
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <Map className="h-4 w-4" />
+                  Map Style
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  <DropdownMenuRadioGroup
+                    value={mapStyle}
+                    onValueChange={(v) => setMapStyle(v as MapStyle)}
+                  >
+                    <DropdownMenuRadioItem value="light">
+                      Light
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="dark">
+                      Dark
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="satellite">
+                      Satellite
+                    </DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => setExportDialogOpen(true)}>
+                <Download className="h-4 w-4" />
+                Export Video
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={() => setClearDialogOpen(true)}
+              >
+                <Trash2 className="h-4 w-4" />
+                Clear Route
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
           <input
             ref={fileInputRef}
             type="file"
@@ -132,36 +203,6 @@ export default function TopToolbar() {
             className="hidden"
             onChange={handleImport}
           />
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
-            onClick={handleExportRoute}
-            aria-label="Export route"
-          >
-            <Save className="h-3.5 w-3.5" />
-            <span className="hidden md:inline">Save Route</span>
-          </Button>
-          <Button
-            variant="destructive"
-            size="sm"
-            className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
-            onClick={() => setClearDialogOpen(true)}
-            aria-label="Clear route"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            <span className="hidden md:inline">Clear Route</span>
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className="gap-1 md:gap-1.5 h-11 md:h-8 text-xs"
-            onClick={() => setExportDialogOpen(true)}
-            aria-label="Export video"
-          >
-            <Download className="h-3.5 w-3.5" />
-            <span className="hidden md:inline">Export</span>
-          </Button>
         </div>
       </div>
       <Dialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>


### PR DESCRIPTION
## Summary
- **TopToolbar overhaul**: Removed inline Import, Save, Clear, Map Style, and Export buttons. Kept Logo (left), Undo/Redo (center-right), and new ⋮ More dropdown (far right) with all actions organized inside using shadcn DropdownMenu. Toolbar height standardized to h-12.
- **LeftPanel simplification**: Removed Import/Save Route buttons and 'Route' header. Now shows CitySearch → RouteList only. Width widened from 320px to 360px.
- **Map empty state**: When 0 locations, shows a centered overlay with map pin icon, "Start by searching for a city" text, and two buttons: "Search a city" (focuses search input) and "Load Demo" (navigates to ?demo=true). Styled with bg-background/80 backdrop-blur-sm rounded-2xl.
- **CitySearch enhancement**: Input made taller (h-11/44px) with text-base. Animated placeholder cycles through "Search Tokyo...", "Search Paris...", "Search New York...", "Search Sydney..." every 3 seconds with fade transition.
- **Consistent styling**: Cards → rounded-xl, buttons → rounded-lg, PlaybackControls → rounded-2xl, component spacing → gap-4, card padding → p-3 mobile / p-4 desktop, page background → bg-[#FAFAFA].

## Test plan
- [ ] Verify toolbar shows only Logo, Undo/Redo, and ⋮ More menu
- [ ] Verify More dropdown contains Import, Save, Clear (destructive), Map Style submenu, Export Video
- [ ] Verify Map Style submenu shows Light/Dark/Satellite radio items
- [ ] Verify LeftPanel has no Import/Save buttons or Route header
- [ ] Verify LeftPanel width is 360px
- [ ] Verify empty state overlay appears on map with 0 locations
- [ ] Verify "Search a city" button focuses the search input
- [ ] Verify "Load Demo" button loads demo project
- [ ] Verify search placeholder animates through city names every 3 seconds
- [ ] Verify rounded corners: cards (xl), playback bar (2xl), buttons (lg)
- [ ] Verify page background is #FAFAFA
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)
- [ ] Verify build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)