### PR TITLE
Fix album pin animation reimplementation

### DIFF
--- a/src/components/editor/ChapterPin.tsx
+++ b/src/components/editor/ChapterPin.tsx
@@ -1,22 +1,269 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import type { Location } from "@/types";
 
-export type ChapterPinState = "active" | "visited" | "future";
+export type ChapterPinState =
+  | "future"
+  | "album-open"
+  | "album-collecting"
+  | "album-closed"
+  | "visited";
 
 interface ChapterPinProps {
   location: Location;
   state: ChapterPinState;
-  /** Screen-space position from map.project() */
   position: { x: number; y: number };
 }
 
-const springTransition = {
+const SPRING_TRANSITION = {
   type: "spring" as const,
-  stiffness: 300,
-  damping: 22,
+  stiffness: 260,
+  damping: 24,
 };
+
+const VISITED_TRANSITION = {
+  duration: 1.35,
+  ease: [0.22, 1, 0.36, 1] as const,
+};
+
+const OPEN_ALBUM_GEOMETRY = {
+  bodyHeight: 60,
+  labelGap: 6,
+  labelHeight: 16,
+  tailGap: 4,
+  tailHeight: 8,
+};
+
+const CLOSED_ALBUM_GEOMETRY = {
+  bodyHeight: 48,
+  labelGap: 6,
+  labelHeight: 16,
+  tailGap: 4,
+  tailHeight: 8,
+};
+
+const VISITED_GEOMETRY = {
+  bodyHeight: 32,
+  labelGap: 2,
+  labelHeight: 14,
+};
+
+export function getChapterPinTargetOffset(
+  state: Exclude<ChapterPinState, "future">,
+): { x: number; y: number } {
+  if (state === "visited") {
+    return {
+      x: 0,
+      y:
+        -(VISITED_GEOMETRY.labelHeight +
+          VISITED_GEOMETRY.labelGap +
+          VISITED_GEOMETRY.bodyHeight / 2),
+    };
+  }
+
+  const geometry =
+    state === "album-closed" ? CLOSED_ALBUM_GEOMETRY : OPEN_ALBUM_GEOMETRY;
+
+  return {
+    x: 0,
+    y:
+      -(geometry.tailHeight +
+        geometry.tailGap +
+        geometry.labelHeight +
+        geometry.labelGap +
+        geometry.bodyHeight / 2),
+  };
+}
+
+function PinLabel({
+  emoji,
+  title,
+  compact = false,
+}: {
+  emoji?: string;
+  title: string;
+  compact?: boolean;
+}) {
+  return (
+    <span
+      className={`flex max-w-[112px] items-center justify-center gap-1 text-center font-medium text-stone-700 drop-shadow-sm ${
+        compact ? "text-[10px]" : "text-[11px]"
+      }`}
+    >
+      {emoji && <span className="shrink-0 text-xs leading-none">{emoji}</span>}
+      <span className="truncate">{title}</span>
+    </span>
+  );
+}
+
+function OpenAlbum({
+  location,
+  collecting,
+}: {
+  location: Location;
+  collecting: boolean;
+}) {
+  const coverPhoto = location.photos[0]?.url;
+  const stackCount = Math.min(Math.max(location.photos.length, 1), 4);
+
+  return (
+    <div className="relative flex flex-col items-center gap-1.5">
+      <motion.div
+        layout
+        className="relative"
+        animate={
+          collecting
+            ? {
+                rotate: -2,
+                y: [0, -2, 0],
+                scale: [1, 1.02, 1],
+              }
+            : {
+                rotate: -4,
+                y: 0,
+                scale: 1,
+              }
+        }
+        transition={
+          collecting
+            ? {
+                duration: 0.5,
+                ease: [0.4, 0, 0.2, 1],
+              }
+            : SPRING_TRANSITION
+        }
+      >
+        <div className="relative h-[60px] w-[84px] rounded-[20px] bg-gradient-to-br from-stone-100 via-white to-stone-200 shadow-[0_18px_30px_rgba(28,25,23,0.18)]">
+          <div className="absolute inset-y-[9px] left-[10px] right-1/2 rounded-[14px] border border-stone-200/80 bg-gradient-to-br from-white via-stone-50 to-stone-100 shadow-inner" />
+          <div className="absolute inset-y-[9px] left-1/2 right-[10px] rounded-[14px] border border-stone-200/80 bg-gradient-to-br from-white via-stone-50 to-stone-100 shadow-inner" />
+          <div className="absolute inset-y-[5px] left-1/2 w-[8px] -translate-x-1/2 rounded-full bg-gradient-to-b from-stone-300 via-stone-200 to-stone-400 opacity-80" />
+
+          {coverPhoto ? (
+            <>
+              <div className="absolute left-[16px] top-[16px] h-[22px] w-[20px] overflow-hidden rounded-[7px] border border-white/90 bg-white shadow-sm">
+                <img
+                  src={coverPhoto}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+              </div>
+              <div className="absolute right-[16px] top-[14px] h-[26px] w-[24px] overflow-hidden rounded-[8px] border border-white/90 bg-white shadow-sm">
+                <img
+                  src={coverPhoto}
+                  alt=""
+                  className="h-full w-full object-cover opacity-90"
+                />
+              </div>
+            </>
+          ) : (
+            <div className="absolute inset-x-0 top-[18px] text-center text-lg leading-none">
+              {location.chapterEmoji || "📍"}
+            </div>
+          )}
+
+          <div className="absolute bottom-[10px] left-[15px] right-[15px] h-[2px] rounded-full bg-stone-200/90" />
+          <div className="absolute bottom-[16px] left-[15px] right-[24px] h-[2px] rounded-full bg-stone-200/80" />
+
+          <AnimatePresence initial={false}>
+            {collecting &&
+              Array.from({ length: stackCount }).map((_, index) => (
+                <motion.div
+                  key={`collecting-sheet-${index}`}
+                  initial={{
+                    opacity: 0,
+                    scale: 0.6,
+                    x: 12 + index * 4,
+                    y: -10 - index * 2,
+                    rotate: index % 2 === 0 ? -8 : 8,
+                  }}
+                  animate={{
+                    opacity: 0.88 - index * 0.14,
+                    scale: 1,
+                    x: 7 + index * 4,
+                    y: 3 + index * 2,
+                    rotate: index % 2 === 0 ? -6 : 6,
+                  }}
+                  exit={{ opacity: 0, scale: 0.7 }}
+                  transition={{
+                    duration: 0.28,
+                    delay: index * 0.06,
+                    ease: [0.2, 0.9, 0.2, 1],
+                  }}
+                  className="absolute top-[8px] h-[18px] w-[14px] rounded-[5px] border border-white/90 bg-white/85 shadow-sm"
+                />
+              ))}
+          </AnimatePresence>
+        </div>
+      </motion.div>
+      <PinLabel
+        emoji={location.chapterEmoji}
+        title={location.chapterTitle || location.name}
+      />
+    </div>
+  );
+}
+
+function ClosedAlbum({ location }: { location: Location }) {
+  const coverPhoto = location.photos[0]?.url;
+
+  return (
+    <div className="relative flex flex-col items-center gap-1.5">
+      <motion.div
+        layout
+        className="relative h-12 w-12 overflow-hidden rounded-2xl border border-white/75 bg-stone-100 shadow-[0_16px_28px_rgba(15,23,42,0.22)]"
+        initial={{ scale: 0.88, rotate: -8, y: -4 }}
+        animate={{ scale: 1, rotate: -3, y: 0 }}
+        transition={{ duration: 0.3, ease: [0.34, 1.56, 0.64, 1] }}
+      >
+        {coverPhoto ? (
+          <img src={coverPhoto} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-stone-200 via-stone-50 to-stone-300 text-lg">
+            {location.chapterEmoji || "📍"}
+          </div>
+        )}
+        <div className="absolute inset-y-0 left-0 w-[8px] bg-gradient-to-r from-stone-900/28 to-transparent" />
+        <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/60" />
+        {location.chapterEmoji && (
+          <div className="absolute bottom-1.5 right-1.5 rounded-full bg-black/45 px-1 py-0.5 text-[10px] leading-none text-white shadow-sm">
+            {location.chapterEmoji}
+          </div>
+        )}
+      </motion.div>
+      <PinLabel
+        compact
+        emoji={location.chapterEmoji}
+        title={location.chapterTitle || location.name}
+      />
+    </div>
+  );
+}
+
+function VisitedPin({ location }: { location: Location }) {
+  const title = location.chapterTitle || location.name;
+  const coverPhoto = location.photos[0]?.url;
+  const emoji = location.chapterEmoji;
+
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <div className="relative">
+        {coverPhoto ? (
+          <img
+            src={coverPhoto}
+            alt=""
+            className="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
+          />
+        ) : (
+          <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-stone-100 text-sm shadow-sm">
+            {emoji || "📍"}
+          </div>
+        )}
+      </div>
+      <PinLabel compact emoji={emoji} title={title} />
+    </div>
+  );
+}
 
 export default function ChapterPin({
   location,
@@ -25,100 +272,55 @@ export default function ChapterPin({
 }: ChapterPinProps) {
   if (state === "future") return null;
 
-  const title = location.chapterTitle || location.name;
-  const coverPhoto = location.photos[0]?.url;
-  const emoji = location.chapterEmoji;
+  const isVisited = state === "visited";
 
-  if (state === "visited") {
-    return (
-      <motion.div
-        initial={{ scale: 1, opacity: 1 }}
-        animate={{ scale: 1, opacity: 0.5 }}
-        transition={{ duration: 0.4 }}
-        className="absolute pointer-events-none"
-        style={{
-          left: position.x,
-          top: position.y,
-          transform: "translate(-50%, -100%)",
-          zIndex: 5,
-        }}
-      >
-        <div className="flex flex-col items-center gap-0.5">
-          {/* Thumbnail */}
-          <div className="relative">
-            {coverPhoto ? (
-              <img
-                src={coverPhoto}
-                alt=""
-                className="h-8 w-8 rounded-full border-2 border-white object-cover shadow-sm"
-              />
-            ) : (
-              <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-indigo-100 text-sm shadow-sm">
-                {emoji || "📍"}
-              </div>
-            )}
-          </div>
-          {/* Title */}
-          <span className="flex items-center gap-0.5 max-w-[80px] text-center text-[10px] font-medium text-gray-700 drop-shadow-sm">
-            {emoji && <span className="shrink-0 text-xs leading-none">{emoji}</span>}
-            <span className="truncate">{title}</span>
-          </span>
-        </div>
-      </motion.div>
-    );
-  }
-
-  // Active state
   return (
     <motion.div
-      initial={{ scale: 0, opacity: 0 }}
-      animate={{ scale: 1, opacity: 1 }}
-      transition={springTransition}
-      className="absolute pointer-events-none"
+      layout
+      initial={{ scale: 0.85, opacity: 0 }}
+      animate={{
+        scale: isVisited ? 0.72 : 1,
+        opacity: isVisited ? 0.5 : 1,
+        y: isVisited ? 8 : 0,
+      }}
+      transition={isVisited ? VISITED_TRANSITION : SPRING_TRANSITION}
+      className="pointer-events-none absolute"
       style={{
         left: position.x,
         top: position.y,
         transform: "translate(-50%, -100%)",
-        zIndex: 15,
+        zIndex: isVisited ? 5 : 15,
       }}
     >
-      <div className="flex max-w-[200px] gap-2.5 rounded-lg border border-white/20 bg-white/80 p-2 shadow-md backdrop-blur-sm">
-        {/* Cover photo */}
-        <div className="relative shrink-0">
-          {coverPhoto ? (
-            <img
-              src={coverPhoto}
-              alt=""
-              className="h-12 w-12 rounded-full border-2 border-white object-cover shadow-sm"
-            />
-          ) : (
-            <div className="flex h-12 w-12 items-center justify-center rounded-full border-2 border-white bg-indigo-100 text-lg shadow-sm">
-              {emoji || "📍"}
-            </div>
+      <AnimatePresence mode="sync" initial={false}>
+        <motion.div
+          key={state}
+          initial={{ opacity: 0, scale: 0.94, y: 8 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.94, y: -4 }}
+          transition={isVisited ? VISITED_TRANSITION : SPRING_TRANSITION}
+          className="flex flex-col items-center"
+        >
+          {(state === "album-open" || state === "album-collecting") && (
+            <>
+              <OpenAlbum
+                location={location}
+                collecting={state === "album-collecting"}
+              />
+              <div className="mt-1 h-2 w-px bg-stone-400/55" />
+            </>
           )}
 
-        </div>
+          {state === "album-closed" && (
+            <>
+              <ClosedAlbum location={location} />
+              <div className="mt-1 h-2 w-px bg-stone-400/55" />
+            </>
+          )}
 
-        {/* Text content */}
-        <div className="min-w-0 flex-1 py-0.5">
-          <p className="flex items-center gap-1 truncate text-sm font-bold leading-tight text-gray-900">
-            {emoji && <span className="shrink-0 text-base leading-none">{emoji}</span>}
-            <span className="truncate">{title}</span>
-          </p>
-          {location.chapterDate && (
-            <p className="truncate text-xs leading-tight text-gray-500">
-              {location.chapterDate}
-            </p>
-          )}
-          {location.chapterNote && (
-            <p className="truncate text-xs leading-tight text-gray-600">
-              {location.chapterNote}
-            </p>
-          )}
-        </div>
-      </div>
-      {/* Pin tail */}
-      <div className="mx-auto h-2 w-px bg-gray-300" />
+          {state === "visited" && <VisitedPin location={location} />}
+        </motion.div>
+      </AnimatePresence>
     </motion.div>
   );
 }

--- a/src/components/editor/ChapterPinsOverlay.tsx
+++ b/src/components/editor/ChapterPinsOverlay.tsx
@@ -1,18 +1,57 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
-
-import ChapterPin from "./ChapterPin";
-import type { ChapterPinState } from "./ChapterPin";
+import { useEffect, useRef, useState } from "react";
+import ChapterPin, {
+  getChapterPinTargetOffset,
+  type ChapterPinState,
+} from "./ChapterPin";
 import { useMap } from "./MapContext";
 import { useProjectStore } from "@/stores/projectStore";
-import { useAnimationStore } from "@/stores/animationStore";
+import {
+  useAnimationStore,
+  type ScreenPoint,
+} from "@/stores/animationStore";
 import { useUIStore } from "@/stores/uiStore";
 
 interface PinPosition {
   locationId: string;
   x: number;
   y: number;
+  state: Exclude<ChapterPinState, "future">;
+}
+
+function arePinPositionsEqual(a: PinPosition[], b: PinPosition[]): boolean {
+  if (a.length !== b.length) return false;
+
+  return a.every((position, index) => {
+    const other = b[index];
+    return (
+      other !== undefined &&
+      position.locationId === other.locationId &&
+      position.x === other.x &&
+      position.y === other.y &&
+      position.state === other.state
+    );
+  });
+}
+
+function areScreenPointsEqual(
+  a: Record<string, ScreenPoint>,
+  b: Record<string, ScreenPoint>,
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+
+  return aKeys.every((key) => {
+    const aPoint = a[key];
+    const bPoint = b[key];
+    return (
+      bPoint !== undefined &&
+      aPoint.x === bPoint.x &&
+      aPoint.y === bPoint.y
+    );
+  });
 }
 
 export default function ChapterPinsOverlay() {
@@ -20,112 +59,155 @@ export default function ChapterPinsOverlay() {
   const locations = useProjectStore((s) => s.locations);
   const playbackState = useAnimationStore((s) => s.playbackState);
   const visitedLocationIds = useAnimationStore((s) => s.visitedLocationIds);
-  const currentArrivalLocationId = useAnimationStore((s) => s.currentArrivalLocationId);
+  const currentArrivalLocationId = useAnimationStore(
+    (s) => s.currentArrivalLocationId,
+  );
+  const albumCollectingLocationId = useAnimationStore(
+    (s) => s.albumCollectingLocationId,
+  );
+  const albumClosedLocationId = useAnimationStore((s) => s.albumClosedLocationId);
+  const setChapterPinPositions = useAnimationStore(
+    (s) => s.setChapterPinPositions,
+  );
   const chapterPinsEnabled = useUIStore((s) => s.chapterPinsEnabled);
 
   const [positions, setPositions] = useState<PinPosition[]>([]);
 
-  console.log(
-    "[ChapterPins] render, positions:",
-    positions.length,
-    "visited:",
-    visitedLocationIds.length,
-  );
-
-  // Use refs to avoid recreating the callback when store data changes
   const locationsRef = useRef(locations);
   locationsRef.current = locations;
   const visitedRef = useRef(visitedLocationIds);
   visitedRef.current = visitedLocationIds;
   const arrivalRef = useRef(currentArrivalLocationId);
   arrivalRef.current = currentArrivalLocationId;
+  const collectingRef = useRef(albumCollectingLocationId);
+  collectingRef.current = albumCollectingLocationId;
+  const closedRef = useRef(albumClosedLocationId);
+  closedRef.current = albumClosedLocationId;
+  const targetPositionsRef = useRef(useAnimationStore.getState().chapterPinPositions);
 
   const computePositions = useRef(() => {
-    /* placeholder — replaced below */
+    /* replaced below */
   });
 
   computePositions.current = () => {
     if (!map) return;
-    const locs = locationsRef.current;
-    const visited = visitedRef.current;
-    const arrival = arrivalRef.current;
 
-    const newPositions: PinPosition[] = [];
+    const nextPositions: PinPosition[] = [];
     const seenCoords = new Set<string>();
-    for (const loc of locs) {
-      if (loc.isWaypoint) continue;
-      const isVisited = visited.includes(loc.id);
-      const isActive = loc.id === arrival;
-      if (!isVisited && !isActive) continue;
 
-      // Deduplicate by coordinates — routes that revisit a city
-      // (e.g. Seattle→...→Seattle) should show only one pin
-      const coordKey = `${loc.coordinates[0].toFixed(4)},${loc.coordinates[1].toFixed(4)}`;
+    for (const location of locationsRef.current) {
+      if (location.isWaypoint) continue;
+
+      let state: ChapterPinState = "future";
+      if (location.id === collectingRef.current) {
+        state = "album-collecting";
+      } else if (location.id === closedRef.current) {
+        state = "album-closed";
+      } else if (location.id === arrivalRef.current) {
+        state = "album-open";
+      } else if (visitedRef.current.includes(location.id)) {
+        state = "visited";
+      }
+
+      if (state === "future") continue;
+
+      const coordKey = `${location.coordinates[0].toFixed(4)},${location.coordinates[1].toFixed(4)}`;
       if (seenCoords.has(coordKey)) continue;
       seenCoords.add(coordKey);
 
-      const point = map.project(loc.coordinates);
-      newPositions.push({
-        locationId: loc.id,
-        x: point.x,
-        y: point.y,
+      const projected = map.project(location.coordinates);
+      nextPositions.push({
+        locationId: location.id,
+        x: projected.x,
+        y: projected.y,
+        state,
       });
     }
-    setPositions(newPositions);
+
+    setPositions((current) =>
+      arePinPositionsEqual(current, nextPositions) ? current : nextPositions,
+    );
+
+    const nextTargetPositions = Object.fromEntries(
+      nextPositions
+        .filter((position) => position.state !== "visited")
+        .map((position) => {
+          const offset = getChapterPinTargetOffset(position.state);
+          return [
+            position.locationId,
+            {
+              x: position.x + offset.x,
+              y: position.y + offset.y,
+            },
+          ];
+        }),
+    ) satisfies Record<string, ScreenPoint>;
+
+    if (!areScreenPointsEqual(targetPositionsRef.current, nextTargetPositions)) {
+      targetPositionsRef.current = nextTargetPositions;
+      setChapterPinPositions(nextTargetPositions);
+    }
   };
 
-  // Update on map movement
   useEffect(() => {
     if (!map) return;
 
-    const update = () => computePositions.current();
+    const update = () => {
+      computePositions.current();
+    };
 
     update();
     map.on("move", update);
     return () => {
       map.off("move", update);
+      targetPositionsRef.current = {};
+      setChapterPinPositions({});
     };
-  }, [map]);
+  }, [map, setChapterPinPositions]);
 
-  // Update when animation state changes (subscribe to avoid re-render loops)
   useEffect(() => {
     if (!map) return;
+
     let prevVisited = useAnimationStore.getState().visitedLocationIds;
     let prevArrival = useAnimationStore.getState().currentArrivalLocationId;
+    let prevCollecting = useAnimationStore.getState().albumCollectingLocationId;
+    let prevClosed = useAnimationStore.getState().albumClosedLocationId;
+
     return useAnimationStore.subscribe((state) => {
-      if (state.visitedLocationIds !== prevVisited || state.currentArrivalLocationId !== prevArrival) {
+      if (
+        state.visitedLocationIds !== prevVisited ||
+        state.currentArrivalLocationId !== prevArrival ||
+        state.albumCollectingLocationId !== prevCollecting ||
+        state.albumClosedLocationId !== prevClosed
+      ) {
         prevVisited = state.visitedLocationIds;
         prevArrival = state.currentArrivalLocationId;
+        prevCollecting = state.albumCollectingLocationId;
+        prevClosed = state.albumClosedLocationId;
         computePositions.current();
       }
     });
   }, [map]);
 
-  const isAnimating = playbackState === "playing" || playbackState === "paused";
+  const isAnimating =
+    playbackState === "playing" || playbackState === "paused";
   if (!chapterPinsEnabled || !isAnimating) return null;
 
   return (
-    <div className="absolute inset-0 pointer-events-none overflow-hidden z-[8]">
-        {positions.filter((pos, idx, arr) => arr.findIndex((p) => p.locationId === pos.locationId) === idx).map((pos) => {
-          const location = locations.find((l) => l.id === pos.locationId);
-          if (!location) return null;
+    <div className="pointer-events-none absolute inset-0 z-[8] overflow-hidden">
+      {positions.map((position) => {
+        const location = locations.find((entry) => entry.id === position.locationId);
+        if (!location) return null;
 
-          let pinState: ChapterPinState = "future";
-          if (location.id === currentArrivalLocationId) {
-            pinState = "active";
-          } else if (visitedLocationIds.includes(location.id)) {
-            pinState = "visited";
-          }
-
-          return (
-            <ChapterPin
-              key={location.id}
-              location={location}
-              state={pinState}
-              position={{ x: pos.x, y: pos.y }}
-            />
-          );
-        })}
+        return (
+          <ChapterPin
+            key={location.id}
+            location={location}
+            position={{ x: position.x, y: position.y }}
+            state={position.state}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -110,10 +110,23 @@ function EditorContent() {
   const demoLoadedRef = useRef(false);
   const prevShowPhotosRef = useRef(false);
   const prevPhotoLocationIdRef = useRef<string | null>(null);
+  const prevPhaseRef = useRef<string | null>(null);
+  const activeAlbumSequenceLocationIdRef = useRef<string | null>(null);
+  const pendingAlbumCloseLocationIdRef = useRef<string | null>(null);
+  const albumVisitedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const startAlbumSequenceRef = useRef<(locationId: string) => void>(() => {});
+  const completeAlbumSequenceRef = useRef<(locationId: string) => void>(
+    () => {},
+  );
+  const resetAlbumSequenceStateRef = useRef<() => void>(() => {});
+  const clearAlbumSequenceTimersRef = useRef<() => void>(() => {});
 
   const setPlaybackState = useAnimationStore((s) => s.setPlaybackState);
   const setCurrentTime = useAnimationStore((s) => s.setCurrentTime);
   const setTotalDuration = useAnimationStore((s) => s.setTotalDuration);
+  const setCurrentPhase = useAnimationStore((s) => s.setCurrentPhase);
   const setCurrentCityLabel = useAnimationStore((s) => s.setCurrentCityLabel);
   const setCurrentCityLabelZh = useAnimationStore(
     (s) => s.setCurrentCityLabelZh,
@@ -145,9 +158,12 @@ function EditorContent() {
 
   const setVisitedLocationIds = useAnimationStore((s) => s.setVisitedLocationIds);
   const setCurrentArrivalLocationId = useAnimationStore((s) => s.setCurrentArrivalLocationId);
+  const setAlbumCollectingLocationId = useAnimationStore(
+    (s) => s.setAlbumCollectingLocationId,
+  );
+  const setAlbumClosedLocationId = useAnimationStore((s) => s.setAlbumClosedLocationId);
   const addBreadcrumb = useAnimationStore((s) => s.addBreadcrumb);
   const setBreadcrumbs = useAnimationStore((s) => s.setBreadcrumbs);
-  const clearBreadcrumbs = useAnimationStore((s) => s.clearBreadcrumbs);
   const reset = useAnimationStore((s) => s.reset);
 
   const cityLabelSize = useUIStore((s) => s.cityLabelSize);
@@ -172,6 +188,89 @@ function EditorContent() {
       ),
     [availableStageSize.height, availableStageSize.width, viewportRatio],
   );
+
+  const clearAlbumSequenceTimers = useCallback(() => {
+    if (albumVisitedTimerRef.current) {
+      clearTimeout(albumVisitedTimerRef.current);
+      albumVisitedTimerRef.current = null;
+    }
+  }, []);
+
+  const resetAlbumSequenceState = useCallback(() => {
+    clearAlbumSequenceTimers();
+    activeAlbumSequenceLocationIdRef.current = null;
+    pendingAlbumCloseLocationIdRef.current = null;
+    setAlbumCollectingLocationId(null);
+    setAlbumClosedLocationId(null);
+  }, [
+    clearAlbumSequenceTimers,
+    setAlbumClosedLocationId,
+    setAlbumCollectingLocationId,
+  ]);
+
+  const completeAlbumSequence = useCallback(
+    (locationId: string) => {
+      if (activeAlbumSequenceLocationIdRef.current !== locationId) return;
+
+      if (useAnimationStore.getState().playbackState !== "playing") {
+        pendingAlbumCloseLocationIdRef.current = locationId;
+        return;
+      }
+
+      pendingAlbumCloseLocationIdRef.current = null;
+      setShowPhotoOverlay(false);
+      setAlbumCollectingLocationId(null);
+      setAlbumClosedLocationId(locationId);
+      setVisiblePhotoLocationId(null);
+      activeAlbumSequenceLocationIdRef.current = null;
+
+      clearAlbumSequenceTimers();
+      albumVisitedTimerRef.current = setTimeout(() => {
+        if (useAnimationStore.getState().albumClosedLocationId === locationId) {
+          setAlbumClosedLocationId(null);
+        }
+        albumVisitedTimerRef.current = null;
+      }, 300);
+    },
+    [
+      clearAlbumSequenceTimers,
+      setAlbumClosedLocationId,
+      setAlbumCollectingLocationId,
+      setShowPhotoOverlay,
+    ],
+  );
+
+  const startAlbumSequence = useCallback(
+    (locationId: string) => {
+      clearAlbumSequenceTimers();
+      pendingAlbumCloseLocationIdRef.current = null;
+      activeAlbumSequenceLocationIdRef.current = locationId;
+      setAlbumClosedLocationId(null);
+      setAlbumCollectingLocationId(locationId);
+      setVisiblePhotoLocationId(locationId);
+      setShowPhotoOverlay(true);
+      setPhotoOverlayOpacity(0);
+    },
+    [
+      clearAlbumSequenceTimers,
+      setAlbumClosedLocationId,
+      setAlbumCollectingLocationId,
+      setPhotoOverlayOpacity,
+      setShowPhotoOverlay,
+    ],
+  );
+
+  useEffect(() => {
+    startAlbumSequenceRef.current = startAlbumSequence;
+    completeAlbumSequenceRef.current = completeAlbumSequence;
+    resetAlbumSequenceStateRef.current = resetAlbumSequenceState;
+    clearAlbumSequenceTimersRef.current = clearAlbumSequenceTimers;
+  }, [
+    clearAlbumSequenceTimers,
+    completeAlbumSequence,
+    resetAlbumSequenceState,
+    startAlbumSequence,
+  ]);
 
   useEffect(() => {
     const stageViewport = stageViewportRef.current;
@@ -398,6 +497,11 @@ function EditorContent() {
       engineRef.current = null;
     }
     reset();
+    resetAlbumSequenceStateRef.current();
+    prevPhaseRef.current = null;
+    prevShowPhotosRef.current = false;
+    prevPhotoLocationIdRef.current = null;
+    setVisiblePhotoLocationId(null);
 
     if (!map || segments.length === 0) return;
 
@@ -415,13 +519,48 @@ function EditorContent() {
     setTimeline(engine.getTimeline());
 
     engine.on("progress", (e) => {
+      const seg = segments[e.segmentIndex];
+      const currentArrivalLocation =
+        seg?.toId != null
+          ? locations.find((location) => location.id === seg.toId) ?? null
+          : null;
+      const currentArrivalHasPhotos =
+        (currentArrivalLocation?.photos.length ?? 0) > 0;
+      const previousPhase = prevPhaseRef.current;
+      const previousPhotoLocationId = prevPhotoLocationIdRef.current;
+      const previousPhotoLocation =
+        previousPhotoLocationId != null
+          ? locations.find((location) => location.id === previousPhotoLocationId) ??
+            null
+          : null;
+      const shouldStartAlbumSequence =
+        previousPhase === "ARRIVE" &&
+        e.phase !== "ARRIVE" &&
+        previousPhotoLocationId !== null &&
+        (previousPhotoLocation?.photos.length ?? 0) > 0 &&
+        activeAlbumSequenceLocationIdRef.current !== previousPhotoLocationId;
+
       setCurrentTime(e.time);
       setCurrentSegmentIndex(e.segmentIndex);
       setCurrentGroupSegmentIndices(e.groupSegmentIndices);
+      setCurrentPhase(e.phase);
       setCurrentCityLabel(e.cityLabel);
       setCurrentCityLabelZh(e.cityLabelZh);
-      setShowPhotoOverlay(e.showPhotos);
-      setPhotoOverlayOpacity(e.photoOpacity);
+
+      if (e.showPhotos && e.phase === "ARRIVE") {
+        setShowPhotoOverlay(true);
+        setPhotoOverlayOpacity(1);
+      } else if (shouldStartAlbumSequence) {
+        startAlbumSequenceRef.current(previousPhotoLocationId);
+      } else if (
+        !e.showPhotos &&
+        activeAlbumSequenceLocationIdRef.current === null &&
+        pendingAlbumCloseLocationIdRef.current === null
+      ) {
+        setShowPhotoOverlay(false);
+        setPhotoOverlayOpacity(0);
+      }
+
       // Chapter pin tracking: derive visited/arrival state from current time
       // (recomputed from scratch so seek/scrub always produces correct state)
       {
@@ -486,16 +625,18 @@ function EditorContent() {
       if (e.showPhotos) {
         if (e.phase === "ARRIVE") {
           // During ARRIVE: set current destination's photos
-          const seg = segments[e.segmentIndex];
-          const toLoc = locations.find((l) => l.id === seg?.toId);
-          setVisiblePhotos(toLoc?.photos || []);
-          setVisiblePhotoLocationId(toLoc?.id ?? null);
+          setVisiblePhotos(currentArrivalLocation?.photos ?? []);
+          setVisiblePhotoLocationId(currentArrivalLocation?.id ?? null);
         }
         // During HOVER/ZOOM_OUT fade-out: keep previous photos (don't update)
       } else {
         // Don't clear outgoing photos/location when a scene transition is active —
         // the outgoing location's photoLayout must persist for correct transition resolution
-        if (e.sceneTransitionProgress === undefined) {
+        if (
+          e.sceneTransitionProgress === undefined &&
+          activeAlbumSequenceLocationIdRef.current === null &&
+          pendingAlbumCloseLocationIdRef.current === null
+        ) {
           setVisiblePhotos([]);
           setVisiblePhotoLocationId(null);
         }
@@ -517,10 +658,15 @@ function EditorContent() {
         }
       }
       prevShowPhotosRef.current = e.showPhotos;
-      if (e.showPhotos && e.phase === "ARRIVE") {
-        const seg = segments[e.segmentIndex];
-        prevPhotoLocationIdRef.current = seg?.toId ?? null;
+      if (e.phase === "ARRIVE") {
+        prevPhotoLocationIdRef.current =
+          e.showPhotos && currentArrivalHasPhotos
+            ? currentArrivalLocation?.id ?? null
+            : null;
+      } else if (!e.showPhotos) {
+        prevPhotoLocationIdRef.current = null;
       }
+      prevPhaseRef.current = e.phase;
 
       // Scene transition metadata
       setSceneTransitionProgress(e.sceneTransitionProgress);
@@ -625,8 +771,9 @@ function EditorContent() {
 
     return () => {
       engine.destroy();
+      clearAlbumSequenceTimersRef.current();
     };
-  }, [map, locations, segments, segmentTimingOverrides]);
+  }, [map, locations, segmentTimingOverrides, segments]);
 
   const handlePlay = useCallback(() => {
     // Immediately hide all future segment layers on the map
@@ -645,25 +792,33 @@ function EditorContent() {
     }
     engineRef.current?.play();
     setPlaybackState("playing");
-
+    const pendingAlbumCloseLocationId = pendingAlbumCloseLocationIdRef.current;
+    if (pendingAlbumCloseLocationId) {
+      completeAlbumSequenceRef.current(pendingAlbumCloseLocationId);
+    }
   }, [map, setPlaybackState]);
 
   const handlePause = useCallback(() => {
+    clearAlbumSequenceTimersRef.current();
     engineRef.current?.pause();
     setPlaybackState("paused");
   }, [setPlaybackState]);
 
   const handleReset = useCallback(() => {
     engineRef.current?.reset();
+    resetAlbumSequenceStateRef.current();
     reset();
     prevShowPhotosRef.current = false;
     prevPhotoLocationIdRef.current = null;
+    prevPhaseRef.current = null;
+    setVisiblePhotoLocationId(null);
   }, [reset]);
 
   const handleSeek = useCallback((progress: number) => {
     const engine = engineRef.current;
     if (!engine) return;
 
+    resetAlbumSequenceStateRef.current();
     engine.seekTo(progress);
 
     // Rebuild breadcrumb state for the seek position
@@ -695,7 +850,15 @@ function EditorContent() {
     // Reset transition tracking refs to match seek state
     prevShowPhotosRef.current = false;
     prevPhotoLocationIdRef.current = null;
+    prevPhaseRef.current = null;
+    setVisiblePhotoLocationId(null);
   }, [setBreadcrumbs]);
+
+  useEffect(() => () => clearAlbumSequenceTimersRef.current(), []);
+
+  const handleFlyToAlbumComplete = useCallback((locationId: string) => {
+    completeAlbumSequenceRef.current(locationId);
+  }, []);
 
   const handleEditLayout = useCallback((locationId: string) => {
     setEditingLocationId(locationId);
@@ -935,6 +1098,7 @@ function EditorContent() {
                   onPlay={handlePlay}
                   onReset={handleReset}
                   onSeek={handleSeek}
+                  onFlyToAlbumComplete={handleFlyToAlbumComplete}
                   onStopEditingLayout={() => setEditingLocationId(null)}
                 />
               </div>
@@ -976,6 +1140,7 @@ function EditorContent() {
                     onPlay={handlePlay}
                     onReset={handleReset}
                     onSeek={handleSeek}
+                    onFlyToAlbumComplete={handleFlyToAlbumComplete}
                     onStopEditingLayout={() => setEditingLocationId(null)}
                   />
                 </div>

--- a/src/components/editor/MapStage.tsx
+++ b/src/components/editor/MapStage.tsx
@@ -39,6 +39,7 @@ interface MapStageProps {
   onPlay: () => void;
   onReset: () => void;
   onSeek: (progress: number) => void;
+  onFlyToAlbumComplete: (locationId: string) => void;
   onStopEditingLayout: () => void;
   showEmptyState: boolean;
 }
@@ -135,6 +136,7 @@ export default function MapStage({
   onPlay,
   onReset,
   onSeek,
+  onFlyToAlbumComplete,
   onStopEditingLayout,
   showEmptyState,
 }: MapStageProps) {
@@ -159,6 +161,7 @@ export default function MapStage({
   const incomingPhotos = useAnimationStore((s) => s.incomingPhotos);
   const incomingPhotoLocationId = useAnimationStore((s) => s.incomingPhotoLocationId);
   const transitionBearing = useAnimationStore((s) => s.transitionBearing);
+  const chapterPinPositions = useAnimationStore((s) => s.chapterPinPositions);
   const visiblePhotoLocation = locations.find((location) => location.id === photoLocationId);
   const incomingLocation = locations.find((location) => location.id === incomingPhotoLocationId);
   const effectiveTransition = resolveSceneTransition(photoLayout, globalSceneTransition);
@@ -239,6 +242,9 @@ export default function MapStage({
         opacity={photoOverlayOpacity}
         bloomOrigin={bloomOrigin}
         bloomElapsedTime={bloomElapsedTime}
+        flyToPosition={photoLocationId ? chapterPinPositions[photoLocationId] ?? null : null}
+        photoLocationId={photoLocationId}
+        onFlyToAlbumComplete={onFlyToAlbumComplete}
         sceneTransition={effectiveTransition}
         sceneTransitionProgress={isTransitioning ? sceneTransitionProgress : undefined}
         incomingPhotos={isTransitioning ? incomingPhotos : undefined}

--- a/src/components/editor/PhotoOverlay.tsx
+++ b/src/components/editor/PhotoOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useState, useEffect, useRef, useMemo } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion, type Transition, type TargetAndTransition } from "framer-motion";
 import { computeAutoLayout, computeTemplateLayout } from "@/lib/photoLayout";
 import {
@@ -185,6 +185,29 @@ function getExitValues(
   }
 }
 
+function getFlyToAlbumValues(
+  rect: PhotoRect,
+  containerSize: { w: number; h: number },
+  overlayOffset: { x: number; y: number },
+  targetPosition: { x: number; y: number },
+  index: number,
+) {
+  const photoCenterX = (rect.x + rect.width / 2) * containerSize.w;
+  const photoCenterY = (rect.y + rect.height / 2) * containerSize.h;
+  const targetX = targetPosition.x - overlayOffset.x;
+  const targetY = targetPosition.y - overlayOffset.y;
+
+  return {
+    exitOpacity: 0,
+    exitScale: 0.15,
+    exitX: targetX - photoCenterX,
+    exitY: targetY - photoCenterY,
+    exitBlur: 2,
+    exitRotate: index % 2 === 0 ? -8 : 8,
+    exitRotateY: 0,
+  };
+}
+
 interface PhotoOverlayProps {
   photos: Photo[];
   visible: boolean;
@@ -201,6 +224,12 @@ interface PhotoOverlayProps {
   bloomOrigin?: { x: number; y: number } | null;
   /** Timeline-driven elapsed time (seconds) since bloom enter started */
   bloomElapsedTime?: number;
+  /** Current album collection target in screen space */
+  flyToPosition?: { x: number; y: number } | null;
+  /** Location whose photos are being displayed or collected */
+  photoLocationId?: string | null;
+  /** Invoked after the fly-to-album animation actually completes */
+  onFlyToAlbumComplete?: (locationId: string) => void;
   /** Active scene transition type */
   sceneTransition?: SceneTransition;
   /** Scene transition progress (0-1): 0 = fully outgoing, 1 = fully incoming */
@@ -274,6 +303,9 @@ export default function PhotoOverlay({
   portalProgressOverride,
   bloomOrigin,
   bloomElapsedTime = 0,
+  flyToPosition,
+  photoLocationId,
+  onFlyToAlbumComplete,
   sceneTransition,
   sceneTransitionProgress,
   incomingPhotos,
@@ -302,6 +334,14 @@ export default function PhotoOverlay({
   const { enterAnimation, exitAnimation } = resolvePhotoAnimations(displayLayout, photoAnimation);
   const photoStyle = resolvePhotoStyle(displayLayout, globalPhotoStyle);
   const incomingPhotoStyleResolved = resolvePhotoStyle(incomingPhotoLayout, globalPhotoStyle);
+  const isActiveTransition = Boolean(
+    sceneTransition && sceneTransition !== "cut" && sceneTransitionProgress !== undefined,
+  );
+  const overlayExitProgress = isActiveTransition ? 0 : 1 - opacity;
+  const shouldFlyToAlbum =
+    overlayExitProgress > 0 &&
+    flyToPosition != null &&
+    photoLocationId != null;
   const usesPortalLayout = photoStyle === "portal" || incomingPhotoStyleResolved === "portal";
 
   const containerStyle = useMemo(() => {
@@ -326,6 +366,7 @@ export default function PhotoOverlay({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerSize, setContainerSize] = useState({ w: 0, h: 0 });
+  const completedFlyLocationIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -337,6 +378,21 @@ export default function PhotoOverlay({
     observer.observe(containerRef.current);
     return () => observer.disconnect();
   }, []);
+
+  useEffect(() => {
+    if (!shouldFlyToAlbum) {
+      completedFlyLocationIdRef.current = null;
+    }
+  }, [shouldFlyToAlbum]);
+
+  const handleFlyToAlbumComplete = useCallback(
+    (locationId: string) => {
+      if (completedFlyLocationIdRef.current === locationId) return;
+      completedFlyLocationIdRef.current = locationId;
+      onFlyToAlbumComplete?.(locationId);
+    },
+    [onFlyToAlbumComplete],
+  );
 
   // ── Bloom animation progress (timeline-driven, not wall-clock) ──
   const isBloom = photoStyle === "bloom";
@@ -440,7 +496,6 @@ export default function PhotoOverlay({
   const incomingIsFreeMode = incomingPhotoLayout?.mode === "free";
 
   // Scene transition: compute outgoing wrapper styles
-  const isActiveTransition = sceneTransition && sceneTransition !== "cut" && sceneTransitionProgress !== undefined;
   const transitionOutgoingStyle = useMemo<React.CSSProperties>(() => {
     if (!isActiveTransition || sceneTransitionProgress === undefined) return {};
     switch (sceneTransition) {
@@ -598,7 +653,7 @@ export default function PhotoOverlay({
       }}
     >
       <div className="absolute inset-0" style={{ pointerEvents: "none", ...transitionOutgoingStyle }}>
-        {hasDisplayPhotos && photoStyle === "portal" ? (
+        {hasDisplayPhotos && photoStyle === "portal" && !shouldFlyToAlbum ? (
           <PortalPhotoLayer
             photos={orderedMetas as PortalPhoto[]}
             containerSize={containerSize}
@@ -657,12 +712,12 @@ export default function PhotoOverlay({
                 ? (index === 0 ? -2 : index === total - 1 ? 2 : 0)
                 : (index % 2 === 0 ? -1.5 : 1.5);
 
-            const exitProgress = isActiveTransition ? 0 : 1 - opacity;
+            const exitProgress = overlayExitProgress;
             const staggerOffset = total > 1 ? (total - 1 - index) / (total - 1) * 0.4 : 0;
             const photoExitT = Math.max(0, Math.min(1, (exitProgress - staggerOffset) / (1 - staggerOffset + 0.01)));
 
             // ── Bloom style: geo-anchored animation ──
-            if (isBloom && bloomOrigin && containerSize.w > 0) {
+            if (isBloom && bloomOrigin && containerSize.w > 0 && !shouldFlyToAlbum) {
               // Convert raw map.project() pixels to overlay-local pixels
               const overlayOffsetX = containerRef.current?.offsetLeft ?? 0;
               const overlayOffsetY = containerRef.current?.offsetTop ?? 0;
@@ -769,12 +824,35 @@ export default function PhotoOverlay({
             const enterDelay = typeof (enter.transition as { delay?: number }).delay === "number"
               ? (enter.transition as { delay?: number }).delay!
               : 0;
+            const overlayOffset = {
+              x: containerRef.current?.offsetLeft ?? 0,
+              y: containerRef.current?.offsetTop ?? 0,
+            };
+            const flyToAlbumExit = shouldFlyToAlbum && flyToPosition
+              ? getFlyToAlbumValues(
+                  rect,
+                  containerSize,
+                  overlayOffset,
+                  flyToPosition,
+                  index,
+                )
+              : null;
             const exit = getExitValues(exitAnimation, exitProgress, photoExitT, index);
 
             const enterRotate = typeof (enter.animate as { rotate?: number }).rotate === "number"
               ? (enter.animate as { rotate?: number }).rotate! + rotation
               : rotation;
-            const animateValues: TargetAndTransition = exitProgress > 0
+            const animateValues: TargetAndTransition = flyToAlbumExit
+              ? {
+                  opacity: flyToAlbumExit.exitOpacity,
+                  scale: flyToAlbumExit.exitScale,
+                  x: flyToAlbumExit.exitX,
+                  y: flyToAlbumExit.exitY,
+                  filter: `blur(${flyToAlbumExit.exitBlur}px)`,
+                  rotate: flyToAlbumExit.exitRotate + rotation,
+                  rotateY: undefined,
+                }
+              : exitProgress > 0
               ? {
                   opacity: exit.exitOpacity,
                   scale: exit.exitScale,
@@ -792,9 +870,16 @@ export default function PhotoOverlay({
                   key={photo.id}
                   initial={enter.initial}
                   animate={animateValues}
-                  transition={exitProgress > 0
+                  transition={flyToAlbumExit
+                    ? { duration: 0.5, ease: [0.4, 0, 0.2, 1] }
+                    : exitProgress > 0
                     ? { duration: 0.5, ease: "easeOut" }
                     : enter.transition
+                  }
+                  onAnimationComplete={
+                    flyToAlbumExit && index === 0 && photoLocationId
+                      ? () => handleFlyToAlbumComplete(photoLocationId)
+                      : undefined
                   }
                   className="absolute overflow-hidden drop-shadow-xl"
                   style={{

--- a/src/stores/animationStore.ts
+++ b/src/stores/animationStore.ts
@@ -9,6 +9,11 @@ export interface Breadcrumb {
   visitedAtSegment: number;      // segment index when this was visited
 }
 
+export interface ScreenPoint {
+  x: number;
+  y: number;
+}
+
 interface AnimationState {
   playbackState: PlaybackState;
   currentTime: number;
@@ -38,6 +43,12 @@ interface AnimationState {
   visitedLocationIds: string[];
   /** ID of the location currently arriving at (active chapter pin) */
   currentArrivalLocationId: string | null;
+  /** ID of the location whose album is currently collecting flying photos */
+  albumCollectingLocationId: string | null;
+  /** ID of the location whose album has snapped shut after collecting photos */
+  albumClosedLocationId: string | null;
+  /** Screen-space positions for chapter pins that the photo overlay can target */
+  chapterPinPositions: Record<string, ScreenPoint>;
   /** Breadcrumb thumbnails left at visited locations */
   breadcrumbs: Breadcrumb[];
 
@@ -62,6 +73,9 @@ interface AnimationState {
   setVisitedLocationIds: (ids: string[]) => void;
   addVisitedLocationId: (id: string) => void;
   setCurrentArrivalLocationId: (id: string | null) => void;
+  setAlbumCollectingLocationId: (id: string | null) => void;
+  setAlbumClosedLocationId: (id: string | null) => void;
+  setChapterPinPositions: (positions: Record<string, ScreenPoint>) => void;
   addBreadcrumb: (b: Breadcrumb) => void;
   setBreadcrumbs: (breadcrumbs: Breadcrumb[]) => void;
   clearBreadcrumbs: () => void;
@@ -89,6 +103,9 @@ export const useAnimationStore = create<AnimationState>((set) => ({
   bloomElapsedTime: 0,
   visitedLocationIds: [],
   currentArrivalLocationId: null,
+  albumCollectingLocationId: null,
+  albumClosedLocationId: null,
+  chapterPinPositions: {},
   breadcrumbs: [],
 
   setPlaybackState: (playbackState) => set({ playbackState }),
@@ -117,6 +134,11 @@ export const useAnimationStore = create<AnimationState>((set) => ({
         : [...state.visitedLocationIds, id],
     })),
   setCurrentArrivalLocationId: (currentArrivalLocationId) => set({ currentArrivalLocationId }),
+  setAlbumCollectingLocationId: (albumCollectingLocationId) =>
+    set({ albumCollectingLocationId }),
+  setAlbumClosedLocationId: (albumClosedLocationId) =>
+    set({ albumClosedLocationId }),
+  setChapterPinPositions: (chapterPinPositions) => set({ chapterPinPositions }),
   addBreadcrumb: (b) =>
     set((state) => {
       // Don't add duplicate breadcrumbs for the same location
@@ -145,6 +167,9 @@ export const useAnimationStore = create<AnimationState>((set) => ({
       bloomElapsedTime: 0,
       visitedLocationIds: [],
       currentArrivalLocationId: null,
+      albumCollectingLocationId: null,
+      albumClosedLocationId: null,
+      chapterPinPositions: {},
       breadcrumbs: [],
     }),
 }));


### PR DESCRIPTION
## Summary
- re-implement the album pin collection flow from PR #95 on current `main`
- fix the reviewed sequencing, timing, pin-position, and cleanup bugs from issue #96
- restore geometry-driven fly targets and completion-driven album closing without touching generated files

## Validation
- `npx tsc --noEmit`
- `npm run build`

Closes #96