### PR TITLE
feat: mobile bottom sheet 3-state drag, playback controls optimization, quick export

### DIFF
--- a/src/components/editor/BottomSheet.tsx
+++ b/src/components/editor/BottomSheet.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { ChevronUp, MapPin } from "lucide-react";
+import { motion, type PanInfo } from "framer-motion";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useProjectStore } from "@/stores/projectStore";
 import { useUIStore } from "@/stores/uiStore";
@@ -21,63 +23,148 @@ export default function BottomSheet({
   onDismissSearchHint,
 }: BottomSheetProps) {
   const locations = useProjectStore((s) => s.locations);
-  const expanded = useUIStore((s) => s.bottomSheetExpanded);
-  const toggleBottomSheet = useUIStore((s) => s.toggleBottomSheet);
-  const setBottomSheetExpanded = useUIStore((s) => s.setBottomSheetExpanded);
+  const bottomSheetState = useUIStore((s) => s.bottomSheetState);
+  const setBottomSheetState = useUIStore((s) => s.setBottomSheetState);
+  const [viewportHeight, setViewportHeight] = useState(0);
+
+  useEffect(() => {
+    const updateViewportHeight = () => {
+      setViewportHeight(window.innerHeight);
+    };
+
+    updateViewportHeight();
+    window.addEventListener("resize", updateViewportHeight);
+    return () => window.removeEventListener("resize", updateViewportHeight);
+  }, []);
+
+  const collapsedHeight = 120;
+  const maxSheetHeight = viewportHeight > 0 ? viewportHeight * 0.85 : 0;
+  const halfVisibleHeight = viewportHeight > 0 ? viewportHeight * 0.5 : 0;
+  const collapsedOffset = Math.max(maxSheetHeight - collapsedHeight, 0);
+  const halfOffset = Math.max(maxSheetHeight - halfVisibleHeight, 0);
+  const stateOffsets = {
+    collapsed: collapsedOffset,
+    half: halfOffset,
+    full: 0,
+  };
+  const currentOffset = stateOffsets[bottomSheetState];
+  const stopsLabel = `${locations.length} ${locations.length === 1 ? "stop" : "stops"}`;
+
+  const snapToNearestState = (offset: number) => {
+    const nearestState = (Object.entries(stateOffsets) as Array<
+      [keyof typeof stateOffsets, number]
+    >).reduce((closest, current) => {
+      return Math.abs(current[1] - offset) < Math.abs(closest[1] - offset)
+        ? current
+        : closest;
+    })[0];
+    setBottomSheetState(nearestState);
+  };
+
+  const handleDragEnd = (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+    if (viewportHeight === 0) return;
+
+    const nextOffset = Math.min(
+      Math.max(currentOffset + info.offset.y, 0),
+      collapsedOffset,
+    );
+    const draggedUp = info.offset.y < -100 || info.velocity.y < -700;
+    const draggedDown = info.offset.y > 100 || info.velocity.y > 700;
+
+    if (draggedUp) {
+      if (bottomSheetState === "collapsed") {
+        setBottomSheetState("half");
+        return;
+      }
+
+      if (bottomSheetState === "half") {
+        setBottomSheetState("full");
+        return;
+      }
+    }
+
+    if (draggedDown) {
+      if (bottomSheetState === "full") {
+        setBottomSheetState("half");
+        return;
+      }
+
+      if (bottomSheetState === "half") {
+        setBottomSheetState("collapsed");
+        return;
+      }
+    }
+
+    snapToNearestState(nextOffset);
+  };
+
+  const toggleSheet = () => {
+    setBottomSheetState(bottomSheetState === "collapsed" ? "half" : "collapsed");
+  };
 
   return (
     <>
-      {/* Backdrop overlay when expanded */}
-      {expanded && (
+      {/* Backdrop overlay only in full state */}
+      {bottomSheetState === "full" && (
         <div
           className="fixed inset-0 z-40 bg-black/30"
-          onClick={() => setBottomSheetExpanded(false)}
+          onClick={() => setBottomSheetState("half")}
         />
       )}
 
       {/* Bottom sheet */}
-      <div
-        className={`fixed left-0 right-0 z-50 bg-background border-t rounded-t-2xl shadow-2xl transition-[bottom] duration-300 ease-out ${
-          expanded ? "bottom-0" : "bottom-[calc(-60vh+56px)]"
-        }`}
-        style={{ height: "60vh" }}
+      <motion.div
+        drag="y"
+        dragConstraints={{ top: 0, bottom: collapsedOffset }}
+        dragElastic={0.08}
+        dragMomentum={false}
+        initial={false}
+        animate={{ y: currentOffset }}
+        onDragEnd={handleDragEnd}
+        transition={{ type: "spring", damping: 30, stiffness: 300 }}
+        className="fixed bottom-0 left-0 right-0 z-50 flex flex-col overflow-hidden rounded-t-[24px] border-t bg-background shadow-[0_-8px_32px_rgba(0,0,0,0.12)]"
+        style={{ height: maxSheetHeight || "85vh" }}
       >
-        {/* Drag handle + collapsed bar */}
-        <div
-          className="flex w-full items-center justify-between px-4 h-14 cursor-pointer"
-          onClick={toggleBottomSheet}
-          role="button"
-          tabIndex={0}
-          aria-expanded={expanded}
-          aria-label="Toggle route panel"
-          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") toggleBottomSheet(); }}
-        >
-          <div className="flex items-center gap-2">
-            <div className="mx-auto w-10 h-1 rounded-full bg-muted-foreground/30 absolute top-2 left-1/2 -translate-x-1/2" />
-            <MapPin className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">
-              {locations.length} {locations.length === 1 ? "stop" : "stops"}
-            </span>
+        <div className="shrink-0 px-4 pb-2 pt-3" style={{ height: collapsedHeight }}>
+          <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-gray-300" />
+          <div
+            className="mb-2 flex items-center justify-between"
+            onClick={toggleSheet}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                toggleSheet();
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            aria-expanded={bottomSheetState !== "collapsed"}
+            aria-label="Toggle route panel"
+          >
+            <div className="inline-flex items-center gap-2 rounded-full bg-indigo-50 px-3 py-1.5 text-sm font-medium text-indigo-700">
+              <MapPin className="h-4 w-4" />
+              <span>{stopsLabel}</span>
+            </div>
+            <ChevronUp
+              className={`h-5 w-5 text-muted-foreground transition-transform duration-200 ${
+                bottomSheetState === "collapsed" ? "" : "rotate-180"
+              }`}
+            />
           </div>
-          <ChevronUp
-            className={`h-4 w-4 text-muted-foreground transition-transform duration-300 ${
-              expanded ? "rotate-180" : ""
-            }`}
+          <CitySearch
+            className="p-0"
+            hintMessage={searchHintMessage}
+            onHintDismiss={onDismissSearchHint}
+            inputClassName="h-10"
           />
         </div>
 
-
-        {/* Expanded content */}
-        <div className="flex flex-col overflow-hidden" style={{ height: "calc(60vh - 56px)" }}>
-          <CitySearch
-            hintMessage={searchHintMessage}
-            onHintDismiss={onDismissSearchHint}
-          />
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden border-t border-border/60">
           <ScrollArea className="flex-1 min-h-0">
             <RouteList onLocationClick={onLocationClick} onEditLayout={onEditLayout} />
           </ScrollArea>
         </div>
-      </div>
+      </motion.div>
     </>
   );
 }

--- a/src/components/editor/CitySearch.tsx
+++ b/src/components/editor/CitySearch.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
 import { Search, MapPin } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import { useProjectStore } from "@/stores/projectStore";
 import { useMap } from "./MapContext";
 import OnboardingHint from "./OnboardingHint";
@@ -17,6 +18,8 @@ interface GeoResult {
 interface CitySearchProps {
   hintMessage?: string;
   onHintDismiss?: () => void;
+  className?: string;
+  inputClassName?: string;
 }
 
 export interface CitySearchHandle {
@@ -38,7 +41,7 @@ function splitPlaceName(placeName: string): { city: string; region: string } {
 }
 
 const CitySearch = forwardRef<CitySearchHandle, CitySearchProps>(
-  function CitySearch({ hintMessage, onHintDismiss }, ref) {
+  function CitySearch({ hintMessage, onHintDismiss, className, inputClassName }, ref) {
     const [query, setQuery] = useState("");
     const [results, setResults] = useState<GeoResult[]>([]);
     const [isOpen, setIsOpen] = useState(false);
@@ -139,7 +142,7 @@ const CitySearch = forwardRef<CitySearchHandle, CitySearchProps>(
     };
 
     return (
-      <div ref={containerRef} className="relative p-3">
+      <div ref={containerRef} className={cn("relative p-3", className)}>
         <div className="relative">
           <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
           <Input
@@ -147,11 +150,11 @@ const CitySearch = forwardRef<CitySearchHandle, CitySearchProps>(
             placeholder={PLACEHOLDER_CITIES[placeholderIndex]}
             value={query}
             onChange={(e) => search(e.target.value)}
-            className={[
+            className={cn([
               "pl-9 h-11 text-base transition-all duration-200",
               "focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/10",
               !query && !placeholderVisible ? "placeholder:opacity-0" : "placeholder:opacity-100",
-            ].join(" ")}
+            ].join(" "), inputClassName)}
           />
         </div>
         {hintMessage && onHintDismiss && (

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -119,7 +119,7 @@ function EditorContent() {
 
   const cityLabelSize = useUIStore((s) => s.cityLabelSize);
   const cityLabelLang = useUIStore((s) => s.cityLabelLang);
-  const setBottomSheetExpanded = useUIStore((s) => s.setBottomSheetExpanded);
+  const setBottomSheetState = useUIStore((s) => s.setBottomSheetState);
   const currentCityLabelEn = useAnimationStore((s) => s.currentCityLabel);
   const currentCityLabelZh = useAnimationStore((s) => s.currentCityLabelZh);
   const currentCityLabel =
@@ -533,9 +533,9 @@ function EditorContent() {
       typeof window !== "undefined" &&
       window.innerWidth < 768
     ) {
-      setBottomSheetExpanded(true);
+      setBottomSheetState("half");
     }
-  }, [searchHintMessage, setBottomSheetExpanded]);
+  }, [searchHintMessage, setBottomSheetState]);
 
   const handleFocusSearch = useCallback(() => {
     searchRef.current?.focus();

--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -86,7 +86,7 @@ export default function ExportDialog() {
   const [exportError, setExportError] = useState<string | null>(null);
   const exporterRef = useRef<VideoExporter | null>(null);
 
-  const handleExport = useCallback(async () => {
+  const startExport = useCallback(async (settings: ExportSettings) => {
     if (!map || segments.length === 0) return;
 
     setIsExporting(true);
@@ -95,16 +95,12 @@ export default function ExportDialog() {
     setProgress(null);
     setExportError(null);
 
-    const settings: ExportSettings = {
-      aspectRatio,
-      resolution: parseInt(resolution),
-      fps: FPS,
+    const engine = new AnimationEngine(map, locations, segments);
+    const exporter = new VideoExporter(engine, map, {
+      ...settings,
       cityLabelSize,
       cityLabelLang,
-    };
-
-    const engine = new AnimationEngine(map, locations, segments);
-    const exporter = new VideoExporter(engine, map, settings);
+    });
     exporterRef.current = exporter;
 
     try {
@@ -132,7 +128,23 @@ export default function ExportDialog() {
       setIsExporting(false);
       exporterRef.current = null;
     }
-  }, [map, locations, segments, aspectRatio, resolution, cityLabelSize, cityLabelLang]);
+  }, [map, locations, segments, cityLabelSize, cityLabelLang]);
+
+  const handleQuickExport = () => {
+    void startExport({
+      aspectRatio: "16:9",
+      resolution: 720,
+      fps: 24,
+    });
+  };
+
+  const handleConfiguredExport = () => {
+    void startExport({
+      aspectRatio,
+      resolution: parseInt(resolution, 10),
+      fps: FPS,
+    });
+  };
 
   const handleCancel = () => {
     exporterRef.current?.cancel();
@@ -282,7 +294,7 @@ export default function ExportDialog() {
           {/* Quick Export button */}
           <Button
             className="w-full h-12 bg-indigo-500 hover:bg-indigo-600 text-base font-medium"
-            onClick={handleExport}
+            onClick={handleQuickExport}
             disabled={segments.length === 0}
           >
             Quick Export (720p)
@@ -371,6 +383,14 @@ export default function ExportDialog() {
                       }}
                     />
                   </div>
+
+                  <Button
+                    className="h-11 w-full"
+                    onClick={handleConfiguredExport}
+                    disabled={segments.length === 0}
+                  >
+                    Start Export
+                  </Button>
                 </div>
               </motion.div>
             )}

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -37,7 +37,7 @@ export default function PlaybackControls({
   const currentTime = useAnimationStore((s) => s.currentTime);
   const totalDuration = useAnimationStore((s) => s.totalDuration);
   const currentSegmentIndex = useAnimationStore((s) => s.currentSegmentIndex);
-  const bottomSheetExpanded = useUIStore((s) => s.bottomSheetExpanded);
+  const bottomSheetState = useUIStore((s) => s.bottomSheetState);
   const locations = useProjectStore((s) => s.locations);
   const segments = useProjectStore((s) => s.segments);
 
@@ -53,13 +53,18 @@ export default function PlaybackControls({
     ? locations.find((l) => l.id === currentSegment.toId)?.name
     : null;
 
+  const controlsBottomClass =
+    bottomSheetState === "half" ? "bottom-[50vh]" : "bottom-[120px]";
+  const hideOnMobile = bottomSheetState === "full";
+
   return (
     <div
       className={[
+        hideOnMobile ? "hidden md:flex" : "flex",
         "flex flex-col items-center",
         // Mobile: fixed full-width, z above BottomSheet (z-50)
         "fixed left-0 right-0 z-[60] transition-[bottom] duration-300 ease-out",
-        bottomSheetExpanded ? "bottom-[60vh]" : "bottom-14",
+        controlsBottomClass,
         // Desktop: override to absolute, centered floating pill
         "md:absolute md:z-10 md:bottom-4 md:left-1/2 md:-translate-x-1/2 md:right-auto",
       ].join(" ")}
@@ -96,7 +101,7 @@ export default function PlaybackControls({
         </Button>
         <div className="relative">
           <button
-            className="h-12 w-12 rounded-full bg-indigo-500 hover:bg-indigo-600 text-white shadow-lg shadow-indigo-500/25 transition-all hover:scale-105 active:scale-95 flex items-center justify-center"
+            className="flex h-14 w-14 items-center justify-center rounded-full bg-indigo-500 text-white shadow-lg shadow-indigo-500/25 transition-all hover:scale-105 hover:bg-indigo-600 active:scale-95 md:h-12 md:w-12"
             onClick={isPlaying ? onPause : onPlay}
             aria-label={isPlaying ? "Pause" : "Play"}
           >
@@ -117,6 +122,7 @@ export default function PlaybackControls({
         </div>
         <div className="flex-1 md:flex-none md:w-48">
           <Slider
+            className="h-5 [&>div:first-child]:h-2 md:[&>div:first-child]:h-1.5"
             value={[progress]}
             min={0}
             max={100}
@@ -127,7 +133,7 @@ export default function PlaybackControls({
             }}
           />
         </div>
-        <span className="text-xs text-muted-foreground min-w-[70px] text-right">
+        <span className="min-w-[70px] text-right text-sm text-muted-foreground md:text-xs">
           {formatTime(currentTime)} / {formatTime(totalDuration)}
         </span>
       </div>

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,11 +1,13 @@
 import { create } from "zustand";
 
+export type BottomSheetState = "collapsed" | "half" | "full";
+
 interface UIState {
   leftPanelOpen: boolean;
   exportDialogOpen: boolean;
   aiPanelOpen: boolean;
   searchQuery: string;
-  bottomSheetExpanded: boolean;
+  bottomSheetState: BottomSheetState;
   cityLabelSize: number; // CSS font size in px (default 18)
   cityLabelLang: "en" | "zh"; // City label language
   exportAspectRatio: "16:9" | "9:16"; // Export aspect ratio (also used for photo layout preview)
@@ -14,8 +16,7 @@ interface UIState {
   setExportDialogOpen: (open: boolean) => void;
   setAIPanelOpen: (open: boolean) => void;
   setSearchQuery: (query: string) => void;
-  setBottomSheetExpanded: (expanded: boolean) => void;
-  toggleBottomSheet: () => void;
+  setBottomSheetState: (state: BottomSheetState) => void;
   setCityLabelSize: (size: number) => void;
   setCityLabelLang: (lang: "en" | "zh") => void;
   setExportAspectRatio: (ratio: "16:9" | "9:16") => void;
@@ -26,7 +27,7 @@ export const useUIStore = create<UIState>((set) => ({
   exportDialogOpen: false,
   aiPanelOpen: false,
   searchQuery: "",
-  bottomSheetExpanded: false,
+  bottomSheetState: "collapsed",
   cityLabelSize: 18,
   cityLabelLang: "en",
   exportAspectRatio: "16:9",
@@ -35,8 +36,7 @@ export const useUIStore = create<UIState>((set) => ({
   setExportDialogOpen: (exportDialogOpen) => set({ exportDialogOpen }),
   setAIPanelOpen: (aiPanelOpen) => set({ aiPanelOpen }),
   setSearchQuery: (searchQuery) => set({ searchQuery }),
-  setBottomSheetExpanded: (bottomSheetExpanded) => set({ bottomSheetExpanded }),
-  toggleBottomSheet: () => set((s) => ({ bottomSheetExpanded: !s.bottomSheetExpanded })),
+  setBottomSheetState: (bottomSheetState) => set({ bottomSheetState }),
   setCityLabelSize: (cityLabelSize) => set({ cityLabelSize }),
   setCityLabelLang: (cityLabelLang) => set({ cityLabelLang }),
   setExportAspectRatio: (exportAspectRatio) => set({ exportAspectRatio }),


### PR DESCRIPTION
## Summary
- redesign the mobile bottom sheet with collapsed, half, and full drag states backed by a typed UI store state
- move mobile playback controls based on the sheet state and hide them while editing in full sheet mode
- add one-click quick export plus a separate configured export action in the export dialog

## Verification
- npx tsc --noEmit
- npm run build