### PR TITLE
fix: resolve free mode ux regressions

### DIFF
--- a/src/components/editor/FreeCanvas.tsx
+++ b/src/components/editor/FreeCanvas.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DEFAULT_CAPTION_BG_COLOR } from "@/lib/constants";
 import type { FreePhotoTransform, Photo } from "@/types";
 
 const CAPTION_FONT_OPTIONS = [
@@ -17,6 +18,13 @@ const CAPTION_COLOR_PRESETS = [
   "#6366f1",
   "#ef4444",
   "#f59e0b",
+] as const;
+
+const CAPTION_BG_PRESETS = [
+  DEFAULT_CAPTION_BG_COLOR,
+  "rgba(0,0,0,0.6)",
+  "rgba(99,102,241,0.7)",
+  "transparent",
 ] as const;
 
 const MIN_PHOTO_SIZE = 0.05;
@@ -124,6 +132,7 @@ function getCaptionTransform(transform: FreePhotoTransform) {
     fontFamily: transform.caption?.fontFamily,
     fontSize: transform.caption?.fontSize,
     color: transform.caption?.color,
+    bgColor: transform.caption?.bgColor ?? DEFAULT_CAPTION_BG_COLOR,
     text: transform.caption?.text,
     rotation: transform.caption?.rotation ?? 0,
   };
@@ -247,6 +256,7 @@ export default function FreeCanvas({
       const transform = transformsRef.current.find((item) => item.photoId === photoId);
       if (!transform) return;
 
+      setEditingCaptionId(null);
       setSelection({ kind: "photo", photoId });
       bringToFront(photoId);
       setActiveGesture({
@@ -265,6 +275,7 @@ export default function FreeCanvas({
     if (!transform) return;
 
     const caption = getCaptionTransform(transform);
+    setEditingCaptionId(null);
     setSelection({ kind: "caption", photoId });
     bringToFront(photoId);
     setActiveGesture({
@@ -281,6 +292,7 @@ export default function FreeCanvas({
     const transform = transformsRef.current.find((item) => item.photoId === photoId);
     if (!transform || containerSize.w <= 0 || containerSize.h <= 0) return;
 
+    setEditingCaptionId(null);
     setSelection({ kind: "photo", photoId });
     bringToFront(photoId);
     setActiveGesture({
@@ -312,6 +324,7 @@ export default function FreeCanvas({
     const anchorX = centerX + anchorOffset.x;
     const anchorY = centerY + anchorOffset.y;
 
+    setEditingCaptionId(null);
     setSelection({ kind: "photo", photoId });
     bringToFront(photoId);
     setActiveGesture({
@@ -533,6 +546,24 @@ export default function FreeCanvas({
     };
   }, [activeGesture, containerSize.h, containerSize.w, getCaptionBounds, updateTransforms]);
 
+  useEffect(() => {
+    if (!editingCaptionId) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.preventDefault();
+      setEditingCaptionId(null);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [editingCaptionId]);
+
   const commitCaptionText = useCallback((photoId: string, text: string) => {
     updateTransforms((current) =>
       current.map((transform) => {
@@ -605,7 +636,7 @@ export default function FreeCanvas({
         const captionCenterY = transform.y + transform.height / 2 + caption.offsetY;
 
         return (
-          <div key={photo.id} className="absolute inset-0" style={{ zIndex: transform.zIndex }}>
+          <Fragment key={photo.id}>
             <div
               className="absolute cursor-grab touch-none active:cursor-grabbing"
               onPointerDown={(event) => {
@@ -619,6 +650,7 @@ export default function FreeCanvas({
                 height: `${transform.height * 100}%`,
                 transform: `rotate(${transform.rotation}deg)`,
                 transformOrigin: "center",
+                zIndex: transform.zIndex,
               }}
             >
               <img
@@ -690,6 +722,7 @@ export default function FreeCanvas({
                   left: `${captionCenterX * 100}%`,
                   top: `${captionCenterY * 100}%`,
                   transform: `translate(-50%, -50%) rotate(${caption.rotation}deg)`,
+                  zIndex: transform.zIndex + 1,
                 }}
               >
                 {editingCaptionId === photo.id ? (
@@ -739,7 +772,7 @@ export default function FreeCanvas({
                       setSelection({ kind: "caption", photoId: photo.id });
                     }}
                     style={{
-                      backgroundColor: captionSelected ? "rgba(255,255,255,0.92)" : "rgba(255,255,255,0.74)",
+                      backgroundColor: caption.bgColor,
                       color: caption.color ?? "#ffffff",
                       fontFamily: caption.fontFamily ?? defaultCaptionFontFamily,
                       fontSize: `${scaledCaptionFontSize}px`,
@@ -752,60 +785,94 @@ export default function FreeCanvas({
 
                 {captionSelected && editingCaptionId !== photo.id ? (
                   <div
-                    className="absolute left-1/2 top-0 z-10 flex -translate-x-1/2 -translate-y-[calc(100%+12px)] items-center gap-2 rounded-xl border border-indigo-100 bg-white/95 px-3 py-2 shadow-xl"
+                    className="absolute left-1/2 top-0 z-10 flex min-w-[240px] -translate-x-1/2 -translate-y-[calc(100%+12px)] flex-col gap-2 rounded-xl border border-indigo-100 bg-white/95 px-3 py-2 shadow-xl"
                     onPointerDown={(event) => event.stopPropagation()}
                   >
-                    <select
-                      className="h-8 rounded-md border border-gray-200 bg-white px-2 text-xs text-gray-700 outline-none focus:border-indigo-500"
-                      value={caption.fontFamily ?? defaultCaptionFontFamily}
-                      onChange={(event) => applyCaptionStyle(photo.id, { fontFamily: event.target.value })}
-                    >
-                      {CAPTION_FONT_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <input
-                      type="range"
-                      min={10}
-                      max={32}
-                      step={1}
-                      value={caption.fontSize ?? defaultCaptionFontSize}
-                      onChange={(event) => applyCaptionStyle(photo.id, { fontSize: Number(event.target.value) })}
-                      className="h-1 w-24 accent-indigo-500"
-                    />
-                    <div className="flex items-center gap-1">
-                      {CAPTION_COLOR_PRESETS.map((color) => (
-                        <button
-                          key={`${photo.id}-${color}`}
-                          type="button"
-                          className={`h-5 w-5 rounded-full border ${
-                            (caption.color ?? "#ffffff") === color ? "border-indigo-500 ring-2 ring-indigo-200" : "border-gray-200"
-                          }`}
-                          style={{ backgroundColor: color }}
-                          onClick={() => applyCaptionStyle(photo.id, { color })}
-                          aria-label={`Set caption color ${color}`}
-                        />
-                      ))}
+                    <div className="flex items-center gap-2">
+                      <select
+                        className="h-8 flex-1 rounded-md border border-gray-200 bg-white px-2 text-xs text-gray-700 outline-none focus:border-indigo-500"
+                        value={caption.fontFamily ?? defaultCaptionFontFamily}
+                        onChange={(event) => applyCaptionStyle(photo.id, { fontFamily: event.target.value })}
+                      >
+                        {CAPTION_FONT_OPTIONS.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                      <input
+                        type="range"
+                        min={10}
+                        max={64}
+                        step={1}
+                        value={caption.fontSize ?? defaultCaptionFontSize}
+                        onChange={(event) => applyCaptionStyle(photo.id, { fontSize: Number(event.target.value) })}
+                        className="h-1 w-24 accent-indigo-500"
+                      />
                     </div>
-                    <input
-                      type="text"
-                      value={customColorInput}
-                      onChange={(event) => setCustomColorInput(event.target.value)}
-                      onBlur={() => {
-                        if (customColorInput.trim()) {
-                          applyCaptionStyle(photo.id, { color: customColorInput.trim() });
-                        }
-                      }}
-                      placeholder="#6366f1"
-                      className="h-8 w-20 rounded-md border border-gray-200 px-2 text-xs text-gray-700 outline-none focus:border-indigo-500"
-                    />
+                    <div className="flex items-center gap-2">
+                      <span className="w-9 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-400">
+                        Text
+                      </span>
+                      <div className="flex items-center gap-1">
+                        {CAPTION_COLOR_PRESETS.map((color) => (
+                          <button
+                            key={`${photo.id}-${color}`}
+                            type="button"
+                            className={`h-5 w-5 rounded-full border ${
+                              (caption.color ?? "#ffffff") === color ? "border-indigo-500 ring-2 ring-indigo-200" : "border-gray-200"
+                            }`}
+                            style={{ backgroundColor: color }}
+                            onClick={() => applyCaptionStyle(photo.id, { color })}
+                            aria-label={`Set caption color ${color}`}
+                          />
+                        ))}
+                      </div>
+                      <input
+                        type="text"
+                        value={customColorInput}
+                        onChange={(event) => setCustomColorInput(event.target.value)}
+                        onBlur={() => {
+                          if (customColorInput.trim()) {
+                            applyCaptionStyle(photo.id, { color: customColorInput.trim() });
+                          }
+                        }}
+                        placeholder="#6366f1"
+                        className="h-8 w-20 rounded-md border border-gray-200 px-2 text-xs text-gray-700 outline-none focus:border-indigo-500"
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="w-9 text-[10px] font-medium uppercase tracking-[0.14em] text-gray-400">
+                        Fill
+                      </span>
+                      <div className="flex items-center gap-1">
+                        {CAPTION_BG_PRESETS.map((color) => (
+                          <button
+                            key={`${photo.id}-bg-${color}`}
+                            type="button"
+                            className={`flex h-5 w-5 items-center justify-center rounded-full border text-[9px] font-semibold ${
+                              caption.bgColor === color ? "border-indigo-500 ring-2 ring-indigo-200" : "border-gray-200"
+                            }`}
+                            style={{
+                              backgroundColor: color === "transparent" ? "#ffffff" : color,
+                              color: color === "transparent" ? "#6b7280" : "transparent",
+                              backgroundImage: color === "transparent"
+                                ? "linear-gradient(135deg, transparent 45%, #ef4444 45%, #ef4444 55%, transparent 55%)"
+                                : undefined,
+                            }}
+                            onClick={() => applyCaptionStyle(photo.id, { bgColor: color })}
+                            aria-label={`Set caption background ${color}`}
+                          >
+                            {color === "transparent" ? "T" : ""}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
                   </div>
                 ) : null}
               </div>
             ) : null}
-          </div>
+          </Fragment>
         );
       })}
     </div>

--- a/src/components/editor/PhotoLayoutEditor.tsx
+++ b/src/components/editor/PhotoLayoutEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { Fragment, useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import {
   DndContext,
@@ -583,8 +583,12 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
     previewPixelSize.width,
   ]);
   const fallbackFreeTransforms = useMemo(
-    () => computedRectsToFreeTransforms(orderedPhotos, computedRects),
-    [computedRects, orderedPhotos],
+    () => computedRectsToFreeTransforms(orderedPhotos, computedRects, {
+      containerWidthPx: previewPixelSize.width,
+      containerHeightPx: previewPixelSize.height,
+      captionFontSizePx: layout.captionFontSize ?? 14,
+    }),
+    [computedRects, layout.captionFontSize, orderedPhotos, previewPixelSize.height, previewPixelSize.width],
   );
   const effectiveFreeTransforms = useMemo(
     () => reconcileFreeTransforms(orderedPhotos, fallbackFreeTransforms, layout.freeTransforms),
@@ -901,7 +905,7 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
             const captionCenterY = transform.y + transform.height / 2 + (transform.caption?.offsetY ?? transform.height / 2 + 0.04);
 
             return (
-              <div key={`free-hit-${photo.id}`} className="absolute inset-0">
+              <Fragment key={`free-hit-${photo.id}`}>
                 <button
                   type="button"
                   className="absolute touch-none cursor-grab rounded-[inherit] bg-transparent active:cursor-grabbing"
@@ -943,7 +947,7 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
                     aria-label={`Move caption for ${photo.caption || "photo"} into free mode`}
                   />
                 ) : null}
-              </div>
+              </Fragment>
             );
           })}
         </div>
@@ -1158,27 +1162,28 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
           }`}
           onClick={(e) => e.stopPropagation()}
         >
-          {/* Header */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
-            <div>
-              <h3 className="text-base font-semibold text-gray-900">{location.name}</h3>
-              <p className="text-xs text-gray-500 mt-0.5">
-                {location.photos.length} photo{location.photos.length !== 1 ? "s" : ""}
-              </p>
+          {!expanded ? (
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+              <div>
+                <h3 className="text-base font-semibold text-gray-900">{location.name}</h3>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  {location.photos.length} photo{location.photos.length !== 1 ? "s" : ""}
+                </p>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => setExpanded(true)}
+                  aria-label="Expand editor"
+                  className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                  <Maximize2 className="h-5 w-5 text-gray-500" />
+                </button>
+                <button onClick={onClose} aria-label="Close photo layout editor" className="p-2 rounded-lg hover:bg-gray-100 transition-colors">
+                  <X className="h-5 w-5 text-gray-500" />
+                </button>
+              </div>
             </div>
-            <div className="flex items-center gap-1">
-              <button
-                onClick={() => setExpanded((v) => !v)}
-                aria-label={expanded ? "Collapse editor" : "Expand editor"}
-                className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
-              >
-                {expanded ? <Minimize2 className="h-5 w-5 text-gray-500" /> : <Maximize2 className="h-5 w-5 text-gray-500" />}
-              </button>
-              <button onClick={onClose} aria-label="Close photo layout editor" className="p-2 rounded-lg hover:bg-gray-100 transition-colors">
-                <X className="h-5 w-5 text-gray-500" />
-              </button>
-            </div>
-          </div>
+          ) : null}
 
           {/* 3-column body */}
           <div className="flex flex-1 min-h-0">
@@ -1321,7 +1326,17 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
             </div>
 
             {/* CENTER — Live preview with map background */}
-            <div ref={desktopPreviewRef} className="flex-1 bg-gray-100 flex items-center justify-center p-6">
+            <div ref={desktopPreviewRef} className={`relative flex-1 bg-gray-100 flex items-center justify-center ${expanded ? "p-2" : "p-6"}`}>
+              {expanded ? (
+                <button
+                  type="button"
+                  onClick={() => setExpanded(false)}
+                  aria-label="Minimize editor"
+                  className="absolute right-4 top-4 z-40 inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/30 bg-white/70 text-gray-700 shadow-lg backdrop-blur-sm transition hover:bg-white/85"
+                >
+                  <Minimize2 className="h-5 w-5" />
+                </button>
+              ) : null}
               <PreviewWithMapBackground mapSnapshot={mapSnapshot} previewContainerStyle={previewContainerStyle}>
                 {layoutPreviewNode}
               </PreviewWithMapBackground>
@@ -1372,16 +1387,17 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
             </div>
           </div>
 
-          {/* Footer */}
-          <div className="flex items-center justify-between px-6 py-4 border-t border-gray-100">
-            <p className="text-xs text-gray-400">Changes are applied automatically</p>
-            <button
-              onClick={onClose}
-              className="px-5 py-2 bg-indigo-500 text-white text-sm font-medium rounded-lg hover:bg-indigo-600 transition-colors"
-            >
-              Done
-            </button>
-          </div>
+          {!expanded ? (
+            <div className="flex items-center justify-between px-6 py-4 border-t border-gray-100">
+              <p className="text-xs text-gray-400">Changes are applied automatically</p>
+              <button
+                onClick={onClose}
+                className="px-5 py-2 bg-indigo-500 text-white text-sm font-medium rounded-lg hover:bg-indigo-600 transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          ) : null}
         </motion.div>
       </div>
     </AnimatePresence>,

--- a/src/components/editor/PhotoOverlay.tsx
+++ b/src/components/editor/PhotoOverlay.tsx
@@ -13,6 +13,7 @@ import {
   BLOOM_ENTER_DURATION_SEC,
   computeBloomFanLayout,
 } from "@/lib/photoAnimation";
+import { DEFAULT_CAPTION_BG_COLOR } from "@/lib/constants";
 import type { PhotoMeta as LayoutPhotoMeta, PhotoRect } from "@/lib/photoLayout";
 import type { FreePhotoTransform, Photo, PhotoLayout, PhotoAnimation, SceneTransition } from "@/types";
 import { useUIStore } from "@/stores/uiStore";
@@ -51,6 +52,7 @@ function getCaptionDisplay(
     fontFamily: transform?.caption?.fontFamily ?? defaultFontFamily,
     fontSizePx: (transform?.caption?.fontSize ?? defaultFontSizePx / Math.max(scale, 0.0001)) * scale,
     color: transform?.caption?.color ?? "#ffffff",
+    bgColor: transform?.caption?.bgColor ?? DEFAULT_CAPTION_BG_COLOR,
     offsetX: transform?.caption?.offsetX ?? 0,
     offsetY: transform?.caption?.offsetY ?? ((transform?.height ?? 0) / 2 + 0.04),
     rotation: transform?.caption?.rotation ?? 0,
@@ -707,8 +709,16 @@ export default function PhotoOverlay({
                     </div>
                     {!displayIsFreeMode && hasCaption && (
                       <p
-                        className="text-gray-700 text-center truncate px-1"
-                        style={{ height: `${captionH}px`, lineHeight: `${captionH}px`, fontSize: `${captionFontSizePx}px`, fontFamily: captionFontFamily, flexShrink: 0 }}
+                        className="mt-1 rounded-md px-2 py-1 text-center text-white shadow-sm"
+                        style={{
+                          minHeight: `${captionH}px`,
+                          fontSize: `${captionFontSizePx}px`,
+                          fontFamily: captionFontFamily,
+                          flexShrink: 0,
+                          backgroundColor: DEFAULT_CAPTION_BG_COLOR,
+                          color: "#ffffff",
+                          textShadow: "0 1px 3px rgba(0,0,0,0.35)",
+                        }}
                       >
                         {photo.caption}
                       </p>
@@ -722,7 +732,7 @@ export default function PhotoOverlay({
                         left: `${(rect.x + rect.width / 2 + captionDisplay.offsetX) * 100}%`,
                         top: `${(rect.y + rect.height / 2 + captionDisplay.offsetY) * 100}%`,
                         transform: `translate(-50%, -50%) rotate(${captionDisplay.rotation}deg)`,
-                        backgroundColor: "rgba(255,255,255,0.74)",
+                        backgroundColor: captionDisplay.bgColor,
                         color: captionDisplay.color,
                         fontFamily: captionDisplay.fontFamily,
                         fontSize: `${captionDisplay.fontSizePx}px`,
@@ -834,8 +844,16 @@ export default function PhotoOverlay({
                   </div>
                   {!displayIsFreeMode && hasCaption && (
                     <p
-                      className="text-gray-700 text-center truncate px-1"
-                      style={{ height: `${captionH}px`, lineHeight: `${captionH}px`, fontSize: `${captionFontSizePx}px`, fontFamily: captionFontFamily, flexShrink: 0 }}
+                      className="mt-1 rounded-md px-2 py-1 text-center text-white shadow-sm"
+                      style={{
+                        minHeight: `${captionH}px`,
+                        fontSize: `${captionFontSizePx}px`,
+                        fontFamily: captionFontFamily,
+                        flexShrink: 0,
+                        backgroundColor: DEFAULT_CAPTION_BG_COLOR,
+                        color: "#ffffff",
+                        textShadow: "0 1px 3px rgba(0,0,0,0.35)",
+                      }}
                     >
                       {photo.caption}
                     </p>
@@ -849,7 +867,7 @@ export default function PhotoOverlay({
                       left: `${(rect.x + rect.width / 2 + captionDisplay.offsetX) * 100}%`,
                       top: `${(rect.y + rect.height / 2 + captionDisplay.offsetY) * 100}%`,
                       transform: `translate(-50%, -50%) rotate(${captionDisplay.rotation}deg)`,
-                      backgroundColor: "rgba(255,255,255,0.74)",
+                      backgroundColor: captionDisplay.bgColor,
                       color: captionDisplay.color,
                       fontFamily: captionDisplay.fontFamily,
                       fontSize: `${captionDisplay.fontSizePx}px`,
@@ -973,8 +991,16 @@ export default function PhotoOverlay({
                     </div>
                     {!incomingIsFreeMode && hasCaption && (
                       <p
-                        className="text-gray-700 text-center truncate px-1"
-                        style={{ height: `${incomingCaptionH}px`, lineHeight: `${incomingCaptionH}px`, fontSize: `${incomingCaptionFontSizePx}px`, fontFamily: incomingCaptionFontFamily, flexShrink: 0 }}
+                        className="mt-1 rounded-md px-2 py-1 text-center text-white shadow-sm"
+                        style={{
+                          minHeight: `${incomingCaptionH}px`,
+                          fontSize: `${incomingCaptionFontSizePx}px`,
+                          fontFamily: incomingCaptionFontFamily,
+                          flexShrink: 0,
+                          backgroundColor: DEFAULT_CAPTION_BG_COLOR,
+                          color: "#ffffff",
+                          textShadow: "0 1px 3px rgba(0,0,0,0.35)",
+                        }}
                       >
                         {photo.caption}
                       </p>
@@ -988,7 +1014,7 @@ export default function PhotoOverlay({
                         left: `${(rect.x + rect.width / 2 + captionDisplay.offsetX) * 100}%`,
                         top: `${(rect.y + rect.height / 2 + captionDisplay.offsetY) * 100}%`,
                         transform: `translate(-50%, -50%) rotate(${captionDisplay.rotation}deg)`,
-                        backgroundColor: "rgba(255,255,255,0.74)",
+                        backgroundColor: captionDisplay.bgColor,
                         color: captionDisplay.color,
                         fontFamily: captionDisplay.fontFamily,
                         fontSize: `${captionDisplay.fontSizePx}px`,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,6 +20,7 @@ export const TARGET_DURATION = {
 } as const;
 
 export const FPS = 30;
+export const DEFAULT_CAPTION_BG_COLOR = "rgba(255,255,255,0.74)";
 
 export interface TransportModeConfig {
   id: TransportMode;

--- a/src/lib/photoLayout.ts
+++ b/src/lib/photoLayout.ts
@@ -782,26 +782,46 @@ export function computeTemplateLayout(
 }
 
 export function computedRectsToFreeTransforms(
-  photos: Array<{ id: string }>,
+  photos: Array<{ id: string; caption?: string }>,
   rects: PhotoRect[],
+  options?: {
+    containerWidthPx?: number;
+    containerHeightPx?: number;
+    captionFontSizePx?: number;
+  },
 ): FreePhotoTransform[] {
+  const containerWidthPx = options?.containerWidthPx ?? 0;
+  const containerHeightPx = options?.containerHeightPx ?? 0;
+  const captionFontSizePx = options?.captionFontSizePx ?? 14;
+  const captionScale = containerWidthPx > 0 ? containerWidthPx / 1000 : 1;
+  const captionHeight =
+    containerHeightPx > 0
+      ? (captionFontSizePx * captionScale * 2) / containerHeightPx
+      : 0;
+
   return photos.reduce<FreePhotoTransform[]>((acc, photo, index) => {
       const rect = rects[index];
       if (!rect) {
         return acc;
       }
 
+      const hasCaption = Boolean(photo.caption?.trim());
+      const photoHeight = hasCaption
+        ? Math.max(rect.height - captionHeight, rect.height * 0.2)
+        : rect.height;
+
       acc.push({
         photoId: photo.id,
         x: rect.x,
         y: rect.y,
         width: rect.width,
-        height: rect.height,
+        height: photoHeight,
         rotation: rect.rotation ?? 0,
         zIndex: index,
         caption: {
+          text: photo.caption,
           offsetX: 0,
-          offsetY: rect.height / 2 + 0.04,
+          offsetY: hasCaption ? rect.height / 2 : rect.height / 2 + 0.04,
           rotation: 0,
         },
       });

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -146,6 +146,9 @@ function deserializeFreeTransforms(
             color: typeof (rawCaption as Record<string, unknown>).color === "string"
               ? (rawCaption as Record<string, unknown>).color as string
               : undefined,
+            bgColor: typeof (rawCaption as Record<string, unknown>).bgColor === "string"
+              ? (rawCaption as Record<string, unknown>).bgColor as string
+              : undefined,
             rotation: typeof (rawCaption as Record<string, unknown>).rotation === "number"
               ? (rawCaption as Record<string, unknown>).rotation as number
               : undefined,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,6 +123,7 @@ export interface FreePhotoTransform {
     fontFamily?: string;
     fontSize?: number;
     color?: string;
+    bgColor?: string;
     rotation?: number;
   };
 }


### PR DESCRIPTION
## Summary
- fix free mode selection, deselection, caption editing, and caption background controls
- preserve WYSIWYG positions when switching into free mode and remove expanded desktop chrome
- align PhotoOverlay caption styling with the free-mode pill treatment

## Validation
- npx tsc --noEmit
- npm run build