### PR TITLE
fix: hide numbered chapter pins during playback

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,78 +1,38 @@
-# TASK: Fix Duplicate Photo Display — Photos Show Multiple Times Per City
+# TASK: Hide Chapter Pin Numbers During Playback
 
 ⚠️ DO NOT MERGE. Create PR and stop.
 
 ## Bug Description
 
-During playback (both preview and video export), each city's photos are displayed **multiple times** instead of once. Users see:
-1. The **previous city's** photos (outgoing, supposed to be gone)
-2. The **current city's** photos (correct)
-3. The **next city's** photos (shouldn't be visible yet — we haven't traveled there)
+During preview playback, the numbered chapter pins (purple circles with "1", "2", "3" etc.) remain visible on the map. In the exported video, these numbered pins are correctly hidden — only the photo-based chapter pins (small circular thumbnails) appear after a city is visited.
 
-This results in 2-3 overlapping sets of photos at once, making it look broken.
+**Expected behavior**: During playback (playing or paused states), the numbered chapter pins should be hidden, matching the export behavior. They should only show when playback is **stopped/idle** (for editing purposes).
 
-## Root Cause: Scene Transition System
+## Current Behavior
+- **Stopped**: Numbered pins visible ✅ (correct — useful for editing)
+- **Playing**: Numbered pins visible ❌ (should be hidden)
+- **Paused**: Numbered pins visible ❌ (should be hidden)
+- **Export**: Numbered pins hidden ✅ (correct)
 
-The scene transition system (`dissolve`, `blur-dissolve`, `wipe`) was designed for **instantaneous** location switches where photos from one city cross-fade directly into the next. But TraceRecap has a **FLY phase** (traveling animation) between cities — the photos should fully disappear before travel begins and only reappear at the next destination's ARRIVE phase.
+## Where to Fix
 
-The current flow for consecutive cities A → B → C, all with photos:
+Look at `src/components/editor/ChapterPinsOverlay.tsx` — this renders the numbered chapter pins on the map. It needs to check the playback state from `animationStore` and hide when playing or paused.
 
-1. **ARRIVE at A** → `showPhotos=true`, A's photos shown ✅
-2. **HOVER at B** (departing A) → `showPhotos=true` (A fading out), `sceneTransitionProgress` defined, `incomingGroupIndex=B` → **B's photos start appearing as "incoming"** ❌ (B hasn't been visited yet!)
-3. **ZOOM_OUT at B** → same as above, B's incoming photos continue showing ❌
-4. **ZOOM_IN at B** → `sceneTransitionProgress` defined, B's incoming photos at higher opacity ❌
-5. **FLY at B** → no sceneTransitionProgress, but...
-6. **ARRIVE at B** → `showPhotos=true`, B's photos shown again with enter animation → **duplicate!**
+The playback state is available from `useAnimationStore`:
+```ts
+const playbackState = useAnimationStore((s) => s.playbackState);
+// playbackState: "idle" | "playing" | "paused"
+```
 
-The problem is in `AnimationEngine.renderFrame()` (around line 485-510). The scene transition fires during HOVER/ZOOM_OUT/ZOOM_IN whenever `prevHasPhotos || nextHasPhotos`, which causes **incoming photos to appear prematurely** during the departure phases, long before the camera has flown to the next city.
+When `playbackState !== "idle"`, the numbered chapter pins should not render (return null or hide with opacity/display:none).
 
-## The Fix
-
-**Disable scene transitions entirely.** The cross-fade between photo sets doesn't make sense when there's a FLY phase (travel animation) separating them. Each city's photos should:
-- Appear with enter animation during **ARRIVE** only
-- Fade out during the next group's **HOVER/ZOOM_OUT** only
-- Never show "incoming" photos from a city we haven't traveled to yet
-
-### Specific changes needed:
-
-#### 1. `src/engine/AnimationEngine.ts` — `renderFrame()` method
-
-Remove or disable the scene transition metadata block (the section that sets `sceneTransitionProgress`, `outgoingGroupIndex`, `incomingGroupIndex`, `transitionBearing`). These fields should always be `undefined`.
-
-The `showPhotos` + `photoOpacity` logic is correct and should stay:
-- ARRIVE → showPhotos=true, photoOpacity=1
-- Next group's HOVER → showPhotos=true, photoOpacity fades 1→0
-- Next group's ZOOM_OUT → showPhotos=true, photoOpacity fades 0.3→0
-
-#### 2. `src/components/editor/EditorLayout.tsx` — progress handler
-
-The code that sets `incomingPhotos` based on `sceneTransitionProgress` will naturally stop firing since the engine no longer emits those fields. But verify that `setIncomingPhotos([])` is still called to clean up.
-
-#### 3. `src/engine/VideoExporter.ts` — `drawSceneTransitionPhotos()`
-
-This method draws incoming photos during export. Since `sceneTransitionProgress` will always be `undefined`, it will early-return and do nothing. The existing `drawPhotos()` method handles the normal ARRIVE + fade-out path correctly when `isInSceneTransition` is false.
-
-#### 4. `src/components/editor/PhotoOverlay.tsx`
-
-The incoming photos section (`hasIncomingPhotos && ...`) will naturally not render since `incomingPhotos` will always be empty. No changes strictly needed, but you can clean up dead code if you want.
-
-#### 5. `src/stores/uiStore.ts`
-
-The `sceneTransition` setting in the UI store (and any UI controls for selecting dissolve/wipe/blur) can stay for now — they just won't have any effect. Don't remove them yet.
-
-### What NOT to change:
-- The `showPhotos` / `photoOpacity` logic — this correctly handles photo enter/exit
-- The `PhotoOverlay` component's enter/exit animations — these work correctly for single-city display
-- Photo layout, Ken Burns, bloom, portal styles — all unrelated
-- City labels, route labels, breadcrumbs — all unrelated
+## Files to Modify
+- `src/components/editor/ChapterPinsOverlay.tsx` — Add playback state check to hide pins during playback
 
 ## Verification
-
-1. `npx tsc --noEmit` passes
-2. `npm run build` passes
-3. During preview playback:
-   - Each city shows its photos ONCE during ARRIVE
-   - Photos fade out when departing (HOVER/ZOOM_OUT of next group)
-   - No "incoming" photos from future cities appear
-   - No overlapping photo sets from multiple cities
-4. Video export matches preview behavior
+- [ ] `npx tsc --noEmit` passes
+- [ ] `npm run build` passes
+- [ ] During preview: numbered pins hidden while playing
+- [ ] During preview: numbered pins hidden while paused
+- [ ] When stopped: numbered pins visible (for editing)
+- [ ] Photo-based breadcrumb pins (small photo circles) still appear during playback (these are separate)

--- a/src/components/editor/MapCanvas.tsx
+++ b/src/components/editor/MapCanvas.tsx
@@ -206,16 +206,14 @@ export default memo(function MapCanvas() {
   }, [locations]);
 
   // Marker visibility during playback:
-  // Playing: only show markers for locations already visited (index <= currentSegmentIndex)
-  // Idle: show all markers
+  // Playing/Paused: hide all numbered markers (photo-based chapter pins handle display)
+  // Idle: show all markers (for editing)
   useEffect(() => {
     if (playbackState === "playing" || playbackState === "paused") {
-      locations.forEach((loc, index) => {
+      locations.forEach((loc) => {
         const marker = markersRef.current.get(loc.id);
         if (marker) {
-          // Waypoints never shown; destinations shown when visited
-          const visible = !loc.isWaypoint && index <= currentSegmentIndex;
-          marker.getElement().style.display = visible ? "flex" : "none";
+          marker.getElement().style.display = "none";
         }
       });
     } else {
@@ -227,7 +225,7 @@ export default memo(function MapCanvas() {
         }
       });
     }
-  }, [playbackState, currentSegmentIndex, locations]);
+  }, [playbackState, locations]);
 
   // Sync segment route layers
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Hide all numbered chapter pins (purple indigo circles with "1", "2", "3") during preview playback (playing/paused states)
- Pins remain visible when idle for editing purposes
- Matches existing export behavior where numbered pins are already hidden

## Changes
- **`src/components/editor/MapCanvas.tsx`**: Changed marker visibility effect to hide all markers during playback instead of selectively showing visited ones. Removed unused `currentSegmentIndex` dependency.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] During preview: numbered pins hidden while playing
- [ ] During preview: numbered pins hidden while paused
- [ ] When stopped: numbered pins visible (for editing)
- [ ] Photo-based chapter pins (small photo circles) still appear during playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)