### PR TITLE
fix: keep location card clicks out of layout editor

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -658,11 +658,6 @@ function EditorContent() {
 
   const handleLocationClick = useCallback(
     (index: number) => {
-      const targetLoc = locations[index];
-      if (targetLoc) {
-        setEditingLocationId(targetLoc.id);
-      }
-
       const engine = engineRef.current;
       if (!engine) return;
       const totalDuration = engine.getTotalDuration();


### PR DESCRIPTION
## Summary
- remove the layout editor side effect from `handleLocationClick`
- keep location card clicks focused on route expansion/collapse and map seeking
- leave explicit layout editing on thumbnail and "Edit layout" actions

## Verification
- `npx tsc --noEmit`
- `npm run build`

## Notes
- Interactive browser verification was blocked locally because the editor requires a Mapbox access token in this environment.