### PR TITLE
fix: top-align constrained map on mobile

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -654,7 +654,7 @@ function EditorContent() {
           ) : (
             <div
               ref={stageViewportRef}
-              className="flex h-full w-full items-center justify-center p-3 md:p-6"
+              className="flex h-full w-full items-start justify-center p-1 md:items-center md:p-6"
             >
               {constrainedMapSize && (
                 <div


### PR DESCRIPTION
## Summary
- top-align constrained map layouts on mobile for non-free viewport ratios
- keep desktop centered behavior unchanged at the `md` breakpoint
- reduce mobile stage padding so the map sits closer to the toolbar

## Verification
- `npx tsc --noEmit`
- `npm run build`
- Browser check at `390x844`: map container top at `y=52`, directly below the toolbar
- Browser check at `1440x900`: map remains vertically centered within the stage

## Notes
- Leaves the existing `TASK.md` worktree change untouched
- DO NOT MERGE