### PR TITLE
feat: UI phase 2 — Kimi-inspired design improvements

### DIFF
--- a/docs/specs/ui-phase2-kimi-spec.md
+++ b/docs/specs/ui-phase2-kimi-spec.md
@@ -1,0 +1,63 @@
+# UI Redesign Phase 2 — Absorbing Kimi's Design Excellence
+
+## What Kimi Did Better (Must Adopt)
+
+### 1. CityCard — Expand/Collapse Pattern ⭐⭐⭐
+Kimi's card has a clean collapsed state (drag handle + number + name + 3 photo thumbnails + chevron + delete) and a detailed expanded state (waypoint toggle, photo management). This is MUCH better than our current "everything visible always" approach.
+
+**Adopt**: 
+- Default collapsed: show drag handle, number badge, English name + Chinese name on same line, up to 3 photo thumbnails (8x8 rounded squares), chevron toggle, delete button
+- Click to expand: show waypoint toggle (custom switch, not emoji button), photo upload area with grid, name editing
+- Use `AnimatePresence` + `motion.div` for smooth expand/collapse with `height: auto`
+- Delete button: ghost style, hover turns red with red background `hover:text-red-500 hover:bg-red-50`
+
+### 2. PlaybackControls — Large Circular Play Button ⭐⭐⭐
+Kimi's play button is a 48px indigo circle with shadow (`shadow-lg shadow-indigo-500/25`), hover scale effect. Way more prominent than our current ghost button.
+
+**Adopt**:
+- Play/Pause: `w-12 h-12 rounded-full bg-indigo-500 hover:bg-indigo-600 text-white shadow-lg shadow-indigo-500/25 hover:scale-105 active:scale-95`
+- Reset stays as ghost icon button
+- Controls bar: `bg-white/90 backdrop-blur-xl rounded-2xl shadow-xl border border-white/50`
+- Add segment info label above controls when playing: `"Taipei → Taichung"` in a small pill
+
+### 3. ExportDialog — Two-Step with Progress Ring ⭐⭐⭐
+Kimi's export dialog is gorgeous:
+- Aspect ratio as two big clickable cards (Monitor icon / Smartphone icon) with selected highlight border
+- "Quick Export (720p)" as primary CTA, full width, `h-12`
+- Advanced settings hidden behind a collapsible section
+- Export progress as SVG circular ring with percentage in center
+- Completion state: big green checkmark circle + file size + download button
+
+**Adopt all of this.**
+
+### 4. SearchBox — Focus Ring + Result Cards ⭐⭐
+- Focus state: `border-indigo-500 ring-2 ring-indigo-500/10 bg-white` (currently we don't have this)
+- Result items have a MapPin icon in indigo-50 circle + city name + Chinese name + country
+- Empty search state: centered MapPin icon + "No cities found"
+
+**Adopt**: Enhanced focus ring, richer search result items with icon, better empty state
+
+### 5. Map Empty State — Larger, More Premium ⭐⭐
+Kimi uses a `w-20 h-20 rounded-2xl bg-white shadow-xl` container for the icon — much more premium than a plain icon. Buttons are properly styled primary/outline pair.
+
+**Adopt**: Larger icon container with shadow, better button styling
+
+### 6. TransportSelector — Distance Divider Lines ⭐
+Kimi shows distance with horizontal line dividers: `─── 2,100 km ───`
+Nice subtle touch.
+
+**Adopt**: Add horizontal divider lines around the distance text
+
+### 7. Map Loading Skeleton ⭐
+Kimi shows a pulse gradient animation while the map loads instead of blank white.
+
+**Adopt**: `animate-pulse bg-gradient-to-br from-gray-100 to-gray-200`
+
+## What To Keep From Our Current Design
+- Our actual animation engine and Mapbox integration (Kimi's is mock)
+- Our drag-and-drop with dnd-kit (Kimi's is mock)
+- Our photo upload with data URLs (Kimi still uses URL input)
+- Our localStorage persistence
+- Our undo/redo system
+- Our onboarding hints system
+- Our existing TopToolbar More menu (Phase 1 already done)

--- a/src/components/editor/CitySearch.tsx
+++ b/src/components/editor/CitySearch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
-import { Search } from "lucide-react";
+import { Search, MapPin } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useProjectStore } from "@/stores/projectStore";
 import { useMap } from "./MapContext";
@@ -29,6 +29,13 @@ const PLACEHOLDER_CITIES = [
   "Search New York...",
   "Search Sydney...",
 ];
+
+function splitPlaceName(placeName: string): { city: string; region: string } {
+  const parts = placeName.split(",");
+  const city = parts[0]?.trim() ?? placeName;
+  const region = parts.slice(1).join(",").trim();
+  return { city, region };
+}
 
 const CitySearch = forwardRef<CitySearchHandle, CitySearchProps>(
   function CitySearch({ hintMessage, onHintDismiss }, ref) {
@@ -141,7 +148,8 @@ const CitySearch = forwardRef<CitySearchHandle, CitySearchProps>(
             value={query}
             onChange={(e) => search(e.target.value)}
             className={[
-              "pl-9 h-11 text-base transition-opacity duration-200",
+              "pl-9 h-11 text-base transition-all duration-200",
+              "focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/10",
               !query && !placeholderVisible ? "placeholder:opacity-0" : "placeholder:opacity-100",
             ].join(" ")}
           />
@@ -155,16 +163,33 @@ const CitySearch = forwardRef<CitySearchHandle, CitySearchProps>(
           />
         )}
         {isOpen && results.length > 0 && (
-          <div className="absolute left-3 right-3 top-[60px] z-50 rounded-xl border bg-popover shadow-lg">
-            {results.map((r) => (
-              <button
-                key={r.id}
-                className="w-full px-3 py-2 text-left text-sm hover:bg-accent truncate first:rounded-t-xl last:rounded-b-xl"
-                onClick={() => selectResult(r)}
-              >
-                {r.place_name}
-              </button>
-            ))}
+          <div className="absolute left-3 right-3 top-[60px] z-50 rounded-xl border bg-popover shadow-lg overflow-hidden">
+            {results.map((r) => {
+              const { city, region } = splitPlaceName(r.place_name);
+              return (
+                <button
+                  key={r.id}
+                  className="w-full px-3 py-2.5 text-left hover:bg-accent flex items-center gap-2.5 first:rounded-t-xl last:rounded-b-xl"
+                  onClick={() => selectResult(r)}
+                >
+                  <div className="w-7 h-7 rounded-full bg-indigo-50 flex items-center justify-center shrink-0">
+                    <MapPin className="h-3.5 w-3.5 text-indigo-500" />
+                  </div>
+                  <div className="min-w-0">
+                    <span className="text-sm font-medium block truncate">{city}</span>
+                    {region && (
+                      <span className="text-xs text-muted-foreground block truncate">{region}</span>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
+        {isOpen && !isLoading && results.length === 0 && query.trim().length >= 2 && (
+          <div className="absolute left-3 right-3 top-[60px] z-50 rounded-xl border bg-popover shadow-lg p-6 flex flex-col items-center gap-2">
+            <MapPin className="h-8 w-8 text-muted-foreground/40" />
+            <p className="text-sm text-muted-foreground">No cities found</p>
           </div>
         )}
         {isLoading && (

--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { Download, X, Loader2, AlertTriangle } from "lucide-react";
+import {
+  Download,
+  X,
+  AlertTriangle,
+  Monitor,
+  Smartphone,
+  Check,
+  ChevronDown,
+} from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,13 +18,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { useMap } from "./MapContext";
 import { useProjectStore } from "@/stores/projectStore";
@@ -24,6 +26,42 @@ import { AnimationEngine } from "@/engine/AnimationEngine";
 import { VideoExporter, type ExportProgress } from "@/engine/VideoExporter";
 import type { AspectRatio, ExportSettings } from "@/types";
 import { FPS } from "@/lib/constants";
+
+function CircularProgress({ percent }: { percent: number }) {
+  const r = 45;
+  const circumference = 2 * Math.PI * r;
+  const offset = circumference - (percent / 100) * circumference;
+
+  return (
+    <div className="relative w-32 h-32 mx-auto">
+      <svg viewBox="0 0 100 100" className="w-full h-full -rotate-90">
+        <circle
+          cx="50"
+          cy="50"
+          r={r}
+          fill="none"
+          stroke="#e5e7eb"
+          strokeWidth="6"
+        />
+        <circle
+          cx="50"
+          cy="50"
+          r={r}
+          fill="none"
+          stroke="#6366f1"
+          strokeWidth="6"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          className="transition-all duration-300"
+        />
+      </svg>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="text-2xl font-bold text-gray-900">{percent}%</span>
+      </div>
+    </div>
+  );
+}
 
 export default function ExportDialog() {
   const open = useUIStore((s) => s.exportDialogOpen);
@@ -39,10 +77,12 @@ export default function ExportDialog() {
   const aspectRatio = useUIStore((s) => s.exportAspectRatio) as AspectRatio;
   const setAspectRatio = useUIStore((s) => s.setExportAspectRatio);
   const [resolution, setResolution] = useState("720");
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const [isExporting, setIsExporting] = useState(false);
   const [progress, setProgress] = useState<ExportProgress | null>(null);
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+  const [downloadSize, setDownloadSize] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
   const exporterRef = useRef<VideoExporter | null>(null);
 
@@ -51,6 +91,7 @@ export default function ExportDialog() {
 
     setIsExporting(true);
     setDownloadUrl(null);
+    setDownloadSize(null);
     setProgress(null);
     setExportError(null);
 
@@ -72,9 +113,10 @@ export default function ExportDialog() {
       if (blob) {
         const url = URL.createObjectURL(blob);
         setDownloadUrl(url);
+        const sizeMB = (blob.size / (1024 * 1024)).toFixed(1);
+        setDownloadSize(`${sizeMB} MB`);
       }
     } catch (error) {
-      // Don't show error when user cancelled
       if (error instanceof DOMException && error.name === "AbortError") {
         setProgress(null);
         return;
@@ -90,7 +132,7 @@ export default function ExportDialog() {
       setIsExporting(false);
       exporterRef.current = null;
     }
-  }, [map, locations, segments, aspectRatio, resolution]);
+  }, [map, locations, segments, aspectRatio, resolution, cityLabelSize, cityLabelLang]);
 
   const handleCancel = () => {
     exporterRef.current?.cancel();
@@ -102,6 +144,7 @@ export default function ExportDialog() {
     if (isExporting) return;
     if (downloadUrl) URL.revokeObjectURL(downloadUrl);
     setDownloadUrl(null);
+    setDownloadSize(null);
     setProgress(null);
     setExportError(null);
     setOpen(newOpen);
@@ -125,6 +168,68 @@ export default function ExportDialog() {
     }
   };
 
+  // Completion state
+  if (downloadUrl) {
+    return (
+      <Dialog open={open} onOpenChange={handleClose}>
+        <DialogContent className="sm:max-w-md">
+          <div className="flex flex-col items-center py-6 space-y-4">
+            <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center">
+              <Check className="h-8 w-8 text-green-600" />
+            </div>
+            <div className="text-center">
+              <h3 className="text-lg font-semibold">Export Complete!</h3>
+              {downloadSize && (
+                <p className="text-sm text-muted-foreground mt-1">
+                  File size: {downloadSize}
+                </p>
+              )}
+            </div>
+            <div className="flex gap-2 w-full">
+              <a href={downloadUrl} download="trace-recap.mp4" className="flex-1">
+                <Button className="w-full bg-indigo-500 hover:bg-indigo-600">
+                  <Download className="h-4 w-4 mr-2" />
+                  Download MP4
+                </Button>
+              </a>
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => handleClose(false)}
+              >
+                Close
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // Exporting state with circular progress
+  if (isExporting && progress) {
+    return (
+      <Dialog open={open} onOpenChange={handleClose}>
+        <DialogContent className="sm:max-w-md">
+          <div className="flex flex-col items-center py-6 space-y-4">
+            <CircularProgress percent={progressPercent} />
+            <p className="text-sm text-muted-foreground">
+              {phaseLabel(progress.phase)}
+            </p>
+            <Button
+              variant="destructive"
+              className="w-full"
+              onClick={handleCancel}
+            >
+              <X className="h-4 w-4 mr-2" />
+              Cancel
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="sm:max-w-md">
@@ -133,73 +238,143 @@ export default function ExportDialog() {
         </DialogHeader>
 
         <div className="space-y-4 py-2">
+          {/* Step 1: Aspect ratio cards */}
           <div className="space-y-2">
             <label className="text-sm font-medium">Aspect Ratio</label>
-            <Select
-              value={aspectRatio}
-              onValueChange={(v) => v && setAspectRatio(v as AspectRatio)}
-              disabled={isExporting}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="16:9">Landscape (16:9)</SelectItem>
-                <SelectItem value="9:16">Portrait (9:16)</SelectItem>
-              </SelectContent>
-            </Select>
+            <div className="grid grid-cols-2 gap-3">
+              <button
+                className={`relative flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-colors ${
+                  aspectRatio === "16:9"
+                    ? "border-indigo-500 bg-indigo-50"
+                    : "border-border hover:border-gray-300"
+                }`}
+                onClick={() => setAspectRatio("16:9")}
+              >
+                {aspectRatio === "16:9" && (
+                  <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-indigo-500 flex items-center justify-center">
+                    <Check className="h-3 w-3 text-white" />
+                  </div>
+                )}
+                <Monitor className="h-8 w-8 text-gray-600" />
+                <span className="text-sm font-medium">Landscape</span>
+                <span className="text-xs text-muted-foreground">16:9</span>
+              </button>
+              <button
+                className={`relative flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-colors ${
+                  aspectRatio === "9:16"
+                    ? "border-indigo-500 bg-indigo-50"
+                    : "border-border hover:border-gray-300"
+                }`}
+                onClick={() => setAspectRatio("9:16")}
+              >
+                {aspectRatio === "9:16" && (
+                  <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-indigo-500 flex items-center justify-center">
+                    <Check className="h-3 w-3 text-white" />
+                  </div>
+                )}
+                <Smartphone className="h-8 w-8 text-gray-600" />
+                <span className="text-sm font-medium">Portrait</span>
+                <span className="text-xs text-muted-foreground">9:16</span>
+              </button>
+            </div>
           </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Resolution</label>
-            <Select
-              value={resolution}
-              onValueChange={(v) => v && setResolution(v)}
-              disabled={isExporting}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="720">720p</SelectItem>
-                <SelectItem value="1080">1080p</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          {/* Quick Export button */}
+          <Button
+            className="w-full h-12 bg-indigo-500 hover:bg-indigo-600 text-base font-medium"
+            onClick={handleExport}
+            disabled={segments.length === 0}
+          >
+            Quick Export (720p)
+          </Button>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium">City Label Language</label>
-            <Select
-              value={cityLabelLang}
-              onValueChange={(v) => v && setCityLabelLang(v as "en" | "zh")}
-              disabled={isExporting}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="en">English</SelectItem>
-                <SelectItem value="zh">中文</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <label className="text-sm font-medium">
-              City Label Size: {cityLabelSize}px
-            </label>
-            <Slider
-              value={[cityLabelSize]}
-              min={12}
-              max={48}
-              step={1}
-              onValueChange={(v) => {
-                const val = Array.isArray(v) ? v[0] : v;
-                setCityLabelSize(val);
-              }}
-              disabled={isExporting}
+          {/* Advanced Settings toggle */}
+          <button
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors w-full justify-center"
+            onClick={() => setShowAdvanced((v) => !v)}
+          >
+            <span>Advanced Settings</span>
+            <ChevronDown
+              className={`h-4 w-4 transition-transform ${showAdvanced ? "rotate-180" : ""}`}
             />
-          </div>
+          </button>
+
+          {/* Advanced settings collapsible */}
+          <AnimatePresence initial={false}>
+            {showAdvanced && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="overflow-hidden"
+              >
+                <div className="space-y-4 pt-1">
+                  {/* Resolution pills */}
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Resolution</label>
+                    <div className="flex gap-2">
+                      {["720", "1080"].map((res) => (
+                        <button
+                          key={res}
+                          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                            resolution === res
+                              ? "bg-indigo-500 text-white"
+                              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                          }`}
+                          onClick={() => setResolution(res)}
+                        >
+                          {res}p
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* City Label pills */}
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">City Label</label>
+                    <div className="flex gap-2">
+                      {[
+                        { value: "en", label: "English" },
+                        { value: "zh", label: "中文" },
+                      ].map((opt) => (
+                        <button
+                          key={opt.value}
+                          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                            cityLabelLang === opt.value
+                              ? "bg-indigo-500 text-white"
+                              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                          }`}
+                          onClick={() =>
+                            setCityLabelLang(opt.value as "en" | "zh")
+                          }
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Label Size slider */}
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">
+                      Label Size: {cityLabelSize}px
+                    </label>
+                    <Slider
+                      value={[cityLabelSize]}
+                      min={12}
+                      max={48}
+                      step={1}
+                      onValueChange={(v) => {
+                        const val = Array.isArray(v) ? v[0] : v;
+                        setCityLabelSize(val);
+                      }}
+                    />
+                  </div>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           {exportError && (
             <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
@@ -207,58 +382,6 @@ export default function ExportDialog() {
               <span>{exportError}</span>
             </div>
           )}
-
-          {isExporting && progress && (
-            <div className="space-y-2">
-              <div className="flex justify-between text-sm">
-                <span className="text-muted-foreground">
-                  {phaseLabel(progress.phase)}
-                </span>
-                {progress.phase === "capturing" && (
-                  <span className="font-medium">{progressPercent}%</span>
-                )}
-              </div>
-              <div className="h-2 rounded-full bg-muted overflow-hidden">
-                <div
-                  className="h-full bg-primary transition-all duration-300"
-                  style={{ width: `${progressPercent}%` }}
-                />
-              </div>
-            </div>
-          )}
-
-          <div className="flex gap-2 pt-2">
-            {downloadUrl ? (
-              <a
-                href={downloadUrl}
-                download="trace-recap.mp4"
-                className="flex-1"
-              >
-                <Button className="w-full">
-                  <Download className="h-4 w-4 mr-2" />
-                  Download MP4
-                </Button>
-              </a>
-            ) : isExporting ? (
-              <Button
-                variant="destructive"
-                className="flex-1"
-                onClick={handleCancel}
-              >
-                <X className="h-4 w-4 mr-2" />
-                Cancel
-              </Button>
-            ) : (
-              <Button
-                className="flex-1"
-                onClick={handleExport}
-                disabled={segments.length === 0}
-              >
-                <Loader2 className="h-4 w-4 mr-2 animate-spin hidden" />
-                Start Export
-              </Button>
-            )}
-          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/editor/LocationCard.tsx
+++ b/src/components/editor/LocationCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { X, GripVertical, Pencil } from "lucide-react";
+import { X, GripVertical, ChevronRight, Pencil, LayoutGrid } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@/components/ui/button";
@@ -82,6 +83,30 @@ function EditableName({
   );
 }
 
+function WaypointSwitch({
+  isWaypoint,
+  onToggle,
+}: {
+  isWaypoint: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      onClick={onToggle}
+      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+        isWaypoint ? "bg-gray-300" : "bg-indigo-500"
+      }`}
+      title={isWaypoint ? "Switch to destination" : "Switch to stop by"}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform ${
+          isWaypoint ? "translate-x-1" : "translate-x-[18px]"
+        }`}
+      />
+    </button>
+  );
+}
+
 export default function LocationCard({
   location,
   index,
@@ -91,6 +116,7 @@ export default function LocationCard({
   onClick,
   onEditLayout,
 }: LocationCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
   const isFirst = index === 0;
   const isWaypoint = location.isWaypoint;
   const updateLocation = useProjectStore((s) => s.updateLocation);
@@ -113,76 +139,158 @@ export default function LocationCard({
     opacity: isDragging ? 0.5 : undefined,
   };
 
+  const photoThumbnails = location.photos.slice(0, 3);
+
   return (
     <div
       ref={setNodeRef}
       style={style}
       {...dropProps}
-      className={`rounded-xl border bg-card p-3 md:p-4 shadow-sm space-y-2 ${
+      className={`rounded-xl border bg-card shadow-sm ${
         isWaypoint ? "opacity-60" : ""
       } ${isDragging ? "shadow-lg" : ""} ${
         isDragOver ? "ring-2 ring-primary ring-offset-1 bg-primary/5" : ""
-      } ${onClick ? "cursor-pointer" : ""}`}
-      onClick={(e) => {
-        // Don't trigger if clicking on buttons, inputs, or editable name spans
-        const target = e.target as HTMLElement;
-        if (target.closest("button") || target.closest("input") || target.closest("[data-no-seek]") || target.closest("[contenteditable]")) return;
-        onClick?.(index);
-      }}
+      }`}
     >
-      <div className="flex items-center gap-2">
+      {/* Collapsed row */}
+      <div
+        className="flex items-center gap-2 p-3 md:p-3 cursor-pointer"
+        onClick={(e) => {
+          const target = e.target as HTMLElement;
+          if (
+            target.closest("[data-drag-handle]") ||
+            target.closest("[data-delete-btn]") ||
+            target.closest("[data-no-seek]") ||
+            target.closest("input")
+          )
+            return;
+          setIsExpanded((v) => !v);
+          onClick?.(index);
+        }}
+      >
+        {/* Drag handle */}
         <div
+          data-drag-handle
           className="flex items-center cursor-grab active:cursor-grabbing touch-none"
           {...attributes}
           {...listeners}
         >
           <GripVertical className="h-4 w-4 text-muted-foreground" />
         </div>
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+
+        {/* Number badge */}
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-indigo-500 text-xs font-semibold text-white">
           {index + 1}
         </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            <EditableName
-              value={location.name}
-              placeholder="English name"
-              onSave={(val) => updateLocation(location.id, { name: val })}
-              className="text-sm font-medium truncate"
-            />
-            {isWaypoint && (
-              <span className="text-[10px] text-muted-foreground whitespace-nowrap">
-                stop by
-              </span>
-            )}
-          </div>
-          <EditableName
-            value={location.nameZh ?? ""}
-            placeholder="中文名"
-            onSave={(val) => updateLocation(location.id, { nameZh: val || undefined })}
-            className="text-xs text-muted-foreground"
-          />
+
+        {/* Names on one line */}
+        <div className="flex-1 min-w-0 flex items-center gap-1.5 truncate">
+          <span className="text-sm font-medium truncate">
+            {location.name || <span className="text-muted-foreground italic">English name</span>}
+          </span>
+          {location.nameZh && (
+            <span className="text-xs text-muted-foreground truncate">
+              {location.nameZh}
+            </span>
+          )}
+          {isWaypoint && (
+            <span className="text-[10px] text-muted-foreground whitespace-nowrap">
+              stop by
+            </span>
+          )}
         </div>
-        {!isFirst && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7 shrink-0"
-            title={isWaypoint ? "Switch to destination" : "Switch to stop by"}
-            onClick={() => onToggleWaypoint(location.id)}
-          >
-            <span className="text-sm">{isWaypoint ? "\u2708\uFE0F" : "\uD83C\uDFE0"}</span>
-          </Button>
+
+        {/* Photo thumbnails (up to 3) */}
+        {photoThumbnails.length > 0 && (
+          <div className="flex gap-0.5 shrink-0">
+            {photoThumbnails.map((photo) => (
+              <img
+                key={photo.id}
+                src={photo.url}
+                alt=""
+                className="w-8 h-8 rounded-lg object-cover bg-muted"
+              />
+            ))}
+          </div>
         )}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 shrink-0"
-          onClick={() => onRemove(location.id)}
+
+        {/* Chevron */}
+        <ChevronRight
+          className={`h-4 w-4 text-muted-foreground shrink-0 transition-transform duration-200 ${
+            isExpanded ? "rotate-90" : ""
+          }`}
+        />
+
+        {/* Delete button */}
+        <button
+          data-delete-btn
+          className="h-7 w-7 shrink-0 flex items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-red-500 hover:bg-red-50"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove(location.id);
+          }}
         >
           <X className="h-4 w-4" />
-        </Button>
+        </button>
       </div>
-      <PhotoManager locationId={location.id} onEditLayout={onEditLayout} />
+
+      {/* Expanded content */}
+      <AnimatePresence initial={false}>
+        {isExpanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+            className="overflow-hidden"
+          >
+            <div className="px-3 pb-3 space-y-3 border-t pt-3">
+              {/* Editable names */}
+              <div className="space-y-1.5">
+                <EditableName
+                  value={location.name}
+                  placeholder="English name"
+                  onSave={(val) => updateLocation(location.id, { name: val })}
+                  className="text-sm font-medium"
+                />
+                <EditableName
+                  value={location.nameZh ?? ""}
+                  placeholder="中文名"
+                  onSave={(val) => updateLocation(location.id, { nameZh: val || undefined })}
+                  className="text-xs text-muted-foreground"
+                />
+              </div>
+
+              {/* Waypoint toggle as switch */}
+              {!isFirst && (
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-muted-foreground">Stop by (waypoint)</span>
+                  <WaypointSwitch
+                    isWaypoint={!!isWaypoint}
+                    onToggle={() => onToggleWaypoint(location.id)}
+                  />
+                </div>
+              )}
+
+              {/* Photo manager */}
+              <PhotoManager locationId={location.id} onEditLayout={onEditLayout} />
+
+              {/* Photo layout edit button */}
+              {location.photos.length > 0 && onEditLayout && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs gap-1 w-full"
+                  onClick={() => onEditLayout(location.id)}
+                >
+                  <LayoutGrid className="h-3 w-3" />
+                  Edit Photo Layout
+                </Button>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/editor/MapCanvas.tsx
+++ b/src/components/editor/MapCanvas.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useMap } from "./MapContext";
@@ -37,6 +38,7 @@ export default function MapCanvas() {
   const mapInstanceRef = useRef<mapboxgl.Map | null>(null);
   const markersRef = useRef<Map<string, mapboxgl.Marker>>(new Map());
   const segmentLayersRef = useRef<Set<string>>(new Set());
+  const [mapLoaded, setMapLoaded] = useState(false);
   const { setMap } = useMap();
   const addLocation = useProjectStore((s) => s.addLocation);
   const locations = useProjectStore((s) => s.locations);
@@ -60,6 +62,7 @@ export default function MapCanvas() {
     });
 
     map.addControl(new mapboxgl.NavigationControl(), "top-right");
+    map.once("style.load", () => setMapLoaded(true));
     mapInstanceRef.current = map;
     setMap(map);
 
@@ -419,5 +422,19 @@ export default function MapCanvas() {
     });
   }, [mapStyle]);
 
-  return <div ref={containerRef} className="w-full h-full" />;
+  return (
+    <div className="relative w-full h-full">
+      <div ref={containerRef} className="w-full h-full" />
+      <AnimatePresence>
+        {!mapLoaded && (
+          <motion.div
+            initial={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.4 }}
+            className="absolute inset-0 animate-pulse bg-gradient-to-br from-gray-100 to-gray-200"
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
 }

--- a/src/components/editor/MapEmptyState.tsx
+++ b/src/components/editor/MapEmptyState.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MapPin } from "lucide-react";
+import { MapPin, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface MapEmptyStateProps {
@@ -15,7 +15,9 @@ export default function MapEmptyState({
   return (
     <div className="absolute inset-0 z-10 flex items-center justify-center pointer-events-none">
       <div className="bg-background/80 backdrop-blur-sm rounded-2xl border shadow-lg p-8 max-w-sm w-full mx-4 flex flex-col items-center gap-4 pointer-events-auto">
-        <MapPin className="h-12 w-12 text-muted-foreground/50" />
+        <div className="w-20 h-20 rounded-2xl bg-white shadow-xl flex items-center justify-center">
+          <MapPin className="h-10 w-10 text-indigo-500" />
+        </div>
         <p className="text-base font-medium text-muted-foreground text-center">
           Start by searching for a city
         </p>
@@ -25,10 +27,11 @@ export default function MapEmptyState({
             className="flex-1 rounded-lg"
             onClick={onSearchClick}
           >
-            Search a city
+            <Search className="h-4 w-4 mr-1.5" />
+            Search
           </Button>
           <Button
-            className="flex-1 rounded-lg"
+            className="flex-1 rounded-lg bg-indigo-500 hover:bg-indigo-600"
             onClick={onLoadDemo}
           >
             Load Demo

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { Play, Pause, RotateCcw } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { useAnimationStore } from "@/stores/animationStore";
+import { useProjectStore } from "@/stores/projectStore";
 import { useUIStore } from "@/stores/uiStore";
 import OnboardingHint from "./OnboardingHint";
 
@@ -34,69 +36,101 @@ export default function PlaybackControls({
   const playbackState = useAnimationStore((s) => s.playbackState);
   const currentTime = useAnimationStore((s) => s.currentTime);
   const totalDuration = useAnimationStore((s) => s.totalDuration);
+  const currentSegmentIndex = useAnimationStore((s) => s.currentSegmentIndex);
   const bottomSheetExpanded = useUIStore((s) => s.bottomSheetExpanded);
+  const locations = useProjectStore((s) => s.locations);
+  const segments = useProjectStore((s) => s.segments);
 
   const progress = totalDuration > 0 ? (currentTime / totalDuration) * 100 : 0;
   const isPlaying = playbackState === "playing";
 
+  // Get current segment info for the pill
+  const currentSegment = segments[currentSegmentIndex];
+  const fromCity = currentSegment
+    ? locations.find((l) => l.id === currentSegment.fromId)?.name
+    : null;
+  const toCity = currentSegment
+    ? locations.find((l) => l.id === currentSegment.toId)?.name
+    : null;
+
   return (
     <div
       className={[
-        "flex items-center gap-2 md:gap-3 bg-background/90 backdrop-blur-sm border shadow-lg px-3 md:px-4 py-2",
-        // Mobile: fixed full-width bar, z above BottomSheet (z-50)
-        "fixed left-0 right-0 z-[60] rounded-none transition-[bottom] duration-300 ease-out",
+        "flex flex-col items-center",
+        // Mobile: fixed full-width, z above BottomSheet (z-50)
+        "fixed left-0 right-0 z-[60] transition-[bottom] duration-300 ease-out",
         bottomSheetExpanded ? "bottom-[60vh]" : "bottom-14",
         // Desktop: override to absolute, centered floating pill
-        "md:absolute md:z-10 md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:right-auto md:rounded-2xl md:w-auto",
+        "md:absolute md:z-10 md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:right-auto",
       ].join(" ")}
     >
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-11 w-11 md:h-8 md:w-8 min-w-[44px] md:min-w-0"
-        onClick={onReset}
-        aria-label="Reset playback"
+      {/* Segment info pill — shown when playing */}
+      <AnimatePresence>
+        {isPlaying && fromCity && toCity && (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            className="mb-2 bg-white/90 backdrop-blur-md rounded-full px-4 py-1.5 shadow-lg text-xs font-medium text-gray-700"
+          >
+            {fromCity} → {toCity}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Controls bar */}
+      <div
+        className={[
+          "flex items-center gap-2 md:gap-3 bg-white/90 backdrop-blur-xl border border-white/50 shadow-xl px-3 md:px-4 py-2",
+          "rounded-none md:rounded-2xl w-full md:w-auto",
+        ].join(" ")}
       >
-        <RotateCcw className="h-4 w-4" />
-      </Button>
-      <div className="relative">
         <Button
           variant="ghost"
           size="icon"
-          className="h-11 w-11 md:h-8 md:w-8 min-w-[44px] md:min-w-0"
-          onClick={isPlaying ? onPause : onPlay}
-          aria-label={isPlaying ? "Pause" : "Play"}
+          className="h-8 w-8 shrink-0"
+          onClick={onReset}
+          aria-label="Reset playback"
         >
-          {isPlaying ? (
-            <Pause className="h-4 w-4" />
-          ) : (
-            <Play className="h-4 w-4" />
-          )}
+          <RotateCcw className="h-4 w-4" />
         </Button>
-        {hintMessage && onHintDismiss && (
-          <OnboardingHint
-            message={hintMessage}
-            onDismiss={onHintDismiss}
-            className="bottom-[calc(100%+0.75rem)] left-1/2 w-56 -translate-x-1/2"
-            arrowClassName="left-1/2 -bottom-[7px] -translate-x-1/2 border-l-0 border-t-0"
+        <div className="relative">
+          <button
+            className="h-12 w-12 rounded-full bg-indigo-500 hover:bg-indigo-600 text-white shadow-lg shadow-indigo-500/25 transition-all hover:scale-105 active:scale-95 flex items-center justify-center"
+            onClick={isPlaying ? onPause : onPlay}
+            aria-label={isPlaying ? "Pause" : "Play"}
+          >
+            {isPlaying ? (
+              <Pause className="h-5 w-5" />
+            ) : (
+              <Play className="h-5 w-5 ml-0.5" />
+            )}
+          </button>
+          {hintMessage && onHintDismiss && (
+            <OnboardingHint
+              message={hintMessage}
+              onDismiss={onHintDismiss}
+              className="bottom-[calc(100%+0.75rem)] left-1/2 w-56 -translate-x-1/2"
+              arrowClassName="left-1/2 -bottom-[7px] -translate-x-1/2 border-l-0 border-t-0"
+            />
+          )}
+        </div>
+        <div className="flex-1 md:flex-none md:w-48">
+          <Slider
+            value={[progress]}
+            min={0}
+            max={100}
+            step={0.1}
+            onValueChange={(v) => {
+              const val = Array.isArray(v) ? v[0] : v;
+              onSeek(val / 100);
+            }}
           />
-        )}
+        </div>
+        <span className="text-xs text-muted-foreground min-w-[70px] text-right">
+          {formatTime(currentTime)} / {formatTime(totalDuration)}
+        </span>
       </div>
-      <div className="flex-1 md:flex-none md:w-48">
-        <Slider
-          value={[progress]}
-          min={0}
-          max={100}
-          step={0.1}
-          onValueChange={(v) => {
-            const val = Array.isArray(v) ? v[0] : v;
-            onSeek(val / 100);
-          }}
-        />
-      </div>
-      <span className="text-xs text-muted-foreground min-w-[70px] text-right">
-        {formatTime(currentTime)} / {formatTime(totalDuration)}
-      </span>
     </div>
   );
 }

--- a/src/components/editor/TransportSelector.tsx
+++ b/src/components/editor/TransportSelector.tsx
@@ -126,44 +126,50 @@ export default function TransportSelector({ segment }: TransportSelectorProps) {
   return (
     <div className="flex flex-col items-center py-1">
       {/* Vertical connecting line + pill */}
-      <div className="flex items-center gap-2">
-        <div className="w-px h-4 bg-border" />
+      <div className="flex items-center gap-2 w-full px-2">
         {expanded ? (
-          <div className="flex items-center gap-1 rounded-full border bg-card px-1.5 py-0.5 shadow-sm">
-            {TRANSPORT_MODES.map((mode) => {
-              const isActive = segment.transportMode === mode.id;
-              const Icon = MODE_ICONS[mode.id];
-              return (
-                <Tooltip key={mode.id}>
-                  <TooltipTrigger
-                    className={`flex h-7 w-7 items-center justify-center rounded-full transition-colors ${
-                      isActive
-                        ? MODE_COLORS[mode.id]
-                        : "text-muted-foreground hover:bg-accent"
-                    }`}
-                    onClick={() => handleModeChange(mode.id)}
-                  >
-                    <Icon className="h-3.5 w-3.5" />
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p>{mode.label}</p>
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
-          </div>
+          <>
+            <div className="w-px h-4 bg-border" />
+            <div className="flex items-center gap-1 rounded-full border bg-card px-1.5 py-0.5 shadow-sm">
+              {TRANSPORT_MODES.map((mode) => {
+                const isActive = segment.transportMode === mode.id;
+                const Icon = MODE_ICONS[mode.id];
+                return (
+                  <Tooltip key={mode.id}>
+                    <TooltipTrigger
+                      className={`flex h-7 w-7 items-center justify-center rounded-full transition-colors ${
+                        isActive
+                          ? MODE_COLORS[mode.id]
+                          : "text-muted-foreground hover:bg-accent"
+                      }`}
+                      onClick={() => handleModeChange(mode.id)}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p>{mode.label}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+            <div className="w-px h-4 bg-border" />
+          </>
         ) : (
-          <button
-            className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:shadow-sm ${activeColor}`}
-            onClick={() => setExpanded(true)}
-          >
-            <ActiveIcon className="h-3.5 w-3.5" />
-            {distance !== null && (
-              <span className="tabular-nums">{formatDistance(distance)}</span>
-            )}
-          </button>
+          <>
+            <div className="flex-1 h-px bg-border" />
+            <button
+              className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors hover:shadow-sm ${activeColor}`}
+              onClick={() => setExpanded(true)}
+            >
+              <ActiveIcon className="h-3.5 w-3.5" />
+              {distance !== null && (
+                <span className="tabular-nums">{formatDistance(distance)}</span>
+              )}
+            </button>
+            <div className="flex-1 h-px bg-border" />
+          </>
         )}
-        <div className="w-px h-4 bg-border" />
       </div>
 
       {/* Timing control — only for group-leading segments */}


### PR DESCRIPTION
## Summary
- **LocationCard**: Expand/collapse pattern with AnimatePresence — collapsed row shows drag handle, indigo number badge, names on one line, photo thumbnails, chevron, delete button; expanded shows editable names, waypoint switch, PhotoManager
- **PlaybackControls**: Large circular indigo play button (w-12 h-12, shadow, scale effects), glassmorphism controls bar, segment info pill above controls when playing
- **ExportDialog**: Two-step flow — aspect ratio as clickable cards with icons/checkmarks, Quick Export (720p) CTA, collapsible Advanced Settings (resolution/label pills, size slider), SVG circular progress ring, completion state with green checkmark
- **CitySearch**: Indigo focus ring on input, MapPin icon circles in results, city/region text split, empty search state
- **MapEmptyState**: Premium icon container (w-20 h-20 rounded-2xl shadow-xl), styled primary/outline buttons
- **TransportSelector**: Horizontal divider lines flanking the collapsed transport pill
- **MapCanvas**: Loading skeleton with animate-pulse gradient, AnimatePresence fade-out when map loads

## Test plan
- [ ] Verify LocationCard expand/collapse animation works, collapsed state is compact
- [ ] Verify play button is large indigo circle with hover/active effects
- [ ] Verify segment info pill appears above controls during playback
- [ ] Verify ExportDialog shows aspect ratio cards, quick export, advanced toggle
- [ ] Verify export progress shows circular ring with percentage
- [ ] Verify search input has indigo focus ring, results show MapPin + city/region split
- [ ] Verify empty search shows "No cities found" state
- [ ] Verify MapEmptyState has premium icon container
- [ ] Verify TransportSelector shows ——— pill ——— divider pattern
- [ ] Verify map shows loading skeleton before style loads
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)