### PR TITLE
fix: prevent duplicate playback photo pins

### DIFF
--- a/src/components/editor/BreadcrumbTrail.tsx
+++ b/src/components/editor/BreadcrumbTrail.tsx
@@ -178,9 +178,12 @@ export default function BreadcrumbTrail() {
   const breadcrumbs = useAnimationStore((s) => s.breadcrumbs);
   const playbackState = useAnimationStore((s) => s.playbackState);
   const breadcrumbsEnabled = useUIStore((s) => s.breadcrumbsEnabled);
+  const chapterPinsEnabled = useUIStore((s) => s.chapterPinsEnabled);
   const addedImagesRef = useRef<Set<string>>(new Set());
   const prevLengthRef = useRef(0);
   const animFrameRef = useRef<number | null>(null);
+  const isPlaybackActive = playbackState === "playing" || playbackState === "paused";
+  const suppressBreadcrumbPins = chapterPinsEnabled && isPlaybackActive;
 
   // Initialize source and layer
   useEffect(() => {
@@ -261,9 +264,13 @@ export default function BreadcrumbTrail() {
       }
     }
 
-    if (!breadcrumbsEnabled || breadcrumbs.length === 0) {
+    if (!breadcrumbsEnabled || suppressBreadcrumbPins || breadcrumbs.length === 0) {
+      if (animFrameRef.current !== null) {
+        cancelAnimationFrame(animFrameRef.current);
+        animFrameRef.current = null;
+      }
       source.setData({ type: "FeatureCollection", features: [] });
-      prevLengthRef.current = 0;
+      prevLengthRef.current = breadcrumbs.length;
       return;
     }
 
@@ -320,7 +327,7 @@ export default function BreadcrumbTrail() {
     };
 
     loadAndUpdate();
-  }, [map, breadcrumbs, breadcrumbsEnabled, playbackState]);
+  }, [map, breadcrumbs, breadcrumbsEnabled, playbackState, suppressBreadcrumbPins]);
 
   // No DOM rendering — breadcrumbs are Mapbox layers
   return null;

--- a/src/components/editor/ChapterPinsOverlay.tsx
+++ b/src/components/editor/ChapterPinsOverlay.tsx
@@ -25,6 +25,13 @@ export default function ChapterPinsOverlay() {
 
   const [positions, setPositions] = useState<PinPosition[]>([]);
 
+  console.log(
+    "[ChapterPins] render, positions:",
+    positions.length,
+    "visited:",
+    visitedLocationIds.length,
+  );
+
   // Use refs to avoid recreating the callback when store data changes
   const locationsRef = useRef(locations);
   locationsRef.current = locations;


### PR DESCRIPTION
## Summary
- suppress breadcrumb photo thumbnails while chapter pins are active during playback
- keep breadcrumb state intact so thumbnails can still appear outside playback when enabled
- add the requested ChapterPinsOverlay render log for debugging render counts

## Verification
- npx tsc --noEmit
- npm run build