### PR TITLE
fix: keep mobile free overlays above playback bar

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -161,6 +161,7 @@ function EditorContent() {
     width: 0,
     height: 0,
   });
+  const [stageViewportBottomInsetPx, setStageViewportBottomInsetPx] = useState(0);
 
   const constrainedMapSize = useMemo(
     () =>
@@ -198,6 +199,47 @@ function EditorContent() {
 
     return () => observer.disconnect();
   }, [map, viewportRatio]);
+
+  useEffect(() => {
+    if (viewportRatio !== "free") {
+      setStageViewportBottomInsetPx(0);
+      return;
+    }
+
+    const stageViewport = stageViewportRef.current;
+    if (!stageViewport || typeof window === "undefined") return;
+
+    const updateStageInset = () => {
+      const rect = stageViewport.getBoundingClientRect();
+      const viewportHeight =
+        window.visualViewport?.height ?? window.innerHeight;
+      const visibleBottom = Math.min(rect.bottom, viewportHeight);
+      const nextInset = Math.max(0, Math.round(rect.bottom - visibleBottom));
+
+      setStageViewportBottomInsetPx((current) =>
+        current === nextInset ? current : nextInset,
+      );
+    };
+
+    updateStageInset();
+
+    const observer = new ResizeObserver(() => {
+      updateStageInset();
+    });
+    observer.observe(stageViewport);
+
+    const visualViewport = window.visualViewport;
+    window.addEventListener("resize", updateStageInset);
+    visualViewport?.addEventListener("resize", updateStageInset);
+    visualViewport?.addEventListener("scroll", updateStageInset);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateStageInset);
+      visualViewport?.removeEventListener("resize", updateStageInset);
+      visualViewport?.removeEventListener("scroll", updateStageInset);
+    };
+  }, [viewportRatio]);
 
   useEffect(() => {
     if (!map || !mapContainerRef.current) return;
@@ -885,6 +927,7 @@ function EditorContent() {
                   playHintMessage={playHintMessage}
                   showPhotoOverlay={showPhotoOverlay}
                   showEmptyState={locations.length === 0}
+                  stageBottomInsetPx={stageViewportBottomInsetPx}
                   onFocusSearch={handleFocusSearch}
                   onHintDismiss={() => dismissHint("playPreview")}
                   onLoadDemo={handleLoadDemo}
@@ -925,6 +968,7 @@ function EditorContent() {
                     playHintMessage={playHintMessage}
                     showPhotoOverlay={showPhotoOverlay}
                     showEmptyState={locations.length === 0}
+                    stageBottomInsetPx={0}
                     onFocusSearch={handleFocusSearch}
                     onHintDismiss={() => dismissHint("playPreview")}
                     onLoadDemo={handleLoadDemo}

--- a/src/components/editor/MapStage.tsx
+++ b/src/components/editor/MapStage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
 import MapCanvas from "./MapCanvas";
 import PlaybackControls from "./PlaybackControls";
 import PhotoOverlay from "./PhotoOverlay";
@@ -30,6 +31,7 @@ interface MapStageProps {
   photoOverlayOpacity: number;
   playHintMessage?: string;
   showPhotoOverlay: boolean;
+  stageBottomInsetPx?: number;
   onFocusSearch: () => void;
   onHintDismiss: () => void;
   onLoadDemo: () => void;
@@ -125,6 +127,7 @@ export default function MapStage({
   photoOverlayOpacity,
   playHintMessage,
   showPhotoOverlay,
+  stageBottomInsetPx = 0,
   onFocusSearch,
   onHintDismiss,
   onLoadDemo,
@@ -173,6 +176,9 @@ export default function MapStage({
   };
 
   const isPlaying = playbackState === "playing";
+  const [playbackBarInsetPx, setPlaybackBarInsetPx] = useState(0);
+  const effectiveBottomInsetPx = stageBottomInsetPx + playbackBarInsetPx;
+  const routeLabelBottomPx = Math.max(80, effectiveBottomInsetPx + 16);
   const currentSegment = segments[currentSegmentIndex];
   const fromLoc = currentSegment
     ? locations.find((l) => l.id === currentSegment.fromId)
@@ -216,7 +222,10 @@ export default function MapStage({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 8 }}
             className="absolute left-1/2 z-10 -translate-x-1/2 bg-white/90 backdrop-blur-md rounded-full px-4 py-1.5 shadow-lg font-medium text-gray-700"
-            style={{ bottom: `max(80px, ${routeLabelBottomPercent}%)`, fontSize: `${routeLabelSize}px` }}
+            style={{
+              bottom: `max(${routeLabelBottomPx}px, ${routeLabelBottomPercent}%)`,
+              fontSize: `${routeLabelSize}px`,
+            }}
           >
             {fromCity} → {toCity}
           </motion.div>
@@ -236,10 +245,11 @@ export default function MapStage({
         transitionBearing={isTransitioning ? transitionBearing : undefined}
         originCoordinates={visiblePhotoLocation?.coordinates}
         incomingOriginCoordinates={isTransitioning ? incomingLocation?.coordinates : undefined}
+        bottomInsetPx={effectiveBottomInsetPx}
         portalAccentColor={getPortalAccentColor(photoLocationId)}
         incomingPortalAccentColor={isTransitioning ? getPortalAccentColor(incomingPhotoLocationId) : undefined}
       />
-      <TripStatsBar />
+      <TripStatsBar bottomInsetPx={effectiveBottomInsetPx} />
       {showPhotoLayoutEditor && editingLocation && (
         <PhotoLayoutEditor
           location={editingLocation}
@@ -254,6 +264,7 @@ export default function MapStage({
           onSeek={onSeek}
           hintMessage={playHintMessage}
           onHintDismiss={onHintDismiss}
+          onPlayingMobileInsetChange={setPlaybackBarInsetPx}
         />
       )}
     </div>

--- a/src/components/editor/PhotoOverlay.tsx
+++ b/src/components/editor/PhotoOverlay.tsx
@@ -190,6 +190,7 @@ interface PhotoOverlayProps {
   visible: boolean;
   photoLayout?: PhotoLayout;
   opacity?: number; // 0-1, for fade-out transition
+  bottomInsetPx?: number;
   containerMode?: "viewport" | "parent"; // 'parent' uses 100% sizing instead of vw/vh
   originCoordinates?: [number, number];
   incomingOriginCoordinates?: [number, number];
@@ -266,6 +267,7 @@ export default function PhotoOverlay({
   visible,
   photoLayout,
   opacity = 1,
+  bottomInsetPx = 0,
   containerMode = "viewport",
   originCoordinates,
   portalAccentColor = "#ffffff",
@@ -311,12 +313,16 @@ export default function PhotoOverlay({
       return { width: "95%", height: "88%" };
     }
     if (viewportRatio === "free") {
-      // Use dvh on mobile to account for browser chrome + playback bar;
-      // on desktop % is fine since the map container matches the visible area.
-      return { width: "95%", height: "min(88%, calc(100dvh - 200px))" };
+      return {
+        width: "95%",
+        height:
+          bottomInsetPx > 0
+            ? `min(88%, calc(100% - ${bottomInsetPx}px))`
+            : "88%",
+      };
     }
     return { width: "95%", height: "88%" };
-  }, [viewportRatio, containerMode, usesPortalLayout]);
+  }, [bottomInsetPx, viewportRatio, containerMode, usesPortalLayout]);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerSize, setContainerSize] = useState({ w: 0, h: 0 });
@@ -586,7 +592,7 @@ export default function PhotoOverlay({
         ...containerStyle,
         margin: "auto",
         top: 0,
-        bottom: 0,
+        bottom: bottomInsetPx,
         left: 0,
         right: 0,
       }}

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useEffect, useRef } from "react";
 import { Play, Pause, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
@@ -15,6 +15,7 @@ interface PlaybackControlsProps {
   onSeek: (progress: number) => void;
   hintMessage?: string;
   onHintDismiss?: () => void;
+  onPlayingMobileInsetChange?: (insetPx: number) => void;
 }
 
 function formatTime(seconds: number): string {
@@ -31,15 +32,64 @@ export default memo(function PlaybackControls({
   onSeek,
   hintMessage,
   onHintDismiss,
+  onPlayingMobileInsetChange,
 }: PlaybackControlsProps) {
   const playbackState = useAnimationStore((s) => s.playbackState);
   const currentTime = useAnimationStore((s) => s.currentTime);
   const totalDuration = useAnimationStore((s) => s.totalDuration);
   const bottomSheetState = useUIStore((s) => s.bottomSheetState);
   const exportDialogOpen = useUIStore((s) => s.exportDialogOpen);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const progress = totalDuration > 0 ? (currentTime / totalDuration) * 100 : 0;
   const isPlaying = playbackState === "playing";
+
+  useEffect(() => {
+    if (!onPlayingMobileInsetChange || typeof window === "undefined") return;
+
+    const updateInset = () => {
+      const isMobile = window.innerWidth < 768;
+      const container = containerRef.current;
+
+      if (!isPlaying || exportDialogOpen || !isMobile || !container) {
+        onPlayingMobileInsetChange(0);
+        return;
+      }
+
+      const rect = container.getBoundingClientRect();
+      const viewportHeight =
+        window.visualViewport?.height ?? window.innerHeight;
+      const nextInset = Math.max(0, Math.round(viewportHeight - rect.top));
+      onPlayingMobileInsetChange(nextInset);
+    };
+
+    updateInset();
+
+    const container = containerRef.current;
+    const observer = container ? new ResizeObserver(updateInset) : null;
+    if (container && observer) {
+      observer.observe(container);
+    }
+    container?.addEventListener("transitionend", updateInset);
+
+    const visualViewport = window.visualViewport;
+    const settleTimeout = window.setTimeout(updateInset, 350);
+    const settleAnimationFrame = window.requestAnimationFrame(updateInset);
+    window.addEventListener("resize", updateInset);
+    visualViewport?.addEventListener("resize", updateInset);
+    visualViewport?.addEventListener("scroll", updateInset);
+
+    return () => {
+      observer?.disconnect();
+      container?.removeEventListener("transitionend", updateInset);
+      window.clearTimeout(settleTimeout);
+      window.cancelAnimationFrame(settleAnimationFrame);
+      window.removeEventListener("resize", updateInset);
+      visualViewport?.removeEventListener("resize", updateInset);
+      visualViewport?.removeEventListener("scroll", updateInset);
+      onPlayingMobileInsetChange(0);
+    };
+  }, [exportDialogOpen, isPlaying, onPlayingMobileInsetChange]);
 
   // Hide controls when export dialog is open
   if (exportDialogOpen) return null;
@@ -89,7 +139,7 @@ export default memo(function PlaybackControls({
     : "h-5 [&>div:first-child]:h-2 md:[&>div:first-child]:h-1.5";
 
   return (
-    <div className={containerClassName}>
+    <div ref={containerRef} className={containerClassName}>
       {/* Controls bar */}
       <div className={barClassName}>
         <div className={resetContainerClassName} aria-hidden={isPlaying}>

--- a/src/components/editor/TripStatsBar.tsx
+++ b/src/components/editor/TripStatsBar.tsx
@@ -60,7 +60,13 @@ function Separator() {
   return <div className="h-3.5 w-px bg-white/20" />;
 }
 
-export default function TripStatsBar() {
+interface TripStatsBarProps {
+  bottomInsetPx?: number;
+}
+
+export default function TripStatsBar({
+  bottomInsetPx = 0,
+}: TripStatsBarProps) {
   const playbackState = useAnimationStore((s) => s.playbackState);
   const currentSegmentIndex = useAnimationStore((s) => s.currentSegmentIndex);
   const currentPhase = useAnimationStore((s) => s.currentPhase);
@@ -149,6 +155,10 @@ export default function TripStatsBar() {
   if (!tripStatsEnabled) return null;
 
   const isActive = playbackState === "playing" || playbackState === "paused";
+  const containerStyle =
+    bottomInsetPx > 0
+      ? { bottom: `${Math.max(56, bottomInsetPx + 12)}px` }
+      : undefined;
 
   return (
     <AnimatePresence>
@@ -159,6 +169,7 @@ export default function TripStatsBar() {
           exit={{ opacity: 0, y: 16 }}
           transition={{ duration: 0.3, ease: "easeOut" }}
           className="absolute bottom-14 left-1/2 z-10 -translate-x-1/2 md:bottom-16"
+          style={containerStyle}
         >
           <div className="flex items-center gap-2.5 rounded-t-lg bg-black/50 px-4 py-1.5 backdrop-blur-sm"
             style={{ height: "36px" }}


### PR DESCRIPTION
## Summary
- measure the free-ratio stage bottom occlusion from the visual viewport
- measure the mobile playback bar footprint during playback and share it with map overlays
- keep the photo overlay, route label, and trip stats bar above the covered area on mobile without changing desktop behavior

## Verification
- npx tsc --noEmit
- npm run build