### PR TITLE
fix: Ken Burns export fallback + stagger parity

### DIFF
--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -71,6 +71,7 @@ export default function ExportDialog() {
   const routeLabelSize = useUIStore((s) => s.routeLabelSize);
   const routeLabelBottomPercent = useUIStore((s) => s.routeLabelBottomPercent);
   const photoAnimation = useUIStore((s) => s.photoAnimation);
+  const photoStyle = useUIStore((s) => s.photoStyle);
 
   const [isExporting, setIsExporting] = useState(false);
   const [progress, setProgress] = useState<ExportProgress | null>(null);
@@ -101,6 +102,7 @@ export default function ExportDialog() {
       routeLabelSize,
       routeLabelBottomPercent,
       photoAnimation,
+      photoStyle,
     });
     exporterRef.current = exporter;
 
@@ -136,7 +138,7 @@ export default function ExportDialog() {
       setIsExporting(false);
       exporterRef.current = null;
     }
-  }, [map, locations, segments, cityLabelSize, cityLabelLang, viewportRatio, routeLabelSize, routeLabelBottomPercent, photoAnimation]);
+  }, [map, locations, segments, cityLabelSize, cityLabelLang, viewportRatio, routeLabelSize, routeLabelBottomPercent, photoAnimation, photoStyle]);
 
   const handleQuickExport = () => {
     void startExport({

--- a/src/engine/VideoExporter.ts
+++ b/src/engine/VideoExporter.ts
@@ -409,6 +409,20 @@ export class VideoExporter {
     }
   }
 
+  /** Per-photo stagger delay in seconds, matching PhotoOverlay's getEnterAnimation */
+  private getStaggerDelay(style: PhotoAnimation, index: number): number {
+    switch (style) {
+      case "none": return 0;
+      case "fade": return index * 0.1;
+      case "flip": return index * 0.1;
+      case "scatter": return index * 0.06;
+      case "typewriter": return index * 0.2;
+      case "slide":
+      case "scale":
+      default: return index * 0.08;
+    }
+  }
+
   /** Cubic ease-out: matches framer-motion's default easeOut */
   private easeOut(t: number): number {
     return 1 - Math.pow(1 - t, 3);
@@ -745,7 +759,7 @@ export class VideoExporter {
         animTransform = this.getExitTransform(exitAnimStyle, exitProgress, photoExitT, i, count);
       } else if (enterAnimStyle !== "none") {
         // Enter animation with per-photo stagger
-        const staggerDelaySec = enterAnimStyle === "typewriter" ? i * 0.2 : i * 0.08;
+        const staggerDelaySec = this.getStaggerDelay(enterAnimStyle, i);
         const staggerDelayFrames = staggerDelaySec * fps;
         const elapsed = frameIndex - enterStartFrame - staggerDelayFrames;
         const rawProgress = Math.max(0, Math.min(1, elapsed / enterDurationFrames));
@@ -836,7 +850,7 @@ export class VideoExporter {
         ctx.rect(imgAreaX, imgAreaY, imgAreaW, imgAreaH);
         ctx.clip();
         if (photoStyle === "kenburns") {
-          const kbStagger = enterAnimStyle === "none" ? 0 : enterAnimStyle === "typewriter" ? i * 0.2 : i * 0.08;
+          const kbStagger = this.getStaggerDelay(enterAnimStyle, i);
           const kbProgress = Math.max(0, Math.min(1, (kenBurnsElapsed - kbStagger) / KEN_BURNS_DURATION_SEC));
           const kb = getKenBurnsTransform(kbProgress, i, fp);
           const areaCX = imgAreaX + imgAreaW / 2;
@@ -912,7 +926,7 @@ export class VideoExporter {
 
         if (photoStyle === "kenburns") {
           // Apply Ken Burns zoom+pan transform (per-photo progress with stagger)
-          const kbStagger = enterAnimStyle === "none" ? 0 : enterAnimStyle === "typewriter" ? i * 0.2 : i * 0.08;
+          const kbStagger = this.getStaggerDelay(enterAnimStyle, i);
           const kbProgress = Math.max(0, Math.min(1, (kenBurnsElapsed - kbStagger) / KEN_BURNS_DURATION_SEC));
           const kb = getKenBurnsTransform(kbProgress, i, fp);
           ctx.translate(kb.translateX * frameW / 100, kb.translateY * frameH / 100);


### PR DESCRIPTION
## Summary
Follow-up to PR #65 addressing review findings:

- **Export fallback**: Pass global `photoStyle` from `uiStore` into `VideoExporter` so locations without explicit override export as Ken Burns when the global default is kenburns
- **Stagger parity**: Extract `getStaggerDelay()` helper with per-animation-style delays matching preview (fade/flip=0.1s, scatter=0.06s, slide/scale=0.08s, typewriter=0.2s)

## Test plan
- [ ] Set global photo style to Ken Burns, add a location without per-location override, export → verify Ken Burns effect in exported video
- [ ] Use fade animation with 3+ photos → verify stagger timing matches preview
- [ ] Use scatter animation → verify 0.06s stagger (not 0.08s) in export
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)