### PR TITLE
fix: Lottie vehicle icons invisible during playback

### DIFF
--- a/src/engine/IconAnimator.ts
+++ b/src/engine/IconAnimator.ts
@@ -129,13 +129,11 @@ export class IconAnimator {
     const key = `${mode}-${direction}`;
     if (key === this.currentPngKey && this.usingSolid) return;
 
-    // Switch visibility: show PNG, hide Lottie
-    if (!this.usingSolid) {
-      this.hideLottie();
-      this.imgEl.style.display = "block";
-      this.lottieEl.style.display = "none";
-      this.usingSolid = true;
-    }
+    // Always ensure correct visibility (handles initial state + lottie→solid transitions)
+    this.hideLottie();
+    this.imgEl.style.display = "block";
+    this.lottieEl.style.display = "none";
+    this.usingSolid = true;
 
     this.currentPngKey = key;
     this.currentMode = null;
@@ -176,12 +174,10 @@ export class IconAnimator {
 
   /** Switch to a Lottie animation (outline/soft styles) */
   private setLottieMode(mode: TransportMode, iconStyle: TransportIconStyle) {
-    // Switch visibility: hide PNG, show Lottie
-    if (this.usingSolid) {
-      this.imgEl.style.display = "none";
-      this.lottieEl.style.display = "block";
-      this.usingSolid = false;
-    }
+    // Always ensure correct visibility (handles initial state + solid→lottie transitions)
+    this.imgEl.style.display = "none";
+    this.lottieEl.style.display = "block";
+    this.usingSolid = false;
 
     if (mode === this.currentMode && iconStyle === this.currentIconStyle) return;
 
@@ -301,7 +297,7 @@ export class IconAnimator {
     this.containerEl.style.width = `${size}px`;
     this.containerEl.style.height = `${size}px`;
     this.containerEl.style.opacity = showIcon ? String(opacity) : "0";
-    this.containerEl.style.display = showIcon ? "block" : "none";
+    this.containerEl.style.display = showIcon ? "flex" : "none";
 
     this.lastState = {
       visible: showIcon && opacity > 0,


### PR DESCRIPTION
## Summary
- **Fixed invisible Lottie icons**: `lottieEl` stayed `display:none` when the first segment used outline/soft style because `setLottieMode()` gated the visibility toggle on `usingSolid` being true, but it initialized as `false`. Removed the conditional so display is always set correctly.
- **Fixed broken flex centering**: `containerEl.style.display` was overwritten from `flex` to `block` in `update()`, breaking child element centering. Changed to `flex`.

## Root Cause
The `usingSolid` flag started as `false`, creating a "neither" initial state. Both `setSolidIcon()` and `setLottieMode()` assumed they were transitioning *from* the other mode, so neither handled the uninitialized case where both children were hidden.

## Test plan
- [ ] Set a segment icon style to "Outline" or "Soft" and play — Lottie icon should now appear on the map
- [ ] Set icon style to "Solid" and play — PNG icon still renders correctly
- [ ] Switch between styles mid-playback — transitions work without flicker
- [ ] Export video with Lottie style — canvas compositing unaffected (separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)