### PR TITLE
fix: album pin appears late — last 20% of ARRIVE phase

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -611,7 +611,10 @@ function EditorContent() {
             );
             if (arrive) {
               const arriveEnd = arrive.startTime + arrive.duration;
-              if (t >= arrive.startTime && t < arriveEnd) {
+              // Only show album pin in the last 20% of ARRIVE phase
+              // (when photos are about to start fading out), not at the start
+              const albumAppearTime = arrive.startTime + arrive.duration * 0.8;
+              if (t >= albumAppearTime && t < arriveEnd) {
                 newArrival = group.toLoc.id;
               } else if (t >= arriveEnd) {
                 // Photos fade out during the next group's HOVER + ZOOM_OUT.


### PR DESCRIPTION
Album pin now only appears in the last 20% of ARRIVE phase, right before photos start fading out.

**Before**: Pin shows immediately on arrival → competes with photo overlay
**After**: Photos display peacefully → pin pops up near the end → photos fly in → visited

One line change in the chapter pin tracking block.