### PR TITLE
fix: scope map language override to name-referencing layers

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -195,16 +195,13 @@ function EditorContent() {
   useEffect(() => {
     if (!map) return;
 
-    // Only target name-label layers (place, settlement, country, state, etc.)
-    // Skip shield/transit/ref layers whose text-field uses other properties
-    const NAME_LAYER_PATTERNS = [
-      "settlement", "place", "country", "state", "continent",
-      "city", "town", "village", "island", "region", "capital",
-    ];
-
-    const isNameLabelLayer = (layerId: string): boolean => {
-      const id = layerId.toLowerCase();
-      return NAME_LAYER_PATTERNS.some((p) => id.includes(p));
+    // Check whether a layer's text-field expression references a 'name' property
+    // (e.g. "name", "name_en", "name_zh-Hans"). Shields, transit refs, and highway
+    // markers use properties like "ref", "shield_text", "house_num" — skip those.
+    const textFieldReferencesName = (textField: unknown): boolean => {
+      if (textField == null) return false;
+      const str = JSON.stringify(textField);
+      return /\bname/.test(str);
     };
 
     const applyMapLanguage = () => {
@@ -218,11 +215,9 @@ function EditorContent() {
 
       for (const layer of style.layers) {
         if (layer.type !== "symbol") continue;
-        if (!isNameLabelLayer(layer.id)) continue;
         const textField = map.getLayoutProperty(layer.id, "text-field");
-        if (textField != null) {
-          map.setLayoutProperty(layer.id, "text-field", textFieldExpr);
-        }
+        if (!textFieldReferencesName(textField)) continue;
+        map.setLayoutProperty(layer.id, "text-field", textFieldExpr);
       }
     };
 


### PR DESCRIPTION
## Summary
- **Bug 2 (text-field too broad)**: Replaced layer-ID pattern matching (`NAME_LAYER_PATTERNS`) with expression-level check — now inspects the actual `text-field` value to see if it references a `name` property before overwriting. This correctly skips shield, transit, ref, and highway-number layers that use `ref`, `shield_text`, `house_num`, etc.
- **Bug 1 (language lost after setStyle)**: Verified the existing `style.load` listener + cleanup is correct — no changes needed. It was already fixed in the prior commit within PR #39.

## Test plan
- [ ] Switch map language to Chinese — verify place/city/country labels change
- [ ] Verify highway shields, transit route numbers, and ref labels remain unchanged
- [ ] Change map style (e.g. satellite ↔ streets) — verify language setting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)