### PR TITLE
feat: WebCodecs client-side export, fix export settings & photo layout preview

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
         "mapbox-gl": "^3.20.0",
+        "mp4-muxer": "^5.2.2",
         "next": "16.2.1",
         "playwright": "^1.58.2",
         "react": "19.2.4",
@@ -4466,6 +4467,12 @@
       "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
       "license": "MIT"
     },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz",
+      "integrity": "sha512-vAvE8C9DGWR+tkb19xyjk1TSUlJ7RUzzp4a9Anu7mwBT+fpyePWK1UxmH14tMO5zHmrnrRIMg5NutnnDztLxgg==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4588,6 +4595,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.8",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
+      "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -9444,6 +9457,17 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
+    },
+    "node_modules/mp4-muxer": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
+      "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.6",
+        "@types/wicg-file-system-access": "^2020.9.5"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "mapbox-gl": "^3.20.0",
+    "mp4-muxer": "^5.2.2",
     "next": "16.2.1",
     "playwright": "^1.58.2",
     "react": "19.2.4",

--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -84,6 +84,7 @@ export default function ExportDialog() {
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
   const [downloadSize, setDownloadSize] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [encodingMethod, setEncodingMethod] = useState<"webcodecs" | "server" | null>(null);
   const exporterRef = useRef<VideoExporter | null>(null);
 
   const handleExport = useCallback(async () => {
@@ -94,6 +95,7 @@ export default function ExportDialog() {
     setDownloadSize(null);
     setProgress(null);
     setExportError(null);
+    setEncodingMethod(null);
 
     const settings: ExportSettings = {
       aspectRatio,
@@ -107,8 +109,13 @@ export default function ExportDialog() {
     const exporter = new VideoExporter(engine, map, settings);
     exporterRef.current = exporter;
 
+    const handleProgress = (p: ExportProgress) => {
+      setProgress(p);
+      if (p.encodingMethod) setEncodingMethod(p.encodingMethod);
+    };
+
     try {
-      const blob = await exporter.export(setProgress);
+      const blob = await exporter.export(handleProgress);
 
       if (blob) {
         const url = URL.createObjectURL(blob);
@@ -200,6 +207,13 @@ export default function ExportDialog() {
                 Close
               </Button>
             </div>
+            {encodingMethod && (
+              <p className="text-xs text-muted-foreground text-center">
+                {encodingMethod === "webcodecs"
+                  ? "Encoded locally with WebCodecs"
+                  : "Encoded on server"}
+              </p>
+            )}
           </div>
         </DialogContent>
       </Dialog>

--- a/src/components/editor/PhotoLayoutEditor.tsx
+++ b/src/components/editor/PhotoLayoutEditor.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   X,
   LayoutGrid,
   LayoutTemplate,
   Image as ImageIcon,
   Images,
-  ChevronLeft,
-  ChevronRight,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useProjectStore } from "@/stores/projectStore";
+import { computeAutoLayout, computeTemplateLayout } from "@/lib/photoLayout";
 import type { Location, LayoutTemplate as LayoutTemplateType, PhotoLayout, Photo } from "@/types";
 
 interface PhotoLayoutEditorProps {
@@ -28,136 +27,65 @@ const LAYOUT_STYLES: { id: LayoutStyle; label: string; icon: typeof LayoutGrid; 
   { id: "carousel", label: "Carousel", icon: Images, template: "filmstrip" },
 ];
 
-/* ── Preview renderers for each layout style ── */
+/* ── Unified preview using actual layout functions ── */
 
-function GridPreview({ photos, borderRadius }: { photos: Photo[]; borderRadius: number }) {
-  const visible = photos.slice(0, 4);
-  return (
-    <div className="grid grid-cols-2 grid-rows-2 gap-2 w-full h-full p-3">
-      {visible.map((photo) => (
-        <div key={photo.id} className="relative overflow-hidden" style={{ borderRadius: `${borderRadius}px` }}>
-          <img
-            src={photo.url}
-            alt=""
-            className="w-full h-full object-cover"
-            style={{ objectPosition: `${(photo.focalPoint?.x ?? 0.5) * 100}% ${(photo.focalPoint?.y ?? 0.5) * 100}%` }}
-          />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function CollagePreview({ photos, borderRadius }: { photos: Photo[]; borderRadius: number }) {
-  const main = photos[0];
-  const others = photos.slice(1, 4);
-  if (!main) return null;
-  return (
-    <div className="relative w-full h-full p-3">
-      <div className="absolute inset-3 overflow-hidden" style={{ borderRadius: `${borderRadius}px` }}>
-        <img
-          src={main.url}
-          alt=""
-          className="w-full h-full object-cover"
-          style={{ objectPosition: `${(main.focalPoint?.x ?? 0.5) * 100}% ${(main.focalPoint?.y ?? 0.5) * 100}%` }}
-        />
-      </div>
-      {others.map((photo, i) => (
-        <div
-          key={photo.id}
-          className="absolute overflow-hidden shadow-lg border-2 border-white"
-          style={{
-            borderRadius: `${borderRadius}px`,
-            width: "35%",
-            height: "35%",
-            bottom: `${12 + i * 4}%`,
-            right: `${8 + i * 18}%`,
-          }}
-        >
-          <img
-            src={photo.url}
-            alt=""
-            className="w-full h-full object-cover"
-            style={{ objectPosition: `${(photo.focalPoint?.x ?? 0.5) * 100}% ${(photo.focalPoint?.y ?? 0.5) * 100}%` }}
-          />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function SinglePreview({ photos, borderRadius, selectedIndex }: { photos: Photo[]; borderRadius: number; selectedIndex: number }) {
-  const photo = photos[selectedIndex] ?? photos[0];
-  if (!photo) return null;
-  return (
-    <div className="flex items-center justify-center w-full h-full p-6">
-      <div className="w-3/4 h-3/4 overflow-hidden" style={{ borderRadius: `${borderRadius}px` }}>
-        <img
-          src={photo.url}
-          alt=""
-          className="w-full h-full object-cover"
-          style={{ objectPosition: `${(photo.focalPoint?.x ?? 0.5) * 100}% ${(photo.focalPoint?.y ?? 0.5) * 100}%` }}
-        />
-      </div>
-    </div>
-  );
-}
-
-function CarouselPreview({
+function LayoutPreview({
   photos,
   borderRadius,
-  carouselIndex,
-  onPrev,
-  onNext,
+  template,
+  gap,
+  customProportions,
 }: {
   photos: Photo[];
   borderRadius: number;
-  carouselIndex: number;
-  onPrev: () => void;
-  onNext: () => void;
+  template: LayoutTemplateType | "auto";
+  gap: number;
+  customProportions?: { rows?: number[]; cols?: number[] };
 }) {
-  const photo = photos[carouselIndex] ?? photos[0];
-  if (!photo) return null;
+  const containerAspect = 16 / 10; // approximate preview container aspect
+  const containerWidthPx = 500; // reference width for gap calculation
+
+  const metas = useMemo(
+    () => photos.map((p) => ({ id: p.id, aspect: 1 })),
+    [photos]
+  );
+
+  const rects = useMemo(() => {
+    if (template === "auto") {
+      return computeAutoLayout(metas, containerAspect, gap, containerWidthPx);
+    }
+    return computeTemplateLayout(metas, containerAspect, template, gap, containerWidthPx, customProportions);
+  }, [metas, containerAspect, template, gap, containerWidthPx, customProportions]);
+
   return (
-    <div className="flex flex-col items-center justify-center w-full h-full p-4">
-      <div className="relative flex-1 w-full flex items-center justify-center">
-        {photos.length > 1 && (
-          <button
-            onClick={onPrev}
-            className="absolute left-2 z-10 w-8 h-8 rounded-full bg-white/80 hover:bg-white shadow flex items-center justify-center transition-colors"
+    <div className="relative w-full h-full">
+      {rects.map((rect, i) => {
+        if (i >= photos.length) return null;
+        const photo = photos[i];
+        return (
+          <div
+            key={photo.id}
+            className="absolute overflow-hidden"
+            style={{
+              left: `${rect.x * 100}%`,
+              top: `${rect.y * 100}%`,
+              width: `${rect.width * 100}%`,
+              height: `${rect.height * 100}%`,
+              borderRadius: `${borderRadius}px`,
+              transform: rect.rotation ? `rotate(${rect.rotation}deg)` : undefined,
+            }}
           >
-            <ChevronLeft className="w-4 h-4 text-gray-700" />
-          </button>
-        )}
-        <div className="w-3/4 h-full overflow-hidden" style={{ borderRadius: `${borderRadius}px` }}>
-          <img
-            src={photo.url}
-            alt=""
-            className="w-full h-full object-cover"
-            style={{ objectPosition: `${(photo.focalPoint?.x ?? 0.5) * 100}% ${(photo.focalPoint?.y ?? 0.5) * 100}%` }}
-          />
-        </div>
-        {photos.length > 1 && (
-          <button
-            onClick={onNext}
-            className="absolute right-2 z-10 w-8 h-8 rounded-full bg-white/80 hover:bg-white shadow flex items-center justify-center transition-colors"
-          >
-            <ChevronRight className="w-4 h-4 text-gray-700" />
-          </button>
-        )}
-      </div>
-      {photos.length > 1 && (
-        <div className="flex gap-1.5 mt-3">
-          {photos.map((p, i) => (
-            <div
-              key={p.id}
-              className={`w-2 h-2 rounded-full transition-colors ${
-                i === carouselIndex ? "bg-indigo-500" : "bg-gray-300"
-              }`}
+            <img
+              src={photo.url}
+              alt=""
+              className="w-full h-full object-cover"
+              style={{
+                objectPosition: `${(photo.focalPoint?.x ?? 0.5) * 100}% ${(photo.focalPoint?.y ?? 0.5) * 100}%`,
+              }}
             />
-          ))}
-        </div>
-      )}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -169,10 +97,10 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
   const activeTemplate: LayoutTemplateType | "auto" =
     layout.mode === "manual" && layout.template ? layout.template : "auto";
   const borderRadiusValue = layout.borderRadius ?? 8;
+  const gapValue = layout.gap ?? 8;
   const photoOrder = layout.order ?? location.photos.map((p) => p.id);
 
   const [selectedPhotoIndex, setSelectedPhotoIndex] = useState(0);
-  const [carouselIndex, setCarouselIndex] = useState(0);
 
   const activeStyle: LayoutStyle = (() => {
     if (activeTemplate === "grid") return "grid";
@@ -265,31 +193,16 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
               ))}
             </div>
 
-            {/* CENTER — Live preview */}
+            {/* CENTER — Live preview using actual layout functions */}
             <div className="flex-1 bg-gray-100 flex items-center justify-center p-6">
               <div className="w-full h-full bg-gray-200/50 rounded-xl overflow-hidden relative">
-                {activeStyle === "grid" && (
-                  <GridPreview photos={orderedPhotos} borderRadius={borderRadiusValue} />
-                )}
-                {activeStyle === "collage" && (
-                  <CollagePreview photos={orderedPhotos} borderRadius={borderRadiusValue} />
-                )}
-                {activeStyle === "single" && (
-                  <SinglePreview
-                    photos={orderedPhotos}
-                    borderRadius={borderRadiusValue}
-                    selectedIndex={selectedPhotoIndex}
-                  />
-                )}
-                {activeStyle === "carousel" && (
-                  <CarouselPreview
-                    photos={orderedPhotos}
-                    borderRadius={borderRadiusValue}
-                    carouselIndex={carouselIndex}
-                    onPrev={() => setCarouselIndex((i) => (i - 1 + orderedPhotos.length) % orderedPhotos.length)}
-                    onNext={() => setCarouselIndex((i) => (i + 1) % orderedPhotos.length)}
-                  />
-                )}
+                <LayoutPreview
+                  photos={orderedPhotos}
+                  borderRadius={borderRadiusValue}
+                  template={activeTemplate}
+                  gap={gapValue}
+                  customProportions={layout.customProportions}
+                />
               </div>
             </div>
 
@@ -304,10 +217,9 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
                     key={photo.id}
                     onClick={() => {
                       setSelectedPhotoIndex(i);
-                      setCarouselIndex(i);
                     }}
                     className={`w-full aspect-square rounded-lg overflow-hidden transition-all ${
-                      (activeStyle === "single" ? selectedPhotoIndex === i : carouselIndex === i)
+                      selectedPhotoIndex === i
                         ? "ring-2 ring-indigo-500 ring-offset-2"
                         : "hover:ring-2 hover:ring-gray-300 hover:ring-offset-1"
                     }`}

--- a/src/engine/VideoExporter.ts
+++ b/src/engine/VideoExporter.ts
@@ -10,11 +10,13 @@ import {
   SEGMENT_SOURCE_PREFIX,
 } from "@/components/editor/routeSegmentSources";
 import { computeAutoLayout, computeTemplateLayout } from "@/lib/photoLayout";
+import { isWebCodecsSupported, WebCodecsExporter } from "./WebCodecsExporter";
 
 export type ExportProgress = {
   phase: "capturing" | "uploading" | "encoding" | "done";
   current: number;
   total: number;
+  encodingMethod?: "webcodecs" | "server";
 };
 
 type ProgressCallback = (progress: ExportProgress) => void;
@@ -534,6 +536,17 @@ export class VideoExporter {
     ctx.fill();
   }
 
+  /** Calculate target export dimensions from aspect ratio and resolution settings */
+  private getTargetDimensions(): { width: number; height: number } {
+    const res = this.settings.resolution; // height in pixels (720 or 1080)
+    const ar = this.settings.aspectRatio;
+    if (ar === "9:16") {
+      return { width: Math.round(res * 9 / 16), height: res };
+    }
+    // 16:9 (default)
+    return { width: Math.round(res * 16 / 9), height: res };
+  }
+
   async export(onProgress: ProgressCallback): Promise<Blob | null> {
     const { fps } = this.settings;
     this.cancelled = false;
@@ -543,23 +556,12 @@ export class VideoExporter {
     const totalDuration = this.engine.getTotalDuration();
     const totalFrames = Math.ceil(totalDuration * fps);
     const canvas = this.map.getCanvas();
+    const useWebCodecs = isWebCodecsSupported();
+
+    const { width: targetW, height: targetH } = this.getTargetDimensions();
 
     await this.preloadIcons();
     await this.preloadPhotos();
-
-    this.engine.renderFrame(0);
-    await this.waitForMapIdle();
-    await new Promise((r) => setTimeout(r, 1000));
-    this.engine.renderFrame(totalDuration * 0.25);
-    await this.waitForMapIdle();
-    this.engine.renderFrame(totalDuration * 0.5);
-    await this.waitForMapIdle();
-    this.engine.renderFrame(totalDuration * 0.75);
-    await this.waitForMapIdle();
-    this.engine.renderFrame(totalDuration);
-    await this.waitForMapIdle();
-    this.engine.renderFrame(0);
-    await this.waitForMapIdle();
 
     this.hideAllSegments();
 
@@ -570,13 +572,133 @@ export class VideoExporter {
     this.engine.on("progress", onProgressEvent);
 
     const offscreen = document.createElement("canvas");
-    offscreen.width = canvas.width;
-    offscreen.height = canvas.height;
+    offscreen.width = targetW;
+    offscreen.height = targetH;
     const offCtx = offscreen.getContext("2d");
     if (!offCtx) throw new Error("Failed to create offscreen 2D context");
 
-    const scaleX = canvas.width / canvas.clientWidth;
-    const scaleY = canvas.height / canvas.clientHeight;
+    const scaleX = targetW / canvas.clientWidth;
+    const scaleY = targetH / canvas.clientHeight;
+
+    try {
+      if (useWebCodecs) {
+        return await this.exportWithWebCodecs(
+          offscreen, offCtx, canvas, scaleX, scaleY,
+          targetW, targetH, totalFrames, totalDuration, fps, onProgress
+        );
+      } else {
+        return await this.exportWithServer(
+          offscreen, offCtx, canvas, scaleX, scaleY,
+          totalFrames, totalDuration, fps, signal, onProgress
+        );
+      }
+    } finally {
+      this.restoreAllSegments();
+      this.engine.getIconAnimator().hide();
+
+      this.engine.off("routeDrawProgress", onRouteDrawEvent);
+      this.engine.off("progress", onProgressEvent);
+    }
+  }
+
+  /** Capture a single frame onto the offscreen canvas */
+  private async captureFrame(
+    offCtx: CanvasRenderingContext2D,
+    offscreen: HTMLCanvasElement,
+    canvas: HTMLCanvasElement,
+    scaleX: number,
+    scaleY: number,
+    captured: { routeDraw: AnimationEvent | null; progress: AnimationEvent | null },
+    frameIndex: number,
+    fps: number,
+    totalDuration: number
+  ): Promise<void> {
+    const time = frameIndex / fps;
+    const progress = time / totalDuration;
+
+    captured.routeDraw = null;
+    captured.progress = null;
+
+    this.engine.seekTo(Math.min(progress, 1));
+    this.applyRouteDrawFromCapture(captured);
+    await this.waitForMapIdle();
+
+    offCtx.clearRect(0, 0, offscreen.width, offscreen.height);
+    offCtx.drawImage(canvas, 0, 0, offscreen.width, offscreen.height);
+    this.drawVehicleIcon(offCtx, scaleX, scaleY);
+    this.drawCityLabelFromCapture(offCtx, offscreen.width, scaleX, captured, this.settings.cityLabelSize ?? 18, this.settings.cityLabelLang ?? "en");
+    this.drawPhotos(offCtx, offscreen.width, offscreen.height, scaleX, captured);
+  }
+
+  private async exportWithWebCodecs(
+    offscreen: HTMLCanvasElement,
+    offCtx: CanvasRenderingContext2D,
+    canvas: HTMLCanvasElement,
+    scaleX: number,
+    scaleY: number,
+    targetW: number,
+    targetH: number,
+    totalFrames: number,
+    totalDuration: number,
+    fps: number,
+    onProgress: ProgressCallback
+  ): Promise<Blob | null> {
+    const captured = { routeDraw: null as AnimationEvent | null, progress: null as AnimationEvent | null };
+    const onRouteDrawEvent = (e: AnimationEvent) => { captured.routeDraw = e; };
+    const onProgressEvent = (e: AnimationEvent) => { captured.progress = e; };
+    this.engine.on("routeDrawProgress", onRouteDrawEvent);
+    this.engine.on("progress", onProgressEvent);
+
+    const webCodecsExporter = new WebCodecsExporter({
+      width: targetW,
+      height: targetH,
+      fps,
+    });
+
+    try {
+      for (let i = 0; i < totalFrames; i++) {
+        if (this.cancelled) return null;
+
+        await this.captureFrame(offCtx, offscreen, canvas, scaleX, scaleY, captured, i, fps, totalDuration);
+        webCodecsExporter.addFrame(offscreen, i);
+
+        onProgress({
+          phase: "capturing",
+          current: i + 1,
+          total: totalFrames,
+          encodingMethod: "webcodecs",
+        });
+      }
+
+      if (this.cancelled) return null;
+
+      onProgress({ phase: "encoding", current: 0, total: 1, encodingMethod: "webcodecs" });
+      const blob = await webCodecsExporter.finalize();
+      onProgress({ phase: "done", current: 1, total: 1, encodingMethod: "webcodecs" });
+      return blob;
+    } finally {
+      this.engine.off("routeDrawProgress", onRouteDrawEvent);
+      this.engine.off("progress", onProgressEvent);
+    }
+  }
+
+  private async exportWithServer(
+    offscreen: HTMLCanvasElement,
+    offCtx: CanvasRenderingContext2D,
+    canvas: HTMLCanvasElement,
+    scaleX: number,
+    scaleY: number,
+    totalFrames: number,
+    totalDuration: number,
+    fps: number,
+    signal: AbortSignal,
+    onProgress: ProgressCallback
+  ): Promise<Blob | null> {
+    const captured = { routeDraw: null as AnimationEvent | null, progress: null as AnimationEvent | null };
+    const onRouteDrawEvent = (e: AnimationEvent) => { captured.routeDraw = e; };
+    const onProgressEvent = (e: AnimationEvent) => { captured.progress = e; };
+    this.engine.on("routeDrawProgress", onRouteDrawEvent);
+    this.engine.on("progress", onProgressEvent);
 
     try {
       const startRes = await fetch("/api/encode-video/start", {
@@ -591,23 +713,7 @@ export class VideoExporter {
       for (let i = 0; i < totalFrames; i++) {
         if (this.cancelled) return null;
 
-        const time = i / fps;
-        const progress = time / totalDuration;
-
-        captured.routeDraw = null;
-        captured.progress = null;
-
-        this.engine.seekTo(Math.min(progress, 1));
-
-        this.applyRouteDrawFromCapture(captured);
-
-        await this.waitForMapIdle();
-
-        offCtx.clearRect(0, 0, offscreen.width, offscreen.height);
-        offCtx.drawImage(canvas, 0, 0);
-        this.drawVehicleIcon(offCtx, scaleX, scaleY);
-        this.drawCityLabelFromCapture(offCtx, offscreen.width, scaleX, captured, this.settings.cityLabelSize ?? 18, this.settings.cityLabelLang ?? "en");
-        this.drawPhotos(offCtx, offscreen.width, offscreen.height, scaleX, captured);
+        await this.captureFrame(offCtx, offscreen, canvas, scaleX, scaleY, captured, i, fps, totalDuration);
 
         const blob = await new Promise<Blob>((resolve, reject) => {
           offscreen.toBlob(
@@ -641,12 +747,13 @@ export class VideoExporter {
           phase: "capturing",
           current: i + 1,
           total: totalFrames,
+          encodingMethod: "server",
         });
       }
 
       if (this.cancelled) return null;
 
-      onProgress({ phase: "encoding", current: 0, total: 1 });
+      onProgress({ phase: "encoding", current: 0, total: 1, encodingMethod: "server" });
 
       const response = await fetch("/api/encode-video", {
         method: "POST",
@@ -660,16 +767,13 @@ export class VideoExporter {
         throw new Error(`Server encoding failed: ${text}`);
       }
 
-      onProgress({ phase: "encoding", current: 1, total: 1 });
+      onProgress({ phase: "encoding", current: 1, total: 1, encodingMethod: "server" });
 
       const mp4Blob = await response.blob();
-      onProgress({ phase: "done", current: 1, total: 1 });
+      onProgress({ phase: "done", current: 1, total: 1, encodingMethod: "server" });
 
       return mp4Blob;
     } finally {
-      this.restoreAllSegments();
-      this.engine.getIconAnimator().hide();
-
       this.engine.off("routeDrawProgress", onRouteDrawEvent);
       this.engine.off("progress", onProgressEvent);
     }

--- a/src/engine/WebCodecsExporter.ts
+++ b/src/engine/WebCodecsExporter.ts
@@ -1,0 +1,83 @@
+import { Muxer, ArrayBufferTarget } from "mp4-muxer";
+
+export function isWebCodecsSupported(): boolean {
+  return (
+    typeof VideoEncoder !== "undefined" &&
+    typeof VideoFrame !== "undefined"
+  );
+}
+
+export interface WebCodecsExportOptions {
+  width: number;
+  height: number;
+  fps: number;
+  bitrate?: number;
+}
+
+/**
+ * Encodes frames from an offscreen canvas into an MP4 blob using WebCodecs + mp4-muxer.
+ * Usage:
+ *   const exporter = new WebCodecsExporter(options);
+ *   for each frame: exporter.addFrame(canvas, frameIndex);
+ *   const blob = await exporter.finalize();
+ */
+export class WebCodecsExporter {
+  private muxer: Muxer<ArrayBufferTarget>;
+  private encoder: VideoEncoder;
+  private fps: number;
+  private frameCount = 0;
+  private encoderError: Error | null = null;
+
+  constructor(options: WebCodecsExportOptions) {
+    const { width, height, fps, bitrate = 5_000_000 } = options;
+    this.fps = fps;
+
+    this.muxer = new Muxer({
+      target: new ArrayBufferTarget(),
+      video: {
+        codec: "avc",
+        width,
+        height,
+      },
+      fastStart: "in-memory",
+    });
+
+    this.encoder = new VideoEncoder({
+      output: (chunk, meta) => {
+        this.muxer.addVideoChunk(chunk, meta ?? undefined);
+      },
+      error: (e) => {
+        this.encoderError = e;
+      },
+    });
+
+    this.encoder.configure({
+      codec: "avc1.42001f",
+      width,
+      height,
+      bitrate,
+      framerate: fps,
+    });
+  }
+
+  addFrame(canvas: HTMLCanvasElement | OffscreenCanvas, frameIndex: number): void {
+    if (this.encoderError) throw this.encoderError;
+
+    const timestamp = frameIndex * (1_000_000 / this.fps);
+    const frame = new VideoFrame(canvas, { timestamp });
+    this.encoder.encode(frame, { keyFrame: frameIndex % 60 === 0 });
+    frame.close();
+    this.frameCount++;
+  }
+
+  async finalize(): Promise<Blob> {
+    if (this.encoderError) throw this.encoderError;
+
+    await this.encoder.flush();
+    this.encoder.close();
+    this.muxer.finalize();
+
+    const buffer = this.muxer.target.buffer;
+    return new Blob([buffer], { type: "video/mp4" });
+  }
+}


### PR DESCRIPTION
## Summary
- **WebCodecs video export (primary)**: Uses `VideoEncoder` + `mp4-muxer` to encode H.264 MP4 directly in the browser — eliminates ~900 HTTP uploads per export
- **Server upload fallback**: Falls back to existing server-side FFmpeg encoding when WebCodecs is unavailable
- **Fix export resolution**: Export now respects `aspectRatio` (16:9/9:16) and `resolution` (720/1080) settings instead of using viewport dimensions
- **Remove warmup frames**: Removes 6 unnecessary `renderFrame` calls that wasted ~3 seconds at export start
- **Fix PhotoLayoutEditor preview**: Preview now uses the same `computeAutoLayout`/`computeTemplateLayout` functions as the actual renderer, so what you see matches what gets exported
- **Encoding method indicator**: Shows "Encoded locally with WebCodecs" or "Encoded on server" after export completes

## Files Changed
- `src/engine/WebCodecsExporter.ts` — new WebCodecs encoder using mp4-muxer
- `src/engine/VideoExporter.ts` — WebCodecs primary path, server fallback, resolution fix, warmup removal
- `src/components/editor/ExportDialog.tsx` — encoding method display
- `src/components/editor/PhotoLayoutEditor.tsx` — unified layout preview using actual layout functions
- `package.json` — added `mp4-muxer` dependency

## Test plan
- [ ] Export video with WebCodecs-supported browser (Chrome/Edge) — should encode locally
- [ ] Export video with WebCodecs-unsupported browser (Safari <17) — should fall back to server
- [ ] Verify 720p and 1080p export resolutions produce correct dimensions
- [ ] Verify 16:9 and 9:16 aspect ratios produce correct dimensions
- [ ] Verify encoding method label appears after export completes
- [ ] Open PhotoLayoutEditor and confirm all 4 layout modes (grid/collage/single/carousel) show accurate previews matching the actual exported layout
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)