### PR TITLE
feat: WYSIWYG viewport ratio selector

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { MapProvider, useMap } from "./MapContext";
 import TopToolbar from "./TopToolbar";
@@ -119,7 +119,33 @@ function EditorContent() {
 
   const cityLabelSize = useUIStore((s) => s.cityLabelSize);
   const cityLabelLang = useUIStore((s) => s.cityLabelLang);
+  const viewportRatio = useUIStore((s) => s.viewportRatio);
   const setBottomSheetState = useUIStore((s) => s.setBottomSheetState);
+
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+
+  const mapContainerStyle = useMemo(() => {
+    if (viewportRatio === "free") return {};
+    const [w, h] = viewportRatio.split(":").map(Number);
+    return { aspectRatio: `${w}/${h}` };
+  }, [viewportRatio]);
+
+  // Resize Mapbox when viewport ratio changes
+  useEffect(() => {
+    if (!map) return;
+    const timer = setTimeout(() => map.resize(), 100);
+    return () => clearTimeout(timer);
+  }, [map, viewportRatio]);
+
+  // ResizeObserver for robust map resize
+  useEffect(() => {
+    if (!map || !mapContainerRef.current) return;
+    const observer = new ResizeObserver(() => {
+      map.resize();
+    });
+    observer.observe(mapContainerRef.current);
+    return () => observer.disconnect();
+  }, [map]);
   const currentCityLabelEn = useAnimationStore((s) => s.currentCityLabel);
   const currentCityLabelZh = useAnimationStore((s) => s.currentCityLabelZh);
   const currentCityLabel =
@@ -557,95 +583,201 @@ function EditorContent() {
           searchRef={searchRef}
         />
         {/* Map area: full width on mobile, flex-1 on desktop */}
-        <div className="flex-1 relative">
-          <MapCanvas />
-          {/* Empty state overlay */}
-          {locations.length === 0 && (
-            <MapEmptyState
-              onSearchClick={handleFocusSearch}
-              onLoadDemo={handleLoadDemo}
-            />
-          )}
-          {/* City label overlay */}
-          <AnimatePresence>
-            {currentCityLabel && (
-              <motion.div
-                key={currentCityLabel}
-                initial={{
-                  opacity: 0,
-                  y: 20,
-                  scale: 0.8,
-                  filter: "blur(8px)",
-                }}
-                animate={{
-                  opacity: 1,
-                  y: 0,
-                  scale: 1,
-                  filter: "blur(0px)",
-                }}
-                exit={{
-                  opacity: 0,
-                  y: -10,
-                  scale: 0.95,
-                  filter: "blur(4px)",
-                }}
-                transition={{
-                  type: "spring",
-                  stiffness: 300,
-                  damping: 25,
-                }}
-                className="absolute top-6 left-1/2 -translate-x-1/2 z-10 rounded-lg bg-background/90 backdrop-blur-sm border shadow-lg px-5 py-2"
-                style={{
-                  textShadow:
-                    "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)",
-                }}
-              >
-                <p
-                  className="font-semibold flex items-center gap-2"
-                  style={{ fontSize: `${cityLabelSize}px` }}
-                >
-                  <svg
-                    className="w-4 h-4 text-indigo-500 flex-shrink-0"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  {currentCityLabel}
-                </p>
-              </motion.div>
+        {viewportRatio === "free" ? (
+          <div className="flex-1 relative">
+            <div ref={mapContainerRef} className="absolute inset-0">
+              <MapCanvas />
+            </div>
+            {/* Empty state overlay */}
+            {locations.length === 0 && (
+              <MapEmptyState
+                onSearchClick={handleFocusSearch}
+                onLoadDemo={handleLoadDemo}
+              />
             )}
-          </AnimatePresence>
-          {/* Photo overlay */}
-          <PhotoOverlay
-            photos={visiblePhotos}
-            visible={showPhotoOverlay}
-            photoLayout={visiblePhotoLocation?.photoLayout}
-            opacity={photoOverlayOpacity}
-          />
-          {/* Photo layout editor */}
-          {editingLocation && editingLocation.photos.length > 0 && (
-            <PhotoLayoutEditor
-              location={editingLocation}
-              onClose={() => setEditingLocationId(null)}
+            {/* City label overlay */}
+            <AnimatePresence>
+              {currentCityLabel && (
+                <motion.div
+                  key={currentCityLabel}
+                  initial={{
+                    opacity: 0,
+                    y: 20,
+                    scale: 0.8,
+                    filter: "blur(8px)",
+                  }}
+                  animate={{
+                    opacity: 1,
+                    y: 0,
+                    scale: 1,
+                    filter: "blur(0px)",
+                  }}
+                  exit={{
+                    opacity: 0,
+                    y: -10,
+                    scale: 0.95,
+                    filter: "blur(4px)",
+                  }}
+                  transition={{
+                    type: "spring",
+                    stiffness: 300,
+                    damping: 25,
+                  }}
+                  className="absolute top-6 left-1/2 -translate-x-1/2 z-10 rounded-lg bg-background/90 backdrop-blur-sm border shadow-lg px-5 py-2"
+                  style={{
+                    textShadow:
+                      "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)",
+                  }}
+                >
+                  <p
+                    className="font-semibold flex items-center gap-2"
+                    style={{ fontSize: `${cityLabelSize}px` }}
+                  >
+                    <svg
+                      className="w-4 h-4 text-indigo-500 flex-shrink-0"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                    {currentCityLabel}
+                  </p>
+                </motion.div>
+              )}
+            </AnimatePresence>
+            {/* Photo overlay */}
+            <PhotoOverlay
+              photos={visiblePhotos}
+              visible={showPhotoOverlay}
+              photoLayout={visiblePhotoLocation?.photoLayout}
+              opacity={photoOverlayOpacity}
             />
-          )}
-          {/* Playback controls — hidden when photo layout editor is open */}
-          {hasSegments && !(editingLocation && editingLocation.photos.length > 0) && (
-            <PlaybackControls
-              onPlay={handlePlay}
-              onPause={handlePause}
-              onReset={handleReset}
-              onSeek={handleSeek}
-              hintMessage={playHintMessage}
-              onHintDismiss={() => dismissHint("playPreview")}
-            />
-          )}
-        </div>
+            {/* Photo layout editor */}
+            {editingLocation && editingLocation.photos.length > 0 && (
+              <PhotoLayoutEditor
+                location={editingLocation}
+                onClose={() => setEditingLocationId(null)}
+              />
+            )}
+            {/* Playback controls — hidden when photo layout editor is open */}
+            {hasSegments && !(editingLocation && editingLocation.photos.length > 0) && (
+              <PlaybackControls
+                onPlay={handlePlay}
+                onPause={handlePause}
+                onReset={handleReset}
+                onSeek={handleSeek}
+                hintMessage={playHintMessage}
+                onHintDismiss={() => dismissHint("playPreview")}
+              />
+            )}
+          </div>
+        ) : (
+          <div className="flex-1 relative flex items-center justify-center bg-gray-900/95">
+            <div
+              ref={mapContainerRef}
+              className="relative bg-background rounded-lg overflow-hidden shadow-2xl border border-gray-700"
+              style={{
+                ...mapContainerStyle,
+                maxHeight: "100%",
+                maxWidth: "100%",
+                width: "auto",
+                height: "100%",
+              }}
+            >
+              <MapCanvas />
+              {/* Empty state overlay */}
+              {locations.length === 0 && (
+                <MapEmptyState
+                  onSearchClick={handleFocusSearch}
+                  onLoadDemo={handleLoadDemo}
+                />
+              )}
+              {/* City label overlay */}
+              <AnimatePresence>
+                {currentCityLabel && (
+                  <motion.div
+                    key={currentCityLabel}
+                    initial={{
+                      opacity: 0,
+                      y: 20,
+                      scale: 0.8,
+                      filter: "blur(8px)",
+                    }}
+                    animate={{
+                      opacity: 1,
+                      y: 0,
+                      scale: 1,
+                      filter: "blur(0px)",
+                    }}
+                    exit={{
+                      opacity: 0,
+                      y: -10,
+                      scale: 0.95,
+                      filter: "blur(4px)",
+                    }}
+                    transition={{
+                      type: "spring",
+                      stiffness: 300,
+                      damping: 25,
+                    }}
+                    className="absolute top-6 left-1/2 -translate-x-1/2 z-10 rounded-lg bg-background/90 backdrop-blur-sm border shadow-lg px-5 py-2"
+                    style={{
+                      textShadow:
+                        "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)",
+                    }}
+                  >
+                    <p
+                      className="font-semibold flex items-center gap-2"
+                      style={{ fontSize: `${cityLabelSize}px` }}
+                    >
+                      <svg
+                        className="w-4 h-4 text-indigo-500 flex-shrink-0"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                      {currentCityLabel}
+                    </p>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+              {/* Photo overlay */}
+              <PhotoOverlay
+                photos={visiblePhotos}
+                visible={showPhotoOverlay}
+                photoLayout={visiblePhotoLocation?.photoLayout}
+                opacity={photoOverlayOpacity}
+              />
+              {/* Photo layout editor */}
+              {editingLocation && editingLocation.photos.length > 0 && (
+                <PhotoLayoutEditor
+                  location={editingLocation}
+                  onClose={() => setEditingLocationId(null)}
+                />
+              )}
+              {/* Playback controls — hidden when photo layout editor is open */}
+              {hasSegments && !(editingLocation && editingLocation.photos.length > 0) && (
+                <PlaybackControls
+                  onPlay={handlePlay}
+                  onPause={handlePause}
+                  onReset={handleReset}
+                  onSeek={handleSeek}
+                  hintMessage={playHintMessage}
+                  onHintDismiss={() => dismissHint("playPreview")}
+                />
+              )}
+            </div>
+          </div>
+        )}
       </div>
       {/* Mobile bottom sheet — hidden during playback */}
       {!isPlaying && (

--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -5,8 +5,6 @@ import {
   Download,
   X,
   AlertTriangle,
-  Monitor,
-  Smartphone,
   Check,
   ChevronDown,
 } from "lucide-react";
@@ -24,7 +22,7 @@ import { useProjectStore } from "@/stores/projectStore";
 import { useUIStore } from "@/stores/uiStore";
 import { AnimationEngine } from "@/engine/AnimationEngine";
 import { VideoExporter, type ExportProgress } from "@/engine/VideoExporter";
-import type { AspectRatio, ExportSettings } from "@/types";
+import type { ExportSettings } from "@/types";
 import { FPS } from "@/lib/constants";
 
 function CircularProgress({ percent }: { percent: number }) {
@@ -74,9 +72,6 @@ export default function ExportDialog() {
   const setCityLabelSize = useUIStore((s) => s.setCityLabelSize);
   const cityLabelLang = useUIStore((s) => s.cityLabelLang);
   const setCityLabelLang = useUIStore((s) => s.setCityLabelLang);
-  const aspectRatio = useUIStore((s) => s.exportAspectRatio) as AspectRatio;
-  const setAspectRatio = useUIStore((s) => s.setExportAspectRatio);
-  const [resolution, setResolution] = useState("720");
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const [isExporting, setIsExporting] = useState(false);
@@ -139,17 +134,15 @@ export default function ExportDialog() {
 
   const handleQuickExport = () => {
     void startExport({
-      aspectRatio: "16:9",
-      resolution: 720,
-      fps: 24,
+      fps: FPS,
     });
   };
 
   const handleConfiguredExport = () => {
     void startExport({
-      aspectRatio,
-      resolution: parseInt(resolution, 10),
       fps: FPS,
+      cityLabelSize,
+      cityLabelLang,
     });
   };
 
@@ -264,46 +257,9 @@ export default function ExportDialog() {
         </DialogHeader>
 
         <div className="space-y-4 py-2">
-          {/* Step 1: Aspect ratio cards */}
-          <div className="space-y-2">
-            <label className="text-sm font-medium">Aspect Ratio</label>
-            <div className="grid grid-cols-2 gap-3">
-              <button
-                className={`relative flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-colors ${
-                  aspectRatio === "16:9"
-                    ? "border-indigo-500 bg-indigo-50"
-                    : "border-border hover:border-gray-300"
-                }`}
-                onClick={() => setAspectRatio("16:9")}
-              >
-                {aspectRatio === "16:9" && (
-                  <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-indigo-500 flex items-center justify-center">
-                    <Check className="h-3 w-3 text-white" />
-                  </div>
-                )}
-                <Monitor className="h-8 w-8 text-gray-600" />
-                <span className="text-sm font-medium">Landscape</span>
-                <span className="text-xs text-muted-foreground">16:9</span>
-              </button>
-              <button
-                className={`relative flex flex-col items-center gap-2 rounded-xl border-2 p-4 transition-colors ${
-                  aspectRatio === "9:16"
-                    ? "border-indigo-500 bg-indigo-50"
-                    : "border-border hover:border-gray-300"
-                }`}
-                onClick={() => setAspectRatio("9:16")}
-              >
-                {aspectRatio === "9:16" && (
-                  <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-indigo-500 flex items-center justify-center">
-                    <Check className="h-3 w-3 text-white" />
-                  </div>
-                )}
-                <Smartphone className="h-8 w-8 text-gray-600" />
-                <span className="text-sm font-medium">Portrait</span>
-                <span className="text-xs text-muted-foreground">9:16</span>
-              </button>
-            </div>
-          </div>
+          <p className="text-sm text-muted-foreground">
+            Exports exactly what you see — the viewport ratio controls the video dimensions.
+          </p>
 
           {/* Quick Export button */}
           <Button
@@ -311,7 +267,7 @@ export default function ExportDialog() {
             onClick={handleQuickExport}
             disabled={segments.length === 0}
           >
-            Quick Export (720p)
+            Export Video
           </Button>
 
           {/* Advanced Settings toggle */}
@@ -336,26 +292,6 @@ export default function ExportDialog() {
                 className="overflow-hidden"
               >
                 <div className="space-y-4 pt-1">
-                  {/* Resolution pills */}
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium">Resolution</label>
-                    <div className="flex gap-2">
-                      {["720", "1080"].map((res) => (
-                        <button
-                          key={res}
-                          className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
-                            resolution === res
-                              ? "bg-indigo-500 text-white"
-                              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                          }`}
-                          onClick={() => setResolution(res)}
-                        >
-                          {res}p
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
                   {/* City Label pills */}
                   <div className="space-y-2">
                     <label className="text-sm font-medium">City Label</label>

--- a/src/components/editor/TopToolbar.tsx
+++ b/src/components/editor/TopToolbar.tsx
@@ -39,7 +39,7 @@ import {
 import { useUIStore } from "@/stores/uiStore";
 import { useProjectStore, type ImportRouteData } from "@/stores/projectStore";
 import { useHistoryStore } from "@/stores/historyStore";
-import type { MapStyle } from "@/types";
+import type { AspectRatio, MapStyle } from "@/types";
 
 export default function TopToolbar() {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -53,10 +53,22 @@ export default function TopToolbar() {
   const clearRoute = useProjectStore((s) => s.clearRoute);
   const mapStyle = useProjectStore((s) => s.mapStyle);
   const setMapStyle = useProjectStore((s) => s.setMapStyle);
+  const viewportRatio = useUIStore((s) => s.viewportRatio);
+  const setViewportRatio = useUIStore((s) => s.setViewportRatio);
   const undo = useHistoryStore((s) => s.undo);
   const redo = useHistoryStore((s) => s.redo);
   const canUndo = useHistoryStore((s) => s.canUndo);
   const canRedo = useHistoryStore((s) => s.canRedo);
+
+  const ratioOptions: AspectRatio[] = ["free", "16:9", "9:16", "4:3", "3:4", "1:1"];
+  const ratioLabels: Record<AspectRatio, string> = {
+    free: "Free",
+    "16:9": "16:9",
+    "9:16": "9:16",
+    "4:3": "4:3",
+    "3:4": "3:4",
+    "1:1": "1:1",
+  };
 
   const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -109,6 +121,48 @@ export default function TopToolbar() {
           >
             TraceRecap
           </Link>
+        </div>
+
+        {/* Center: viewport ratio selector (desktop) */}
+        <div className="hidden md:flex items-center gap-1 rounded-lg border p-0.5 bg-muted/50">
+          {ratioOptions.map((ratio) => (
+            <button
+              key={ratio}
+              className={`px-2 py-1 text-xs rounded-md font-medium transition-colors ${
+                viewportRatio === ratio
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground hover:bg-accent"
+              }`}
+              onClick={() => setViewportRatio(ratio)}
+            >
+              {ratioLabels[ratio]}
+            </button>
+          ))}
+        </div>
+
+        {/* Center: viewport ratio selector (mobile dropdown) */}
+        <div className="md:hidden">
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <button className="px-2 py-1 text-xs rounded-md font-medium border bg-muted/50">
+                  {ratioLabels[viewportRatio]}
+                </button>
+              }
+            />
+            <DropdownMenuContent align="center" sideOffset={4}>
+              <DropdownMenuRadioGroup
+                value={viewportRatio}
+                onValueChange={(v) => setViewportRatio(v as AspectRatio)}
+              >
+                {ratioOptions.map((ratio) => (
+                  <DropdownMenuRadioItem key={ratio} value={ratio}>
+                    {ratioLabels[ratio]}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         {/* Right: undo/redo + more menu */}

--- a/src/engine/VideoExporter.ts
+++ b/src/engine/VideoExporter.ts
@@ -536,17 +536,6 @@ export class VideoExporter {
     ctx.fill();
   }
 
-  /** Calculate target export dimensions from aspect ratio and resolution settings */
-  private getTargetDimensions(): { width: number; height: number } {
-    const res = this.settings.resolution; // height in pixels (720 or 1080)
-    const ar = this.settings.aspectRatio;
-    if (ar === "9:16") {
-      return { width: Math.round(res * 9 / 16), height: res };
-    }
-    // 16:9 (default)
-    return { width: Math.round(res * 16 / 9), height: res };
-  }
-
   async export(onProgress: ProgressCallback): Promise<Blob | null> {
     const { fps } = this.settings;
     this.cancelled = false;
@@ -558,7 +547,9 @@ export class VideoExporter {
     const canvas = this.map.getCanvas();
     const useWebCodecs = isWebCodecsSupported();
 
-    const { width: targetW, height: targetH } = this.getTargetDimensions();
+    // WYSIWYG: use the actual map canvas dimensions
+    const targetW = canvas.width;
+    const targetH = canvas.height;
 
     await this.preloadIcons();
     await this.preloadPhotos();

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { AspectRatio } from "@/types";
 
 export type BottomSheetState = "collapsed" | "half" | "full";
 
@@ -10,7 +11,7 @@ interface UIState {
   bottomSheetState: BottomSheetState;
   cityLabelSize: number; // CSS font size in px (default 18)
   cityLabelLang: "en" | "zh"; // City label language
-  exportAspectRatio: "16:9" | "9:16"; // Export aspect ratio (also used for photo layout preview)
+  viewportRatio: AspectRatio; // WYSIWYG viewport aspect ratio
 
   setLeftPanelOpen: (open: boolean) => void;
   setExportDialogOpen: (open: boolean) => void;
@@ -19,7 +20,7 @@ interface UIState {
   setBottomSheetState: (state: BottomSheetState) => void;
   setCityLabelSize: (size: number) => void;
   setCityLabelLang: (lang: "en" | "zh") => void;
-  setExportAspectRatio: (ratio: "16:9" | "9:16") => void;
+  setViewportRatio: (ratio: AspectRatio) => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -30,7 +31,7 @@ export const useUIStore = create<UIState>((set) => ({
   bottomSheetState: "collapsed",
   cityLabelSize: 18,
   cityLabelLang: "en",
-  exportAspectRatio: "16:9",
+  viewportRatio: "free",
 
   setLeftPanelOpen: (leftPanelOpen) => set({ leftPanelOpen }),
   setExportDialogOpen: (exportDialogOpen) => set({ exportDialogOpen }),
@@ -39,5 +40,5 @@ export const useUIStore = create<UIState>((set) => ({
   setBottomSheetState: (bottomSheetState) => set({ bottomSheetState }),
   setCityLabelSize: (cityLabelSize) => set({ cityLabelSize }),
   setCityLabelLang: (cityLabelLang) => set({ cityLabelLang }),
-  setExportAspectRatio: (exportAspectRatio) => set({ exportAspectRatio }),
+  setViewportRatio: (viewportRatio) => set({ viewportRatio }),
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,11 +70,9 @@ export interface CameraState {
 
 export type PlaybackState = "idle" | "playing" | "paused" | "exporting";
 
-export type AspectRatio = "16:9" | "9:16";
+export type AspectRatio = "free" | "16:9" | "9:16" | "4:3" | "3:4" | "1:1";
 
 export interface ExportSettings {
-  aspectRatio: AspectRatio;
-  resolution: number; // height in pixels (720 or 1080)
   fps: number;
   cityLabelSize?: number; // CSS font size in px (default 18)
   cityLabelLang?: "en" | "zh";


### PR DESCRIPTION
## Summary
- **Viewport ratio in toolbar**: Added pill-button ratio selector (Free | 16:9 | 9:16 | 4:3 | 3:4 | 1:1) to the center of the top toolbar. Mobile shows a compact dropdown.
- **WYSIWYG map preview**: When a ratio is selected, the map container constrains to that aspect ratio, centered with a dark background — like Chrome DevTools responsive mode. `map.resize()` is called via ResizeObserver for correct Mapbox rendering.
- **Simplified export**: Removed aspect ratio and resolution selection from ExportDialog. Export now captures the actual canvas pixel dimensions (true WYSIWYG). One-click "Export Video" button.
- **Updated types**: Expanded `AspectRatio` type to include `'free' | '4:3' | '3:4' | '1:1'`. Removed `aspectRatio` and `resolution` from `ExportSettings`.

## Files changed
- `src/types/index.ts` — expanded AspectRatio, simplified ExportSettings
- `src/stores/uiStore.ts` — replaced `exportAspectRatio` with `viewportRatio`
- `src/components/editor/TopToolbar.tsx` — ratio selector buttons
- `src/components/editor/EditorLayout.tsx` — constrained map container with ResizeObserver
- `src/components/editor/ExportDialog.tsx` — removed ratio/resolution UI
- `src/engine/VideoExporter.ts` — uses actual canvas dimensions

## Test plan
- [ ] Select each ratio in toolbar — map resizes correctly with dark surround
- [ ] "Free" mode fills available space (original behavior)
- [ ] Mobile dropdown shows current ratio and allows switching
- [ ] Export produces video matching the visible viewport dimensions
- [ ] Mapbox tiles render correctly after ratio change (no blank areas)
- [ ] `npx tsc --noEmit` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)