### PR TITLE
fix: simplify album transition — no cover photo, no closed state race

### DIFF
--- a/src/components/editor/ChapterPin.tsx
+++ b/src/components/editor/ChapterPin.tsx
@@ -227,43 +227,26 @@ function OpenAlbum({
 }
 
 /**
- * Closed Album — book snapping shut with cover photo visible.
- * Brief appearance (200ms) before morphing to visited pin.
+ * Closed Album — clean book cover, no photo. Brief hold before visited.
  */
 function ClosedAlbum({ location }: { location: Location }) {
-  const coverPhoto = location.photos[0]?.url;
-
   return (
     <div className="relative flex flex-col items-center gap-2">
-      {/* Same size as OpenAlbum (252×180) — book closing effect */}
       <motion.div
         layout
-        className="relative h-[180px] w-[252px] overflow-hidden rounded-[28px] border-2 border-white/80 bg-stone-100 shadow-[0_24px_48px_rgba(15,23,42,0.25)]"
+        className="relative h-[180px] w-[252px] overflow-hidden rounded-[28px] border-2 border-white/80 bg-gradient-to-br from-stone-100 via-white to-stone-200 shadow-[0_24px_48px_rgba(15,23,42,0.25)]"
         initial={{ scaleX: 0.1, scaleY: 1.05, rotate: -4, opacity: 0.8 }}
         animate={{ scaleX: 1, scaleY: 1, rotate: -2, opacity: 1 }}
         transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
       >
-        {coverPhoto ? (
-          <img
-            src={coverPhoto}
-            alt=""
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-stone-200 via-stone-50 to-stone-300 text-4xl">
-            {location.chapterEmoji || "📍"}
-          </div>
-        )}
-        {/* Spine shadow */}
-        <div className="absolute inset-y-0 left-0 w-[14px] bg-gradient-to-r from-stone-900/30 to-transparent" />
+        {/* Spine */}
+        <div className="absolute inset-y-[8px] left-1/2 w-[10px] -translate-x-1/2 rounded-full bg-gradient-to-b from-stone-300 via-stone-200 to-stone-400 opacity-80" />
+        {/* Centered emoji */}
+        <div className="absolute inset-0 flex items-center justify-center text-4xl opacity-50">
+          {location.chapterEmoji || "📍"}
+        </div>
         {/* Inner ring */}
         <div className="absolute inset-0 rounded-[28px] ring-1 ring-inset ring-white/50" />
-        {/* Emoji badge */}
-        {location.chapterEmoji && (
-          <div className="absolute bottom-3 right-3 rounded-full bg-black/50 px-2 py-1 text-base leading-none text-white shadow-sm">
-            {location.chapterEmoji}
-          </div>
-        )}
       </motion.div>
       <PinLabel
         emoji={location.chapterEmoji}

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -652,41 +652,20 @@ function EditorContent() {
         setCurrentArrivalLocationId(newArrival);
       }
 
-      // Album state machine driven by animation phases:
-      // collecting (open with photos) → closed (cover, 200ms) → visited
-      // Only trigger close when there's NO active fly-to-album animation.
+      // Album state machine: collecting → visited (skip closed to avoid race)
+      // When ZOOM_OUT or FLY starts, clear collecting. The chapter pin tracking
+      // block above already marks the location as visited, so the pin will
+      // naturally transition via AnimatePresence.
       {
         const currentCollecting = useAnimationStore.getState().albumCollectingLocationId;
-        const currentClosed = useAnimationStore.getState().albumClosedLocationId;
         const hasActiveSequence = activeAlbumSequenceLocationIdRef.current !== null;
 
-        // ZOOM_OUT means we've moved past the departure HOVER — safe to close
-        if (e.phase === "ZOOM_OUT" && currentCollecting !== null && !hasActiveSequence) {
+        if (
+          (e.phase === "ZOOM_OUT" || e.phase === "FLY") &&
+          currentCollecting !== null &&
+          !hasActiveSequence
+        ) {
           setAlbumCollectingLocationId(null);
-          setAlbumClosedLocationId(currentCollecting);
-          // Show closed album for 200ms then transition to visited
-          clearAlbumSequenceTimers();
-          albumVisitedTimerRef.current = setTimeout(() => {
-            if (useAnimationStore.getState().playbackState !== "playing") {
-              pendingAlbumCloseLocationIdRef.current = currentCollecting;
-              albumVisitedTimerRef.current = null;
-              return;
-            }
-            if (useAnimationStore.getState().albumClosedLocationId === currentCollecting) {
-              setAlbumClosedLocationId(null);
-            }
-            albumVisitedTimerRef.current = null;
-          }, 200);
-        }
-
-        // Safety: FLY phase force-clears any lingering album state
-        if (e.phase === "FLY") {
-          if (currentCollecting !== null && !hasActiveSequence) {
-            setAlbumCollectingLocationId(null);
-          }
-          if (currentClosed !== null) {
-            setAlbumClosedLocationId(null);
-          }
         }
       }
 


### PR DESCRIPTION
## Changes

### Remove cover photo from ClosedAlbum
Clean book with spine + emoji only. Less visual distraction.

### Skip album-closed state in playback
The album-closed state was a 200ms flash with a cover photo, but it was the source of all race conditions (double trigger, stale timers, pause/resume edge cases). 

New flow: `collecting → visited` (direct). When ZOOM_OUT or FLY starts, clear `albumCollectingLocationId`. The chapter pin tracking block already marks the location as visited, so AnimatePresence smoothly transitions album → circle.

### What this eliminates
- The 200ms setTimeout and its pause/resume guards
- The `albumClosedLocationId` state during playback
- The complex closed→visited path
- ~40 lines of orchestration code

### ClosedAlbum component kept
Still available for future use (scrub preview, etc.) but not triggered during playback.

Fixes #102 (race condition)