### PR TITLE
fix: playback UX polish — segment label, controls position, map snapshot

### DIFF
--- a/src/components/editor/MapStage.tsx
+++ b/src/components/editor/MapStage.tsx
@@ -148,7 +148,7 @@ export default function MapStage({
       </AnimatePresence>
       {/* Route segment indicator — inside the map container */}
       <AnimatePresence>
-        {isPlaying && fromCity && toCity && (
+        {isPlaying && !showPhotoOverlay && fromCity && toCity && (
           <motion.div
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}

--- a/src/components/editor/PhotoLayoutEditor.tsx
+++ b/src/components/editor/PhotoLayoutEditor.tsx
@@ -191,8 +191,8 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
       });
     };
 
-    if (map.isStyleLoaded() && map.loaded() && map.idle()) {
-      // Map is already fully rendered and idle — capture immediately
+    if (map.isStyleLoaded() && map.loaded()) {
+      // Map is already fully rendered — capture immediately
       capture();
     } else {
       // Map is still loading or rendering — capture once it settles

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -39,9 +39,10 @@ export default function PlaybackControls({
   const progress = totalDuration > 0 ? (currentTime / totalDuration) * 100 : 0;
   const isPlaying = playbackState === "playing";
 
-  const controlsBottomClass =
-    bottomSheetState === "half" ? "bottom-[50vh]" : "bottom-[120px]";
-  const hideOnMobile = bottomSheetState === "full";
+  const controlsBottomClass = isPlaying
+    ? "bottom-4" // BottomSheet is hidden during playback
+    : bottomSheetState === "half" ? "bottom-[50vh]" : "bottom-[120px]";
+  const hideOnMobile = !isPlaying && bottomSheetState === "full";
 
   return (
     <div


### PR DESCRIPTION
## Summary
- **Segment label**: Hide "FromCity → ToCity" pill during photo overlay display; only show during active route movement
- **PlaybackControls position**: Override bottom position to `bottom-4` on mobile during playback (BottomSheet is hidden), and don't hide controls when sheet was previously "full"
- **Map snapshot idle edge case**: Remove invalid `map.idle()` check; capture immediately when `map.isStyleLoaded() && map.loaded()` are true

## Test plan
- [ ] Play animation — segment label appears during route drawing, disappears when photos show
- [ ] On mobile, PlaybackControls sit at bottom of screen during playback (not floating at 50vh)
- [ ] Open PhotoLayoutEditor in "free" ratio mode — preview aspect matches map canvas
- [ ] Open PhotoLayoutEditor when map is already idle — snapshot captures immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)