### PR TITLE
fix: compress oversized photos on project load

### DIFF
--- a/src/components/editor/PhotoManager.tsx
+++ b/src/components/editor/PhotoManager.tsx
@@ -3,51 +3,10 @@
 import { useRef, useState, useCallback } from "react";
 import { Upload, X, LayoutGrid } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { compressImage } from "@/lib/imageUtils";
 import { useProjectStore } from "@/stores/projectStore";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-const MAX_DIMENSION = 1920; // max width or height after compression
-const JPEG_QUALITY = 0.8; // 80% JPEG quality
-
-/** Compress image: resize to max 1920px + JPEG 80% quality */
-async function compressImage(file: File): Promise<Blob> {
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => {
-      let { width, height } = img;
-
-      // Scale down if larger than MAX_DIMENSION
-      if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
-        if (width > height) {
-          height = Math.round(height * (MAX_DIMENSION / width));
-          width = MAX_DIMENSION;
-        } else {
-          width = Math.round(width * (MAX_DIMENSION / height));
-          height = MAX_DIMENSION;
-        }
-      }
-
-      const canvas = document.createElement("canvas");
-      canvas.width = width;
-      canvas.height = height;
-      const ctx = canvas.getContext("2d")!;
-      ctx.drawImage(img, 0, 0, width, height);
-
-      canvas.toBlob(
-        (blob) => resolve(blob ?? file),
-        "image/jpeg",
-        JPEG_QUALITY,
-      );
-      URL.revokeObjectURL(img.src);
-    };
-    img.onerror = () => resolve(file); // fallback to original
-    img.src = URL.createObjectURL(file);
-  });
-}
-
-function createPhotoURL(blob: Blob): string {
-  return URL.createObjectURL(blob);
-}
 
 async function processImageFiles(
   files: FileList | null,
@@ -66,7 +25,7 @@ async function processImageFiles(
     }
     // Compress: resize to max 1920px + JPEG 80% → typically 100-300KB per photo
     const compressed = await compressImage(file);
-    const url = createPhotoURL(compressed);
+    const url = URL.createObjectURL(compressed);
     addPhoto(locationId, { url });
   }
 }

--- a/src/lib/imageUtils.ts
+++ b/src/lib/imageUtils.ts
@@ -1,0 +1,145 @@
+const MAX_IMAGE_DIMENSION = 1920;
+const JPEG_QUALITY = 0.8;
+
+export interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+function hasBrowserImageApis(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof Image !== "undefined" &&
+    typeof document !== "undefined"
+  );
+}
+
+function getTargetDimensions(
+  width: number,
+  height: number,
+): ImageDimensions {
+  if (width <= MAX_IMAGE_DIMENSION && height <= MAX_IMAGE_DIMENSION) {
+    return { width, height };
+  }
+
+  if (width > height) {
+    return {
+      width: MAX_IMAGE_DIMENSION,
+      height: Math.round(height * (MAX_IMAGE_DIMENSION / width)),
+    };
+  }
+
+  return {
+    width: Math.round(width * (MAX_IMAGE_DIMENSION / height)),
+    height: MAX_IMAGE_DIMENSION,
+  };
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("Failed to load image."));
+    img.src = src;
+  });
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  fallback: Blob,
+): Promise<Blob> {
+  return new Promise((resolve) => {
+    canvas.toBlob(
+      (blob) => resolve(blob ?? fallback),
+      "image/jpeg",
+      JPEG_QUALITY,
+    );
+  });
+}
+
+async function drawCompressedImage(
+  src: string,
+  fallback: Blob,
+): Promise<Blob> {
+  if (!hasBrowserImageApis()) {
+    return fallback;
+  }
+
+  const img = await loadImage(src);
+  const { width, height } = getTargetDimensions(
+    img.naturalWidth || img.width,
+    img.naturalHeight || img.height,
+  );
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    return fallback;
+  }
+
+  context.drawImage(img, 0, 0, width, height);
+  return canvasToBlob(canvas, fallback);
+}
+
+async function dataUrlToBlob(dataUrl: string): Promise<Blob> {
+  const response = await fetch(dataUrl);
+  return response.blob();
+}
+
+export function isImageOversized(dimensions: ImageDimensions): boolean {
+  return (
+    dimensions.width > MAX_IMAGE_DIMENSION ||
+    dimensions.height > MAX_IMAGE_DIMENSION
+  );
+}
+
+export async function getImageDimensions(
+  src: string,
+): Promise<ImageDimensions | null> {
+  if (!hasBrowserImageApis()) {
+    return null;
+  }
+
+  try {
+    const img = await loadImage(src);
+    return {
+      width: img.naturalWidth || img.width,
+      height: img.naturalHeight || img.height,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function compressImage(file: File): Promise<Blob> {
+  if (!hasBrowserImageApis()) {
+    return file;
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+
+  try {
+    return await drawCompressedImage(objectUrl, file);
+  } catch {
+    return file;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+export async function compressDataUrl(dataUrl: string): Promise<Blob> {
+  const fallback = await dataUrlToBlob(dataUrl);
+
+  if (!hasBrowserImageApis()) {
+    return fallback;
+  }
+
+  try {
+    return await drawCompressedImage(dataUrl, fallback);
+  } catch {
+    return fallback;
+  }
+}

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -27,6 +27,11 @@ import {
   migrateFromLocalStorage,
   putProjectData,
 } from "@/lib/storage";
+import {
+  compressDataUrl,
+  getImageDimensions,
+  isImageOversized,
+} from "@/lib/imageUtils";
 
 export interface ImportRouteData {
   name: string;
@@ -148,6 +153,7 @@ let persistSuspended = false;
 let lastSavedProjectJson = "";
 let saveCommitChain: Promise<void> = Promise.resolve();
 const projectSaveVersions = new Map<string, number>();
+let activeLoadCompressionJob = 0;
 
 const VALID_TRANSPORT_MODES: TransportMode[] = [
   "flight",
@@ -1054,12 +1060,99 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   },
 
   loadRouteData: async (data) => {
+    const loadCompressionJob = ++activeLoadCompressionJob;
+
+    const compressLoadedPhotos = async () => {
+      if (!isBrowser()) return;
+
+      const projectId = get().currentProjectId;
+      if (!projectId) return;
+
+      const importedLocations = get().locations;
+
+      for (const location of importedLocations) {
+        for (const photo of location.photos) {
+          try {
+            if (!photo.url.startsWith("data:")) continue;
+            if (loadCompressionJob !== activeLoadCompressionJob) return;
+
+            const dimensions = await getImageDimensions(photo.url);
+            if (!dimensions || !isImageOversized(dimensions)) continue;
+
+            const compressedBlob = await compressDataUrl(photo.url);
+            const compressedUrl = URL.createObjectURL(compressedBlob);
+
+            if (loadCompressionJob !== activeLoadCompressionJob) {
+              URL.revokeObjectURL(compressedUrl);
+              return;
+            }
+
+            const currentState = get();
+            const currentLocation = currentState.locations.find(
+              (entry) => entry.id === location.id,
+            );
+            const currentPhoto = currentLocation?.photos.find(
+              (entry) => entry.id === photo.id,
+            );
+
+            if (
+              currentState.currentProjectId !== projectId ||
+              !currentPhoto ||
+              currentPhoto.url !== photo.url
+            ) {
+              URL.revokeObjectURL(compressedUrl);
+              continue;
+            }
+
+            markLocationDirty(location.id);
+
+            let didUpdate = false;
+            set((state) => {
+              const locations = state.locations.map((entry) => {
+                if (entry.id !== location.id) {
+                  return entry;
+                }
+
+                const photos = entry.photos.map((item) => {
+                  if (item.id === photo.id && item.url === photo.url) {
+                    didUpdate = true;
+                    return { ...item, url: compressedUrl };
+                  }
+                  return item;
+                });
+
+                return didUpdate ? { ...entry, photos } : entry;
+              });
+
+              return didUpdate ? { locations } : state;
+            });
+
+            if (!didUpdate) {
+              URL.revokeObjectURL(compressedUrl);
+            }
+
+            await new Promise<void>((resolve) => {
+              window.setTimeout(resolve, 0);
+            });
+          } catch (error) {
+            console.error(
+              `Failed to compress imported photo ${photo.id}.`,
+              error,
+            );
+          }
+        }
+      }
+    };
+
     try {
       // Ensure there's a project to save into
       if (!get().currentProjectId) {
         await get().createNewProject(data.name);
       }
       get().importRoute(data);
+      void compressLoadedPhotos().catch((error) => {
+        console.error("Failed to compress loaded project photos.", error);
+      });
       await get().regenerateSegmentGeometries();
     } catch (error) {
       console.error("Failed to load route data.", error);


### PR DESCRIPTION
## Summary
- extract image compression helpers into a shared utility used by uploads and project imports
- recompress oversized data URL photos in the background when loading route data and swap them to blob URLs without losing metadata
- keep the existing upload flow using the shared compression logic

## Verification
- npx tsc --noEmit
- npm run build