### PR TITLE
fix: sync chapter pin positions with map camera

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/editor/ChapterPin.tsx
+++ b/src/components/editor/ChapterPin.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import type { Location } from "@/types";
 
@@ -13,7 +14,7 @@ export type ChapterPinState =
 interface ChapterPinProps {
   location: Location;
   state: ChapterPinState;
-  position: { x: number; y: number };
+  registerRef: (locationId: string, el: HTMLDivElement | null) => void;
 }
 
 const SPRING_TRANSITION = {
@@ -268,59 +269,70 @@ function VisitedPin({ location }: { location: Location }) {
 export default function ChapterPin({
   location,
   state,
-  position,
+  registerRef,
 }: ChapterPinProps) {
   if (state === "future") return null;
 
   const isVisited = state === "visited";
 
+  // Merge the registerRef callback with the DOM element
+  const refCallback = useCallback(
+    (el: HTMLDivElement | null) => {
+      registerRef(location.id, el);
+    },
+    [location.id, registerRef],
+  );
+
   return (
-    <motion.div
-      layout
-      initial={{ scale: 0.85, opacity: 0 }}
-      animate={{
-        scale: isVisited ? 0.72 : 1,
-        opacity: isVisited ? 0.5 : 1,
-        y: isVisited ? 8 : 0,
-      }}
-      transition={isVisited ? VISITED_TRANSITION : SPRING_TRANSITION}
-      className="pointer-events-none absolute"
+    <div
+      ref={refCallback}
+      className="pointer-events-none absolute left-0 top-0"
       style={{
-        left: position.x,
-        top: position.y,
-        transform: "translate(-50%, -100%)",
+        /* position is set via transform by ChapterPinsOverlay (DOM-direct) */
+        willChange: "transform",
         zIndex: isVisited ? 5 : 15,
       }}
     >
-      <AnimatePresence mode="sync" initial={false}>
-        <motion.div
-          key={state}
-          initial={{ opacity: 0, scale: 0.94, y: 8 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          exit={{ opacity: 0, scale: 0.94, y: -4 }}
-          transition={isVisited ? VISITED_TRANSITION : SPRING_TRANSITION}
-          className="flex flex-col items-center"
-        >
-          {(state === "album-open" || state === "album-collecting") && (
-            <>
-              <OpenAlbum
-                location={location}
-                collecting={state === "album-collecting"}
-              />
-              <div className="mt-1 h-2 w-px bg-stone-400/55" />
-            </>
-          )}
+      <motion.div
+        layout
+        initial={{ scale: 0.85, opacity: 0 }}
+        animate={{
+          scale: isVisited ? 0.72 : 1,
+          opacity: isVisited ? 0.5 : 1,
+          y: isVisited ? 8 : 0,
+        }}
+        transition={isVisited ? VISITED_TRANSITION : SPRING_TRANSITION}
+      >
+        <AnimatePresence mode="sync" initial={false}>
+          <motion.div
+            key={state}
+            initial={{ opacity: 0, scale: 0.94, y: 8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, y: -4 }}
+            transition={isVisited ? VISITED_TRANSITION : SPRING_TRANSITION}
+            className="flex flex-col items-center"
+          >
+            {(state === "album-open" || state === "album-collecting") && (
+              <>
+                <OpenAlbum
+                  location={location}
+                  collecting={state === "album-collecting"}
+                />
+                <div className="mt-1 h-2 w-px bg-stone-400/55" />
+              </>
+            )}
 
-          {state === "album-closed" && (
-            <>
-              <ClosedAlbum location={location} />
-              <div className="mt-1 h-2 w-px bg-stone-400/55" />
-            </>
-          )}
+            {state === "album-closed" && (
+              <>
+                <ClosedAlbum location={location} />
+                <div className="mt-1 h-2 w-px bg-stone-400/55" />
+              </>
+            )}
 
-          {state === "visited" && <VisitedPin location={location} />}
-        </motion.div>
-      </AnimatePresence>
-    </motion.div>
+            {state === "visited" && <VisitedPin location={location} />}
+          </motion.div>
+        </AnimatePresence>
+      </motion.div>
+    </div>
   );
 }

--- a/src/components/editor/ChapterPinsOverlay.tsx
+++ b/src/components/editor/ChapterPinsOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ChapterPin, {
   getChapterPinTargetOffset,
   type ChapterPinState,
@@ -13,24 +13,19 @@ import {
 } from "@/stores/animationStore";
 import { useUIStore } from "@/stores/uiStore";
 
-interface PinPosition {
+interface PinEntry {
   locationId: string;
-  x: number;
-  y: number;
   state: Exclude<ChapterPinState, "future">;
 }
 
-function arePinPositionsEqual(a: PinPosition[], b: PinPosition[]): boolean {
+function arePinEntriesEqual(a: PinEntry[], b: PinEntry[]): boolean {
   if (a.length !== b.length) return false;
-
-  return a.every((position, index) => {
+  return a.every((entry, index) => {
     const other = b[index];
     return (
       other !== undefined &&
-      position.locationId === other.locationId &&
-      position.x === other.x &&
-      position.y === other.y &&
-      position.state === other.state
+      entry.locationId === other.locationId &&
+      entry.state === other.state
     );
   });
 }
@@ -71,8 +66,11 @@ export default function ChapterPinsOverlay() {
   );
   const chapterPinsEnabled = useUIStore((s) => s.chapterPinsEnabled);
 
-  const [positions, setPositions] = useState<PinPosition[]>([]);
+  // Pin entries track which pins are visible and their state (no x/y — that's DOM-direct)
+  const [pinEntries, setPinEntries] = useState<PinEntry[]>([]);
 
+  // Refs for DOM-direct position updates (bypasses React re-render cycle)
+  const pinElementsRef = useRef<Map<string, HTMLDivElement>>(new Map());
   const locationsRef = useRef(locations);
   locationsRef.current = locations;
   const visitedRef = useRef(visitedLocationIds);
@@ -83,16 +81,59 @@ export default function ChapterPinsOverlay() {
   collectingRef.current = albumCollectingLocationId;
   const closedRef = useRef(albumClosedLocationId);
   closedRef.current = albumClosedLocationId;
+  const pinEntriesRef = useRef(pinEntries);
+  pinEntriesRef.current = pinEntries;
   const targetPositionsRef = useRef(useAnimationStore.getState().chapterPinPositions);
 
-  const computePositions = useRef(() => {
-    /* replaced below */
-  });
+  // Register/unregister pin DOM elements
+  const registerPinRef = useCallback((locationId: string, el: HTMLDivElement | null) => {
+    if (el) {
+      pinElementsRef.current.set(locationId, el);
+    } else {
+      pinElementsRef.current.delete(locationId);
+    }
+  }, []);
 
-  computePositions.current = () => {
+  // Synchronously update pin DOM positions — called directly in map "move" handler
+  const updatePinDOMPositions = useCallback(() => {
     if (!map) return;
 
-    const nextPositions: PinPosition[] = [];
+    const nextTargetPositions: Record<string, ScreenPoint> = {};
+
+    for (const entry of pinEntriesRef.current) {
+      const location = locationsRef.current.find((l) => l.id === entry.locationId);
+      if (!location) continue;
+
+      const projected = map.project(location.coordinates);
+      const x = projected.x;
+      const y = projected.y;
+
+      // Update DOM element position directly (no React re-render)
+      const el = pinElementsRef.current.get(entry.locationId);
+      if (el) {
+        el.style.transform = `translate(${x}px, ${y}px) translate(-50%, -100%)`;
+      }
+
+      // Compute target positions for PhotoOverlay fly-to-album
+      if (entry.state !== "visited") {
+        const offset = getChapterPinTargetOffset(entry.state);
+        nextTargetPositions[entry.locationId] = {
+          x: x + offset.x,
+          y: y + offset.y,
+        };
+      }
+    }
+
+    if (!areScreenPointsEqual(targetPositionsRef.current, nextTargetPositions)) {
+      targetPositionsRef.current = nextTargetPositions;
+      setChapterPinPositions(nextTargetPositions);
+    }
+  }, [map, setChapterPinPositions]);
+
+  // Compute which pins should be visible and their states (triggers React re-render only on state changes)
+  const computePinEntries = useRef(() => {});
+  computePinEntries.current = () => {
+    const nextEntries: PinEntry[] = [];
     const seenCoords = new Set<string>();
 
     for (const location of locationsRef.current) {
@@ -115,56 +156,32 @@ export default function ChapterPinsOverlay() {
       if (seenCoords.has(coordKey)) continue;
       seenCoords.add(coordKey);
 
-      const projected = map.project(location.coordinates);
-      nextPositions.push({
-        locationId: location.id,
-        x: projected.x,
-        y: projected.y,
-        state,
-      });
+      nextEntries.push({ locationId: location.id, state });
     }
 
-    setPositions((current) =>
-      arePinPositionsEqual(current, nextPositions) ? current : nextPositions,
+    setPinEntries((current) =>
+      arePinEntriesEqual(current, nextEntries) ? current : nextEntries,
     );
-
-    const nextTargetPositions = Object.fromEntries(
-      nextPositions
-        .filter((position) => position.state !== "visited")
-        .map((position) => {
-          const offset = getChapterPinTargetOffset(position.state);
-          return [
-            position.locationId,
-            {
-              x: position.x + offset.x,
-              y: position.y + offset.y,
-            },
-          ];
-        }),
-    ) satisfies Record<string, ScreenPoint>;
-
-    if (!areScreenPointsEqual(targetPositionsRef.current, nextTargetPositions)) {
-      targetPositionsRef.current = nextTargetPositions;
-      setChapterPinPositions(nextTargetPositions);
-    }
   };
 
+  // Listen to map "move" events — update DOM positions synchronously
   useEffect(() => {
     if (!map) return;
 
-    const update = () => {
-      computePositions.current();
+    const onMove = () => {
+      updatePinDOMPositions();
     };
 
-    update();
-    map.on("move", update);
+    onMove();
+    map.on("move", onMove);
     return () => {
-      map.off("move", update);
+      map.off("move", onMove);
       targetPositionsRef.current = {};
       setChapterPinPositions({});
     };
-  }, [map, setChapterPinPositions]);
+  }, [map, setChapterPinPositions, updatePinDOMPositions]);
 
+  // Listen to animation store state changes — recompute pin entries + update positions
   useEffect(() => {
     if (!map) return;
 
@@ -184,10 +201,20 @@ export default function ChapterPinsOverlay() {
         prevArrival = state.currentArrivalLocationId;
         prevCollecting = state.albumCollectingLocationId;
         prevClosed = state.albumClosedLocationId;
-        computePositions.current();
+        computePinEntries.current();
+        // Also update DOM positions immediately for the new set of pins
+        // (use requestAnimationFrame so new pin elements are mounted first)
+        requestAnimationFrame(() => {
+          updatePinDOMPositions();
+        });
       }
     });
-  }, [map]);
+  }, [map, updatePinDOMPositions]);
+
+  // Initial pin entry computation
+  useEffect(() => {
+    computePinEntries.current();
+  }, [locations]);
 
   const isAnimating =
     playbackState === "playing" || playbackState === "paused";
@@ -195,16 +222,16 @@ export default function ChapterPinsOverlay() {
 
   return (
     <div className="pointer-events-none absolute inset-0 z-[8] overflow-hidden">
-      {positions.map((position) => {
-        const location = locations.find((entry) => entry.id === position.locationId);
+      {pinEntries.map((entry) => {
+        const location = locations.find((l) => l.id === entry.locationId);
         if (!location) return null;
 
         return (
           <ChapterPin
             key={location.id}
             location={location}
-            position={{ x: position.x, y: position.y }}
-            state={position.state}
+            state={entry.state}
+            registerRef={registerPinRef}
           />
         );
       })}


### PR DESCRIPTION
## Problem
Chapter pins (album-open, album-closed, visited) were drifting during animation playback — they appeared to follow the transport icon instead of staying fixed on their city's geographic position.

## Root Cause
Pin screen positions were updated via React `setState` inside the `map.on('move')` callback. Since `map.jumpTo()` fires every animation frame but React batches and defers re-renders, pin positions were always **one frame behind** the camera — creating a visible lag that looked like the pins were moving with the transport.

## Fix
Split pin updates into two paths:

| What | How | When |
|------|-----|------|
| **Position (x/y)** | Direct DOM `transform` manipulation via refs | Synchronously in `map.on('move')` — same frame as camera |
| **State (visible/album-open/visited)** | React `setState` | On animation store changes (normal React flow) |

### Changes
- **ChapterPinsOverlay**: Maintains a `Map<locationId, HTMLDivElement>` of pin refs. On every `map.move`, directly sets `el.style.transform` with the projected screen coordinates — zero React overhead.
- **ChapterPin**: Now receives `registerRef` callback instead of `position` prop. Root element uses `left:0;top:0` with `will-change:transform`.
- Pin entry state (which pins are shown, their album state) still flows through React state for proper mount/unmount/animation.

## Verification
- `npx tsc --noEmit` ✅
- `npm run build` ✅

Closes the pin-follows-vehicle bug from PR #97.