### PR TITLE
feat: add album pin collection animation

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/editor/ChapterPin.tsx
+++ b/src/components/editor/ChapterPin.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import type { Location } from "@/types";
 
-export type ChapterPinState = "active" | "visited" | "future";
+export type ChapterPinState =
+  | "future"
+  | "album-open"
+  | "album-collecting"
+  | "album-closed"
+  | "visited";
 
 interface ChapterPinProps {
   location: Location;
@@ -12,11 +17,194 @@ interface ChapterPinProps {
   position: { x: number; y: number };
 }
 
-const springTransition = {
+const SPRING_TRANSITION = {
   type: "spring" as const,
-  stiffness: 300,
-  damping: 22,
+  stiffness: 260,
+  damping: 24,
 };
+
+const VISITED_TRANSITION = {
+  duration: 1.35,
+  ease: [0.22, 1, 0.36, 1] as const,
+};
+
+function PinLabel({
+  emoji,
+  title,
+  compact = false,
+}: {
+  emoji?: string;
+  title: string;
+  compact?: boolean;
+}) {
+  return (
+    <span
+      className={`flex max-w-[112px] items-center justify-center gap-1 text-center font-medium text-stone-700 drop-shadow-sm ${
+        compact ? "text-[10px]" : "text-[11px]"
+      }`}
+    >
+      {emoji && <span className="shrink-0 text-xs leading-none">{emoji}</span>}
+      <span className="truncate">{title}</span>
+    </span>
+  );
+}
+
+function OpenAlbum({
+  location,
+  collecting,
+}: {
+  location: Location;
+  collecting: boolean;
+}) {
+  const coverPhoto = location.photos[0]?.url;
+  const stackCount = Math.min(Math.max(location.photos.length, 1), 4);
+
+  return (
+    <div className="relative flex flex-col items-center gap-1.5">
+      <motion.div
+        layout
+        className="relative"
+        animate={
+          collecting
+            ? {
+                rotate: -2,
+                y: [0, -2, 0],
+                scale: [1, 1.02, 1],
+              }
+            : {
+                rotate: -4,
+                y: 0,
+                scale: 1,
+              }
+        }
+        transition={
+          collecting
+            ? {
+                duration: 0.5,
+                ease: [0.4, 0, 0.2, 1],
+              }
+            : SPRING_TRANSITION
+        }
+      >
+        <div className="relative h-[60px] w-[84px] rounded-[20px] bg-gradient-to-br from-stone-100 via-white to-stone-200 shadow-[0_18px_30px_rgba(28,25,23,0.18)]">
+          <div className="absolute inset-y-[9px] left-[10px] right-1/2 rounded-[14px] border border-stone-200/80 bg-gradient-to-br from-white via-stone-50 to-stone-100 shadow-inner" />
+          <div className="absolute inset-y-[9px] right-[10px] left-1/2 rounded-[14px] border border-stone-200/80 bg-gradient-to-br from-white via-stone-50 to-stone-100 shadow-inner" />
+          <div className="absolute inset-y-[5px] left-1/2 w-[8px] -translate-x-1/2 rounded-full bg-gradient-to-b from-stone-300 via-stone-200 to-stone-400 opacity-80" />
+
+          {coverPhoto ? (
+            <>
+              <div className="absolute left-[16px] top-[16px] h-[22px] w-[20px] overflow-hidden rounded-[7px] border border-white/90 bg-white shadow-sm">
+                <img src={coverPhoto} alt="" className="h-full w-full object-cover" />
+              </div>
+              <div className="absolute right-[16px] top-[14px] h-[26px] w-[24px] overflow-hidden rounded-[8px] border border-white/90 bg-white shadow-sm">
+                <img src={coverPhoto} alt="" className="h-full w-full object-cover opacity-90" />
+              </div>
+            </>
+          ) : (
+            <div className="absolute inset-x-0 top-[18px] text-center text-lg leading-none">
+              {location.chapterEmoji || "📍"}
+            </div>
+          )}
+
+          <div className="absolute bottom-[10px] left-[15px] right-[15px] h-[2px] rounded-full bg-stone-200/90" />
+          <div className="absolute bottom-[16px] left-[15px] right-[24px] h-[2px] rounded-full bg-stone-200/80" />
+
+          <AnimatePresence initial={false}>
+            {collecting &&
+              Array.from({ length: stackCount }).map((_, index) => (
+                <motion.div
+                  key={`collecting-sheet-${index}`}
+                  initial={{
+                    opacity: 0,
+                    scale: 0.6,
+                    x: 12 + index * 4,
+                    y: -10 - index * 2,
+                    rotate: index % 2 === 0 ? -8 : 8,
+                  }}
+                  animate={{
+                    opacity: 0.88 - index * 0.14,
+                    scale: 1,
+                    x: 7 + index * 4,
+                    y: 3 + index * 2,
+                    rotate: index % 2 === 0 ? -6 : 6,
+                  }}
+                  exit={{ opacity: 0, scale: 0.7 }}
+                  transition={{
+                    duration: 0.28,
+                    delay: index * 0.06,
+                    ease: [0.2, 0.9, 0.2, 1],
+                  }}
+                  className="absolute top-[8px] h-[18px] w-[14px] rounded-[5px] border border-white/90 bg-white/85 shadow-sm"
+                />
+              ))}
+          </AnimatePresence>
+        </div>
+      </motion.div>
+      <PinLabel emoji={location.chapterEmoji} title={location.chapterTitle || location.name} />
+    </div>
+  );
+}
+
+function ClosedAlbum({ location }: { location: Location }) {
+  const coverPhoto = location.photos[0]?.url;
+
+  return (
+    <div className="relative flex flex-col items-center gap-1.5">
+      <motion.div
+        layout
+        className="relative h-12 w-12 overflow-hidden rounded-2xl border border-white/75 bg-stone-100 shadow-[0_16px_28px_rgba(15,23,42,0.22)]"
+        initial={{ scale: 0.88, rotate: -8, y: -4 }}
+        animate={{ scale: 1, rotate: -3, y: 0 }}
+        transition={{ duration: 0.3, ease: [0.34, 1.56, 0.64, 1] }}
+      >
+        {coverPhoto ? (
+          <img src={coverPhoto} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-stone-200 via-stone-50 to-stone-300 text-lg">
+            {location.chapterEmoji || "📍"}
+          </div>
+        )}
+        <div className="absolute inset-y-0 left-0 w-[8px] bg-gradient-to-r from-stone-900/28 to-transparent" />
+        <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/60" />
+        {location.chapterEmoji && (
+          <div className="absolute bottom-1.5 right-1.5 rounded-full bg-black/45 px-1 py-0.5 text-[10px] leading-none text-white shadow-sm">
+            {location.chapterEmoji}
+          </div>
+        )}
+      </motion.div>
+      <PinLabel
+        compact
+        emoji={location.chapterEmoji}
+        title={location.chapterTitle || location.name}
+      />
+    </div>
+  );
+}
+
+function VisitedPin({ location }: { location: Location }) {
+  const title = location.chapterTitle || location.name;
+  const coverPhoto = location.photos[0]?.url;
+  const emoji = location.chapterEmoji;
+
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <div className="relative">
+        {coverPhoto ? (
+          <img
+            src={coverPhoto}
+            alt=""
+            className="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
+          />
+        ) : (
+          <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-stone-100 text-sm shadow-sm">
+            {emoji || "📍"}
+          </div>
+        )}
+      </div>
+      <PinLabel compact emoji={emoji} title={title} />
+    </div>
+  );
+}
 
 export default function ChapterPin({
   location,
@@ -25,100 +213,52 @@ export default function ChapterPin({
 }: ChapterPinProps) {
   if (state === "future") return null;
 
-  const title = location.chapterTitle || location.name;
-  const coverPhoto = location.photos[0]?.url;
-  const emoji = location.chapterEmoji;
+  const isVisited = state === "visited";
 
-  if (state === "visited") {
-    return (
-      <motion.div
-        initial={{ scale: 1, opacity: 1 }}
-        animate={{ scale: 1, opacity: 0.5 }}
-        transition={{ duration: 0.4 }}
-        className="absolute pointer-events-none"
-        style={{
-          left: position.x,
-          top: position.y,
-          transform: "translate(-50%, -100%)",
-          zIndex: 5,
-        }}
-      >
-        <div className="flex flex-col items-center gap-0.5">
-          {/* Thumbnail */}
-          <div className="relative">
-            {coverPhoto ? (
-              <img
-                src={coverPhoto}
-                alt=""
-                className="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
-              />
-            ) : (
-              <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-indigo-100 text-sm shadow-sm">
-                {emoji || "📍"}
-              </div>
-            )}
-          </div>
-          {/* Title */}
-          <span className="flex items-center gap-0.5 max-w-[80px] text-center text-[10px] font-medium text-gray-700 drop-shadow-sm">
-            {emoji && <span className="shrink-0 text-xs leading-none">{emoji}</span>}
-            <span className="truncate">{title}</span>
-          </span>
-        </div>
-      </motion.div>
-    );
-  }
-
-  // Active state
   return (
     <motion.div
-      initial={{ scale: 0, opacity: 0 }}
-      animate={{ scale: 1, opacity: 1 }}
-      transition={springTransition}
+      layout
+      initial={{ scale: 0.85, opacity: 0 }}
+      animate={{
+        scale: isVisited ? 0.72 : 1,
+        opacity: isVisited ? 0.5 : 1,
+        y: isVisited ? 8 : 0,
+      }}
+      transition={isVisited ? VISITED_TRANSITION : SPRING_TRANSITION}
       className="absolute pointer-events-none"
       style={{
         left: position.x,
         top: position.y,
         transform: "translate(-50%, -100%)",
-        zIndex: 15,
+        zIndex: isVisited ? 5 : 15,
       }}
     >
-      <div className="flex max-w-[200px] gap-2.5 rounded-lg border border-white/20 bg-white/80 p-2 shadow-md backdrop-blur-sm">
-        {/* Cover photo */}
-        <div className="relative shrink-0">
-          {coverPhoto ? (
-            <img
-              src={coverPhoto}
-              alt=""
-              className="h-12 w-12 rounded-full border-2 border-white object-cover shadow-sm"
-            />
-          ) : (
-            <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-white bg-indigo-100 text-lg shadow-sm">
-              {emoji || "📍"}
-            </div>
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={state}
+          initial={{ opacity: 0, scale: 0.94, y: 8 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.94, y: -4 }}
+          transition={isVisited ? VISITED_TRANSITION : SPRING_TRANSITION}
+          className="flex flex-col items-center"
+        >
+          {(state === "album-open" || state === "album-collecting") && (
+            <>
+              <OpenAlbum location={location} collecting={state === "album-collecting"} />
+              <div className="mt-1 h-2 w-px bg-stone-400/55" />
+            </>
           )}
 
-        </div>
+          {state === "album-closed" && (
+            <>
+              <ClosedAlbum location={location} />
+              <div className="mt-1 h-2 w-px bg-stone-400/55" />
+            </>
+          )}
 
-        {/* Text content */}
-        <div className="min-w-0 flex-1 py-0.5">
-          <p className="flex items-center gap-1 truncate text-sm font-bold leading-tight text-gray-900">
-            {emoji && <span className="shrink-0 text-base leading-none">{emoji}</span>}
-            <span className="truncate">{title}</span>
-          </p>
-          {location.chapterDate && (
-            <p className="truncate text-xs leading-tight text-gray-500">
-              {location.chapterDate}
-            </p>
-          )}
-          {location.chapterNote && (
-            <p className="truncate text-xs leading-tight text-gray-600">
-              {location.chapterNote}
-            </p>
-          )}
-        </div>
-      </div>
-      {/* Pin tail */}
-      <div className="mx-auto h-2 w-px bg-gray-300" />
+          {state === "visited" && <VisitedPin location={location} />}
+        </motion.div>
+      </AnimatePresence>
     </motion.div>
   );
 }

--- a/src/components/editor/ChapterPinsOverlay.tsx
+++ b/src/components/editor/ChapterPinsOverlay.tsx
@@ -21,6 +21,9 @@ export default function ChapterPinsOverlay() {
   const playbackState = useAnimationStore((s) => s.playbackState);
   const visitedLocationIds = useAnimationStore((s) => s.visitedLocationIds);
   const currentArrivalLocationId = useAnimationStore((s) => s.currentArrivalLocationId);
+  const albumCollectingLocationId = useAnimationStore((s) => s.albumCollectingLocationId);
+  const albumClosedLocationId = useAnimationStore((s) => s.albumClosedLocationId);
+  const setChapterPinPositions = useAnimationStore((s) => s.setChapterPinPositions);
   const chapterPinsEnabled = useUIStore((s) => s.chapterPinsEnabled);
 
   const [positions, setPositions] = useState<PinPosition[]>([]);
@@ -32,6 +35,10 @@ export default function ChapterPinsOverlay() {
   visitedRef.current = visitedLocationIds;
   const arrivalRef = useRef(currentArrivalLocationId);
   arrivalRef.current = currentArrivalLocationId;
+  const collectingRef = useRef(albumCollectingLocationId);
+  collectingRef.current = albumCollectingLocationId;
+  const closedRef = useRef(albumClosedLocationId);
+  closedRef.current = albumClosedLocationId;
 
   const computePositions = useRef(() => {
     /* placeholder — replaced below */
@@ -42,6 +49,8 @@ export default function ChapterPinsOverlay() {
     const locs = locationsRef.current;
     const visited = visitedRef.current;
     const arrival = arrivalRef.current;
+    const collecting = collectingRef.current;
+    const closed = closedRef.current;
 
     const newPositions: PinPosition[] = [];
     const seenCoords = new Set<string>();
@@ -49,7 +58,9 @@ export default function ChapterPinsOverlay() {
       if (loc.isWaypoint) continue;
       const isVisited = visited.includes(loc.id);
       const isActive = loc.id === arrival;
-      if (!isVisited && !isActive) continue;
+      const isCollecting = loc.id === collecting;
+      const isClosed = loc.id === closed;
+      if (!isVisited && !isActive && !isCollecting && !isClosed) continue;
 
       // Deduplicate by coordinates — routes that revisit a city
       // (e.g. Seattle→...→Seattle) should show only one pin
@@ -65,6 +76,14 @@ export default function ChapterPinsOverlay() {
       });
     }
     setPositions(newPositions);
+    setChapterPinPositions(
+      Object.fromEntries(
+        newPositions.map((position) => [
+          position.locationId,
+          { x: position.x, y: position.y },
+        ]),
+      ),
+    );
   };
 
   // Update on map movement
@@ -85,10 +104,19 @@ export default function ChapterPinsOverlay() {
     if (!map) return;
     let prevVisited = useAnimationStore.getState().visitedLocationIds;
     let prevArrival = useAnimationStore.getState().currentArrivalLocationId;
+    let prevCollecting = useAnimationStore.getState().albumCollectingLocationId;
+    let prevClosed = useAnimationStore.getState().albumClosedLocationId;
     return useAnimationStore.subscribe((state) => {
-      if (state.visitedLocationIds !== prevVisited || state.currentArrivalLocationId !== prevArrival) {
+      if (
+        state.visitedLocationIds !== prevVisited ||
+        state.currentArrivalLocationId !== prevArrival ||
+        state.albumCollectingLocationId !== prevCollecting ||
+        state.albumClosedLocationId !== prevClosed
+      ) {
         prevVisited = state.visitedLocationIds;
         prevArrival = state.currentArrivalLocationId;
+        prevCollecting = state.albumCollectingLocationId;
+        prevClosed = state.albumClosedLocationId;
         computePositions.current();
       }
     });
@@ -104,8 +132,12 @@ export default function ChapterPinsOverlay() {
           if (!location) return null;
 
           let pinState: ChapterPinState = "future";
-          if (location.id === currentArrivalLocationId) {
-            pinState = "active";
+          if (location.id === albumCollectingLocationId) {
+            pinState = "album-collecting";
+          } else if (location.id === albumClosedLocationId) {
+            pinState = "album-closed";
+          } else if (location.id === currentArrivalLocationId) {
+            pinState = "album-open";
           } else if (visitedLocationIds.includes(location.id)) {
             pinState = "visited";
           }

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -110,6 +110,10 @@ function EditorContent() {
   const demoLoadedRef = useRef(false);
   const prevShowPhotosRef = useRef(false);
   const prevPhotoLocationIdRef = useRef<string | null>(null);
+  const prevPhaseRef = useRef<string | null>(null);
+  const activeAlbumSequenceLocationIdRef = useRef<string | null>(null);
+  const albumCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const albumVisitedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const setPlaybackState = useAnimationStore((s) => s.setPlaybackState);
   const setCurrentTime = useAnimationStore((s) => s.setCurrentTime);
@@ -129,6 +133,7 @@ function EditorContent() {
   const setCurrentGroupSegmentIndices = useAnimationStore(
     (s) => s.setCurrentGroupSegmentIndices,
   );
+  const setCurrentPhase = useAnimationStore((s) => s.setCurrentPhase);
   const setTimeline = useAnimationStore((s) => s.setTimeline);
   const setSceneTransitionProgress = useAnimationStore(
     (s) => s.setSceneTransitionProgress,
@@ -145,9 +150,12 @@ function EditorContent() {
 
   const setVisitedLocationIds = useAnimationStore((s) => s.setVisitedLocationIds);
   const setCurrentArrivalLocationId = useAnimationStore((s) => s.setCurrentArrivalLocationId);
+  const setAlbumCollectingLocationId = useAnimationStore(
+    (s) => s.setAlbumCollectingLocationId,
+  );
+  const setAlbumClosedLocationId = useAnimationStore((s) => s.setAlbumClosedLocationId);
   const addBreadcrumb = useAnimationStore((s) => s.addBreadcrumb);
   const setBreadcrumbs = useAnimationStore((s) => s.setBreadcrumbs);
-  const clearBreadcrumbs = useAnimationStore((s) => s.clearBreadcrumbs);
   const reset = useAnimationStore((s) => s.reset);
 
   const cityLabelSize = useUIStore((s) => s.cityLabelSize);
@@ -172,6 +180,60 @@ function EditorContent() {
       ),
     [availableStageSize.height, availableStageSize.width, viewportRatio],
   );
+
+  const clearAlbumSequenceTimers = useCallback(() => {
+    if (albumCloseTimerRef.current) {
+      clearTimeout(albumCloseTimerRef.current);
+      albumCloseTimerRef.current = null;
+    }
+    if (albumVisitedTimerRef.current) {
+      clearTimeout(albumVisitedTimerRef.current);
+      albumVisitedTimerRef.current = null;
+    }
+  }, []);
+
+  const resetAlbumSequenceState = useCallback(() => {
+    clearAlbumSequenceTimers();
+    activeAlbumSequenceLocationIdRef.current = null;
+    setAlbumCollectingLocationId(null);
+    setAlbumClosedLocationId(null);
+  }, [
+    clearAlbumSequenceTimers,
+    setAlbumClosedLocationId,
+    setAlbumCollectingLocationId,
+  ]);
+
+  const startAlbumSequence = useCallback((locationId: string) => {
+    clearAlbumSequenceTimers();
+    activeAlbumSequenceLocationIdRef.current = locationId;
+    setAlbumClosedLocationId(null);
+    setAlbumCollectingLocationId(locationId);
+    setShowPhotoOverlay(true);
+    setPhotoOverlayOpacity(0);
+
+    albumCloseTimerRef.current = setTimeout(() => {
+      if (activeAlbumSequenceLocationIdRef.current !== locationId) return;
+
+      setShowPhotoOverlay(false);
+      setAlbumCollectingLocationId(null);
+      setAlbumClosedLocationId(locationId);
+      activeAlbumSequenceLocationIdRef.current = null;
+      albumCloseTimerRef.current = null;
+
+      albumVisitedTimerRef.current = setTimeout(() => {
+        if (useAnimationStore.getState().albumClosedLocationId === locationId) {
+          setAlbumClosedLocationId(null);
+        }
+        albumVisitedTimerRef.current = null;
+      }, 300);
+    }, 500);
+  }, [
+    clearAlbumSequenceTimers,
+    setAlbumClosedLocationId,
+    setAlbumCollectingLocationId,
+    setPhotoOverlayOpacity,
+    setShowPhotoOverlay,
+  ]);
 
   useEffect(() => {
     const stageViewport = stageViewportRef.current;
@@ -398,6 +460,8 @@ function EditorContent() {
       engineRef.current = null;
     }
     reset();
+    resetAlbumSequenceState();
+    prevPhaseRef.current = null;
 
     if (!map || segments.length === 0) return;
 
@@ -418,10 +482,27 @@ function EditorContent() {
       setCurrentTime(e.time);
       setCurrentSegmentIndex(e.segmentIndex);
       setCurrentGroupSegmentIndices(e.groupSegmentIndices);
+      setCurrentPhase(e.phase);
       setCurrentCityLabel(e.cityLabel);
       setCurrentCityLabelZh(e.cityLabelZh);
-      setShowPhotoOverlay(e.showPhotos);
-      setPhotoOverlayOpacity(e.photoOpacity);
+
+      const previousPhase = prevPhaseRef.current;
+      const previousPhotoLocationId = prevPhotoLocationIdRef.current;
+      const shouldStartAlbumSequence =
+        previousPhase === "ARRIVE" &&
+        e.phase !== "ARRIVE" &&
+        previousPhotoLocationId !== null &&
+        activeAlbumSequenceLocationIdRef.current !== previousPhotoLocationId;
+
+      if (e.showPhotos && e.phase === "ARRIVE") {
+        setShowPhotoOverlay(true);
+        setPhotoOverlayOpacity(1);
+      } else if (shouldStartAlbumSequence) {
+        startAlbumSequence(previousPhotoLocationId);
+      } else if (!e.showPhotos && activeAlbumSequenceLocationIdRef.current === null) {
+        setShowPhotoOverlay(false);
+        setPhotoOverlayOpacity(0);
+      }
       // Chapter pin tracking: derive visited/arrival state from current time
       // (recomputed from scratch so seek/scrub always produces correct state)
       {
@@ -521,6 +602,7 @@ function EditorContent() {
         const seg = segments[e.segmentIndex];
         prevPhotoLocationIdRef.current = seg?.toId ?? null;
       }
+      prevPhaseRef.current = e.phase;
 
       // Scene transition metadata
       setSceneTransitionProgress(e.sceneTransitionProgress);
@@ -625,8 +707,38 @@ function EditorContent() {
 
     return () => {
       engine.destroy();
+      clearAlbumSequenceTimers();
     };
-  }, [map, locations, segments, segmentTimingOverrides]);
+  }, [
+    addBreadcrumb,
+    clearAlbumSequenceTimers,
+    locations,
+    map,
+    reset,
+    resetAlbumSequenceState,
+    segmentTimingOverrides,
+    segments,
+    setBloomElapsedTime,
+    setCurrentArrivalLocationId,
+    setCurrentCityLabel,
+    setCurrentCityLabelZh,
+    setCurrentGroupSegmentIndices,
+    setCurrentPhase,
+    setCurrentSegmentIndex,
+    setCurrentTime,
+    setIncomingPhotoLocationId,
+    setIncomingPhotos,
+    setPhotoOverlayOpacity,
+    setPlaybackState,
+    setSceneTransitionProgress,
+    setShowPhotoOverlay,
+    setTimeline,
+    setTotalDuration,
+    setTransitionBearing,
+    setVisiblePhotos,
+    setVisitedLocationIds,
+    startAlbumSequence,
+  ]);
 
   const handlePlay = useCallback(() => {
     // Immediately hide all future segment layers on the map
@@ -655,15 +767,28 @@ function EditorContent() {
 
   const handleReset = useCallback(() => {
     engineRef.current?.reset();
+    clearAlbumSequenceTimers();
     reset();
     prevShowPhotosRef.current = false;
     prevPhotoLocationIdRef.current = null;
-  }, [reset]);
+    prevPhaseRef.current = null;
+    activeAlbumSequenceLocationIdRef.current = null;
+    setAlbumCollectingLocationId(null);
+    setAlbumClosedLocationId(null);
+  }, [
+    clearAlbumSequenceTimers,
+    reset,
+    setAlbumClosedLocationId,
+    setAlbumCollectingLocationId,
+  ]);
 
   const handleSeek = useCallback((progress: number) => {
     const engine = engineRef.current;
     if (!engine) return;
 
+    clearAlbumSequenceTimers();
+    setAlbumCollectingLocationId(null);
+    setAlbumClosedLocationId(null);
     engine.seekTo(progress);
 
     // Rebuild breadcrumb state for the seek position
@@ -695,7 +820,16 @@ function EditorContent() {
     // Reset transition tracking refs to match seek state
     prevShowPhotosRef.current = false;
     prevPhotoLocationIdRef.current = null;
-  }, [setBreadcrumbs]);
+    prevPhaseRef.current = null;
+    activeAlbumSequenceLocationIdRef.current = null;
+  }, [
+    clearAlbumSequenceTimers,
+    setAlbumClosedLocationId,
+    setAlbumCollectingLocationId,
+    setBreadcrumbs,
+  ]);
+
+  useEffect(() => () => clearAlbumSequenceTimers(), [clearAlbumSequenceTimers]);
 
   const handleEditLayout = useCallback((locationId: string) => {
     setEditingLocationId(locationId);

--- a/src/components/editor/MapStage.tsx
+++ b/src/components/editor/MapStage.tsx
@@ -159,6 +159,7 @@ export default function MapStage({
   const incomingPhotos = useAnimationStore((s) => s.incomingPhotos);
   const incomingPhotoLocationId = useAnimationStore((s) => s.incomingPhotoLocationId);
   const transitionBearing = useAnimationStore((s) => s.transitionBearing);
+  const chapterPinPositions = useAnimationStore((s) => s.chapterPinPositions);
   const visiblePhotoLocation = locations.find((location) => location.id === photoLocationId);
   const incomingLocation = locations.find((location) => location.id === incomingPhotoLocationId);
   const effectiveTransition = resolveSceneTransition(photoLayout, globalSceneTransition);
@@ -239,6 +240,7 @@ export default function MapStage({
         opacity={photoOverlayOpacity}
         bloomOrigin={bloomOrigin}
         bloomElapsedTime={bloomElapsedTime}
+        flyToPosition={photoLocationId ? chapterPinPositions[photoLocationId] ?? null : null}
         sceneTransition={effectiveTransition}
         sceneTransitionProgress={isTransitioning ? sceneTransitionProgress : undefined}
         incomingPhotos={isTransitioning ? incomingPhotos : undefined}

--- a/src/components/editor/PhotoOverlay.tsx
+++ b/src/components/editor/PhotoOverlay.tsx
@@ -185,6 +185,29 @@ function getExitValues(
   }
 }
 
+function getFlyToAlbumValues(
+  rect: PhotoRect,
+  containerSize: { w: number; h: number },
+  overlayOffset: { x: number; y: number },
+  targetPosition: { x: number; y: number },
+  index: number,
+) {
+  const photoCenterX = (rect.x + rect.width / 2) * containerSize.w;
+  const photoCenterY = (rect.y + rect.height / 2) * containerSize.h;
+  const targetX = targetPosition.x - overlayOffset.x;
+  const targetY = targetPosition.y - overlayOffset.y - 52;
+
+  return {
+    exitOpacity: 0,
+    exitScale: 0.15,
+    exitX: targetX - photoCenterX,
+    exitY: targetY - photoCenterY,
+    exitBlur: 2,
+    exitRotate: index % 2 === 0 ? -8 : 8,
+    exitRotateY: 0,
+  };
+}
+
 interface PhotoOverlayProps {
   photos: Photo[];
   visible: boolean;
@@ -201,6 +224,8 @@ interface PhotoOverlayProps {
   bloomOrigin?: { x: number; y: number } | null;
   /** Timeline-driven elapsed time (seconds) since bloom enter started */
   bloomElapsedTime?: number;
+  /** Screen-space chapter pin position from map.project() */
+  flyToPosition?: { x: number; y: number } | null;
   /** Active scene transition type */
   sceneTransition?: SceneTransition;
   /** Scene transition progress (0-1): 0 = fully outgoing, 1 = fully incoming */
@@ -274,6 +299,7 @@ export default function PhotoOverlay({
   portalProgressOverride,
   bloomOrigin,
   bloomElapsedTime = 0,
+  flyToPosition,
   sceneTransition,
   sceneTransitionProgress,
   incomingPhotos,
@@ -302,6 +328,11 @@ export default function PhotoOverlay({
   const { enterAnimation, exitAnimation } = resolvePhotoAnimations(displayLayout, photoAnimation);
   const photoStyle = resolvePhotoStyle(displayLayout, globalPhotoStyle);
   const incomingPhotoStyleResolved = resolvePhotoStyle(incomingPhotoLayout, globalPhotoStyle);
+  const isActiveTransition = Boolean(
+    sceneTransition && sceneTransition !== "cut" && sceneTransitionProgress !== undefined,
+  );
+  const overlayExitProgress = isActiveTransition ? 0 : 1 - opacity;
+  const shouldFlyToAlbum = overlayExitProgress > 0 && flyToPosition != null;
   const usesPortalLayout = photoStyle === "portal" || incomingPhotoStyleResolved === "portal";
 
   const containerStyle = useMemo(() => {
@@ -440,7 +471,6 @@ export default function PhotoOverlay({
   const incomingIsFreeMode = incomingPhotoLayout?.mode === "free";
 
   // Scene transition: compute outgoing wrapper styles
-  const isActiveTransition = sceneTransition && sceneTransition !== "cut" && sceneTransitionProgress !== undefined;
   const transitionOutgoingStyle = useMemo<React.CSSProperties>(() => {
     if (!isActiveTransition || sceneTransitionProgress === undefined) return {};
     switch (sceneTransition) {
@@ -598,7 +628,7 @@ export default function PhotoOverlay({
       }}
     >
       <div className="absolute inset-0" style={{ pointerEvents: "none", ...transitionOutgoingStyle }}>
-        {hasDisplayPhotos && photoStyle === "portal" ? (
+        {hasDisplayPhotos && photoStyle === "portal" && !shouldFlyToAlbum ? (
           <PortalPhotoLayer
             photos={orderedMetas as PortalPhoto[]}
             containerSize={containerSize}
@@ -657,12 +687,12 @@ export default function PhotoOverlay({
                 ? (index === 0 ? -2 : index === total - 1 ? 2 : 0)
                 : (index % 2 === 0 ? -1.5 : 1.5);
 
-            const exitProgress = isActiveTransition ? 0 : 1 - opacity;
+            const exitProgress = overlayExitProgress;
             const staggerOffset = total > 1 ? (total - 1 - index) / (total - 1) * 0.4 : 0;
             const photoExitT = Math.max(0, Math.min(1, (exitProgress - staggerOffset) / (1 - staggerOffset + 0.01)));
 
             // ── Bloom style: geo-anchored animation ──
-            if (isBloom && bloomOrigin && containerSize.w > 0) {
+            if (isBloom && bloomOrigin && containerSize.w > 0 && !shouldFlyToAlbum) {
               // Convert raw map.project() pixels to overlay-local pixels
               const overlayOffsetX = containerRef.current?.offsetLeft ?? 0;
               const overlayOffsetY = containerRef.current?.offsetTop ?? 0;
@@ -769,12 +799,35 @@ export default function PhotoOverlay({
             const enterDelay = typeof (enter.transition as { delay?: number }).delay === "number"
               ? (enter.transition as { delay?: number }).delay!
               : 0;
+            const overlayOffset = {
+              x: containerRef.current?.offsetLeft ?? 0,
+              y: containerRef.current?.offsetTop ?? 0,
+            };
+            const flyToAlbumExit = shouldFlyToAlbum && flyToPosition
+              ? getFlyToAlbumValues(
+                  rect,
+                  containerSize,
+                  overlayOffset,
+                  flyToPosition,
+                  index,
+                )
+              : null;
             const exit = getExitValues(exitAnimation, exitProgress, photoExitT, index);
 
             const enterRotate = typeof (enter.animate as { rotate?: number }).rotate === "number"
               ? (enter.animate as { rotate?: number }).rotate! + rotation
               : rotation;
-            const animateValues: TargetAndTransition = exitProgress > 0
+            const animateValues: TargetAndTransition = flyToAlbumExit
+              ? {
+                  opacity: flyToAlbumExit.exitOpacity,
+                  scale: flyToAlbumExit.exitScale,
+                  x: flyToAlbumExit.exitX,
+                  y: flyToAlbumExit.exitY,
+                  filter: `blur(${flyToAlbumExit.exitBlur}px)`,
+                  rotate: flyToAlbumExit.exitRotate + rotation,
+                  rotateY: undefined,
+                }
+              : exitProgress > 0
               ? {
                   opacity: exit.exitOpacity,
                   scale: exit.exitScale,
@@ -792,7 +845,9 @@ export default function PhotoOverlay({
                   key={photo.id}
                   initial={enter.initial}
                   animate={animateValues}
-                  transition={exitProgress > 0
+                  transition={flyToAlbumExit
+                    ? { duration: 0.5, ease: [0.4, 0, 0.2, 1] }
+                    : exitProgress > 0
                     ? { duration: 0.5, ease: "easeOut" }
                     : enter.transition
                   }
@@ -885,11 +940,24 @@ export default function PhotoOverlay({
                     <motion.div
                       key={`${photo.id}-caption`}
                       initial={enter.initial}
-                      animate={exitProgress > 0
+                      animate={flyToAlbumExit
+                        ? {
+                            opacity: flyToAlbumExit.exitOpacity,
+                            scale: flyToAlbumExit.exitScale,
+                            x: flyToAlbumExit.exitX,
+                            y: flyToAlbumExit.exitY,
+                          }
+                        : exitProgress > 0
                         ? { opacity: exit.exitOpacity, scale: exit.exitScale, x: exit.exitX, y: exit.exitY }
                         : enter.animate
                       }
-                      transition={exitProgress > 0 ? { duration: 0.5, ease: "easeOut" } : enter.transition}
+                      transition={
+                        flyToAlbumExit
+                          ? { duration: 0.5, ease: [0.4, 0, 0.2, 1] }
+                          : exitProgress > 0
+                            ? { duration: 0.5, ease: "easeOut" }
+                            : enter.transition
+                      }
                       className="whitespace-nowrap rounded-md px-2 py-1 text-center shadow-sm"
                       style={{
                         transform: `rotate(${captionDisplay.rotation}deg)`,

--- a/src/stores/animationStore.ts
+++ b/src/stores/animationStore.ts
@@ -9,6 +9,11 @@ export interface Breadcrumb {
   visitedAtSegment: number;      // segment index when this was visited
 }
 
+export interface ScreenPoint {
+  x: number;
+  y: number;
+}
+
 interface AnimationState {
   playbackState: PlaybackState;
   currentTime: number;
@@ -38,6 +43,12 @@ interface AnimationState {
   visitedLocationIds: string[];
   /** ID of the location currently arriving at (active chapter pin) */
   currentArrivalLocationId: string | null;
+  /** ID of the location whose album is currently collecting flying photos */
+  albumCollectingLocationId: string | null;
+  /** ID of the location whose album has snapped shut after collecting photos */
+  albumClosedLocationId: string | null;
+  /** Current projected screen positions for visible chapter pins */
+  chapterPinPositions: Record<string, ScreenPoint>;
   /** Breadcrumb thumbnails left at visited locations */
   breadcrumbs: Breadcrumb[];
 
@@ -62,6 +73,9 @@ interface AnimationState {
   setVisitedLocationIds: (ids: string[]) => void;
   addVisitedLocationId: (id: string) => void;
   setCurrentArrivalLocationId: (id: string | null) => void;
+  setAlbumCollectingLocationId: (id: string | null) => void;
+  setAlbumClosedLocationId: (id: string | null) => void;
+  setChapterPinPositions: (positions: Record<string, ScreenPoint>) => void;
   addBreadcrumb: (b: Breadcrumb) => void;
   setBreadcrumbs: (breadcrumbs: Breadcrumb[]) => void;
   clearBreadcrumbs: () => void;
@@ -89,6 +103,9 @@ export const useAnimationStore = create<AnimationState>((set) => ({
   bloomElapsedTime: 0,
   visitedLocationIds: [],
   currentArrivalLocationId: null,
+  albumCollectingLocationId: null,
+  albumClosedLocationId: null,
+  chapterPinPositions: {},
   breadcrumbs: [],
 
   setPlaybackState: (playbackState) => set({ playbackState }),
@@ -117,6 +134,9 @@ export const useAnimationStore = create<AnimationState>((set) => ({
         : [...state.visitedLocationIds, id],
     })),
   setCurrentArrivalLocationId: (currentArrivalLocationId) => set({ currentArrivalLocationId }),
+  setAlbumCollectingLocationId: (albumCollectingLocationId) => set({ albumCollectingLocationId }),
+  setAlbumClosedLocationId: (albumClosedLocationId) => set({ albumClosedLocationId }),
+  setChapterPinPositions: (chapterPinPositions) => set({ chapterPinPositions }),
   addBreadcrumb: (b) =>
     set((state) => {
       // Don't add duplicate breadcrumbs for the same location
@@ -145,6 +165,9 @@ export const useAnimationStore = create<AnimationState>((set) => ({
       bloomElapsedTime: 0,
       visitedLocationIds: [],
       currentArrivalLocationId: null,
+      albumCollectingLocationId: null,
+      albumClosedLocationId: null,
+      chapterPinPositions: {},
       breadcrumbs: [],
     }),
 }));


### PR DESCRIPTION
## Summary
- redesign chapter pins into album open, collecting, closed, and visited states
- add fixed 0.5s photo fly-to-pin exit and wire it across photo styles
- coordinate the album collection/close/visited timing from the editor playback flow

## Verification
- npx tsc --noEmit
- npm run build