### PR TITLE
fix: normalize wipe bearing for antimeridian crossings

### DIFF
--- a/src/engine/AnimationEngine.ts
+++ b/src/engine/AnimationEngine.ts
@@ -513,7 +513,10 @@ export class AnimationEngine {
         if (sceneTransitionProgress !== undefined && prevGroup) {
           const fromCoords = prevGroup.toLoc.coordinates;
           const toCoords = group.toLoc.coordinates;
-          const dLng = toCoords[0] - fromCoords[0];
+          let dLng = toCoords[0] - fromCoords[0];
+          // Normalize longitude delta for antimeridian crossings
+          if (dLng > 180) dLng -= 360;
+          if (dLng < -180) dLng += 360;
           const dLat = toCoords[1] - fromCoords[1];
           transitionBearing = (Math.atan2(dLng, dLat) * 180) / Math.PI;
         }


### PR DESCRIPTION
Wraps `dLng` into `[-180, 180]` range so directional wipes don't flip for routes crossing the international date line (e.g. 179° → -179°).

Follow-up to #68, addresses Codex review issue #3.

**Changes:** `src/engine/AnimationEngine.ts` — 3 lines added (normalize dLng before bearing calc)