### PR TITLE
feat: redesign PhotoLayoutEditor with mobile WYSIWYG and map background

### DIFF
--- a/src/components/editor/PhotoLayoutEditor.tsx
+++ b/src/components/editor/PhotoLayoutEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import {
   X,
   LayoutGrid,
@@ -232,18 +233,26 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
   }, []);
 
   // Compute numeric aspect ratio from viewport ratio setting
+  // For "free", use the actual map canvas aspect ratio so the preview matches
   const previewAspect = useMemo(() => {
     if (viewportRatio === "free") {
+      if (map) {
+        const canvas = map.getCanvas();
+        if (canvas.width > 0 && canvas.height > 0) {
+          return canvas.width / canvas.height;
+        }
+      }
+      // Fallback to panel size if map not available
       if (panelSize && panelSize.width > 0 && panelSize.height > 0) {
         return panelSize.width / panelSize.height;
       }
-      return 16 / 9; // fallback
+      return 16 / 9; // last resort fallback
     }
     const [w, h] = viewportRatio.split(":").map(Number);
     return w / h;
-  }, [viewportRatio, panelSize]);
+  }, [viewportRatio, panelSize, map]);
 
-  // Compute fitted preview container style for non-free ratios
+  // Compute fitted preview container style
   const previewContainerStyle = useMemo<React.CSSProperties>(() => {
     if (viewportRatio === "free" || !panelSize) {
       return { width: "100%", height: "100%" };
@@ -317,7 +326,8 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
     />
   );
 
-  return (
+  // Portal to body to escape overflow-hidden ancestors (MapStage container)
+  return createPortal(
     <AnimatePresence>
       <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm">
         {/* ── Mobile layout ── */}
@@ -498,6 +508,7 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
           </div>
         </motion.div>
       </div>
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary
- **Mobile**: Full-screen modal with WYSIWYG preview area (map snapshot background + live photo layout in viewport ratio) at the top, and compact controls (horizontal layout pills + scrollable photo thumbnails) at the bottom
- **Desktop**: Keeps existing 3-column layout but replaces the gray preview background with a map snapshot for consistent WYSIWYG experience
- Captures the map canvas as a JPEG snapshot when the editor opens via `useMap()` hook, with graceful fallback to a dark background

## Changes
- `src/components/editor/PhotoLayoutEditor.tsx` — Dual-layout rendering using Tailwind responsive classes (`md:hidden` / `hidden md:flex`), map snapshot capture, `PreviewWithMapBackground` helper component, separate `ResizeObserver` refs for mobile/desktop panels

## Test plan
- [ ] Open PhotoLayoutEditor on mobile viewport (< 768px) — verify full-screen modal with map background in preview
- [ ] Verify preview uses correct viewport ratio (change ratio in settings, reopen editor)
- [ ] Tap layout style pills (Grid, Collage, Single, Carousel) — preview updates in real-time
- [ ] Scroll photo thumbnails horizontally when many photos present
- [ ] Open on desktop (≥ 768px) — verify 3-column layout with map background in center preview
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)