### PR TITLE
feat: smart city label positioning

### DIFF
--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -67,6 +67,7 @@ export default function ExportDialog() {
 
   const cityLabelSize = useUIStore((s) => s.cityLabelSize);
   const cityLabelLang = useUIStore((s) => s.cityLabelLang);
+  const cityLabelTopPercent = useUIStore((s) => s.cityLabelTopPercent);
   const viewportRatio = useUIStore((s) => s.viewportRatio);
   const routeLabelSize = useUIStore((s) => s.routeLabelSize);
   const routeLabelBottomPercent = useUIStore((s) => s.routeLabelBottomPercent);
@@ -98,6 +99,7 @@ export default function ExportDialog() {
       ...settings,
       cityLabelSize,
       cityLabelLang,
+      cityLabelTopPercent,
       viewportRatio,
       routeLabelSize,
       routeLabelBottomPercent,
@@ -138,7 +140,7 @@ export default function ExportDialog() {
       setIsExporting(false);
       exporterRef.current = null;
     }
-  }, [map, locations, segments, cityLabelSize, cityLabelLang, viewportRatio, routeLabelSize, routeLabelBottomPercent, photoAnimation, photoStyle]);
+  }, [map, locations, segments, cityLabelSize, cityLabelLang, cityLabelTopPercent, viewportRatio, routeLabelSize, routeLabelBottomPercent, photoAnimation, photoStyle]);
 
   const handleQuickExport = () => {
     void startExport({

--- a/src/components/editor/MapStage.tsx
+++ b/src/components/editor/MapStage.tsx
@@ -13,6 +13,7 @@ import { useAnimationStore } from "@/stores/animationStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useUIStore } from "@/stores/uiStore";
 import type { Location, Photo, PhotoLayout } from "@/types";
+import { computeCityLabelTopPercent } from "@/lib/cityLabelPosition";
 import { resolveSceneTransition } from "@/lib/sceneTransition";
 
 interface MapStageProps {
@@ -59,12 +60,14 @@ function CityLabelOverlay({
         y: 20,
         scale: 0.8,
         filter: "blur(8px)",
+        top: `${cityLabelTopPercent}%`,
       }}
       animate={{
         opacity: 1,
         y: 0,
         scale: 1,
         filter: "blur(0px)",
+        top: `${cityLabelTopPercent}%`,
       }}
       exit={{
         opacity: 0,
@@ -79,7 +82,6 @@ function CityLabelOverlay({
       }}
       className="absolute left-1/2 z-10 -translate-x-1/2 rounded-lg border bg-background/90 px-5 py-2 shadow-lg backdrop-blur-sm"
       style={{
-        top: `${cityLabelTopPercent}%`,
         textShadow:
           "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)",
       }}
@@ -157,6 +159,11 @@ export default function MapStage({
   const incomingLocation = locations.find((location) => location.id === incomingPhotoLocationId);
   const effectiveTransition = resolveSceneTransition(photoLayout, globalSceneTransition);
   const isTransitioning = effectiveTransition !== "cut" && sceneTransitionProgress !== undefined;
+  const adjustedCityLabelTopPercent = computeCityLabelTopPercent(
+    cityLabelTopPercent,
+    showPhotoOverlay,
+    photoOverlayOpacity,
+  );
 
   const getPortalAccentColor = (locationId: string | null | undefined): string => {
     if (!locationId || !moodColorsEnabled) return "#ffffff";
@@ -189,7 +196,7 @@ export default function MapStage({
           <CityLabelOverlay
             cityLabel={currentCityLabel}
             cityLabelSize={cityLabelSize}
-            cityLabelTopPercent={cityLabelTopPercent}
+            cityLabelTopPercent={adjustedCityLabelTopPercent}
             emoji={currentCityEmoji}
           />
         )}

--- a/src/engine/VideoExporter.ts
+++ b/src/engine/VideoExporter.ts
@@ -38,6 +38,7 @@ import { useProjectStore } from "@/stores/projectStore";
 import { resolveSceneTransition, computeDissolveOpacity, computeBlurDissolve, computeWipeProgress } from "@/lib/sceneTransition";
 import { computePortalLayout, computePortalPhaseProgress } from "@/lib/portalLayout";
 import { computeTripStats, getSortedTransportModes, TRANSPORT_MODE_EMOJI } from "@/lib/tripStats";
+import { computeCityLabelTopPercent } from "@/lib/cityLabelPosition";
 
 export type ExportProgress = {
   phase: "capturing" | "uploading" | "encoding" | "done";
@@ -427,8 +428,10 @@ export class VideoExporter {
   private drawCityLabel(
     ctx: CanvasRenderingContext2D,
     canvasWidth: number,
+    canvasHeight: number,
     scaleX: number,
     label: string,
+    topPercent: number,
     baseFontSize: number = 18,
     accentColor: string = "#6366f1"
   ): void {
@@ -445,7 +448,7 @@ export class VideoExporter {
     const boxWidth = padH + dotRadius * 2 + dotGap + textWidth + padH;
     const boxHeight = padV + 22 * scaleX + padV;
     const x = (canvasWidth - boxWidth) / 2;
-    const y = 24 * scaleX;
+    const y = (canvasHeight * topPercent) / 100;
     const radius = 8 * scaleX;
 
     ctx.save();
@@ -948,6 +951,7 @@ export class VideoExporter {
   private drawCityLabelFromCapture(
     ctx: CanvasRenderingContext2D,
     canvasWidth: number,
+    canvasHeight: number,
     scaleX: number,
     captured: { progress: AnimationEvent | null },
     baseFontSize: number = 18,
@@ -958,9 +962,25 @@ export class VideoExporter {
     const label = lang === "zh" ? (labelZh || labelEn) : labelEn;
     if (label) {
       // Use mood color for the accent dot if available
-      const segIdx = captured.progress?.segmentIndex ?? -1;
+      const progress = captured.progress;
+      const segIdx = progress?.segmentIndex ?? -1;
       const accentColor = this.getSegmentAccentColor(segIdx);
-      this.drawCityLabel(ctx, canvasWidth, scaleX, label, baseFontSize, accentColor);
+      const baseTopPercent = this.settings.cityLabelTopPercent ?? 5;
+      const topPercent = computeCityLabelTopPercent(
+        baseTopPercent,
+        progress?.showPhotos ?? false,
+        progress?.photoOpacity ?? 0,
+      );
+      this.drawCityLabel(
+        ctx,
+        canvasWidth,
+        canvasHeight,
+        scaleX,
+        label,
+        topPercent,
+        baseFontSize,
+        accentColor,
+      );
     }
   }
 
@@ -2434,7 +2454,15 @@ export class VideoExporter {
     offCtx.clearRect(0, 0, offscreen.width, offscreen.height);
     offCtx.drawImage(canvas, 0, 0, offscreen.width, offscreen.height);
     this.drawVehicleIcon(offCtx, scaleX, scaleY);
-    this.drawCityLabelFromCapture(offCtx, offscreen.width, scaleX, captured, this.settings.cityLabelSize ?? 18, this.settings.cityLabelLang ?? "en");
+    this.drawCityLabelFromCapture(
+      offCtx,
+      offscreen.width,
+      offscreen.height,
+      scaleX,
+      captured,
+      this.settings.cityLabelSize ?? 18,
+      this.settings.cityLabelLang ?? "en",
+    );
     this.drawRouteLabel(offCtx, offscreen.width, offscreen.height, scaleX, captured, this.settings.routeLabelSize ?? 14);
     // Chapter pins: update tracking and draw BEFORE photos (pins behind photos, matching preview z-order)
     this.updateChapterPinState(captured.progress);

--- a/src/lib/cityLabelPosition.ts
+++ b/src/lib/cityLabelPosition.ts
@@ -1,0 +1,26 @@
+const PHOTO_OVERLAY_LABEL_SHIFT_RATIO = 0.15;
+const MIN_CITY_LABEL_TOP_PERCENT = 2;
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+export function computeCityLabelTopPercent(
+  baseTopPercent: number,
+  photoOverlayVisible: boolean,
+  photoOverlayOpacity: number,
+): number {
+  if (!photoOverlayVisible || photoOverlayOpacity <= 0) {
+    return baseTopPercent;
+  }
+
+  const shiftedTopPercent = Math.max(
+    MIN_CITY_LABEL_TOP_PERCENT,
+    baseTopPercent * PHOTO_OVERLAY_LABEL_SHIFT_RATIO,
+  );
+  const visibleProgress = clamp01(photoOverlayOpacity);
+  const adjustedTopPercent =
+    baseTopPercent + (shiftedTopPercent - baseTopPercent) * visibleProgress;
+
+  return Math.max(MIN_CITY_LABEL_TOP_PERCENT, adjustedTopPercent);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,7 @@ export interface ExportSettings {
   fps: number;
   cityLabelSize?: number; // CSS font size in px (default 18)
   cityLabelLang?: "en" | "zh";
+  cityLabelTopPercent?: number; // City label top position % (default 5)
   viewportRatio?: AspectRatio;
   routeLabelSize?: number; // Route label font size in px (default 14)
   routeLabelBottomPercent?: number; // Route label bottom position % (default 15)


### PR DESCRIPTION
## Summary
- add shared runtime city-label positioning logic that shifts labels upward while photos are visible
- animate the preview label position in MapStage without changing persisted label settings
- apply the same positioning rule in video export and pass the configured label top percent into export settings

## Verification
- npx tsc --noEmit
- npm run build

Do not merge; task requested PR creation only.