### PR TITLE
fix: visited pin — single smooth shrink, no double animation

### DIFF
--- a/src/components/editor/ChapterPin.tsx
+++ b/src/components/editor/ChapterPin.tsx
@@ -329,10 +329,9 @@ export default function ChapterPin({
           {isVisited ? (
             <motion.div
               key="visited"
-              initial={{ opacity: 0, scale: 0.94, y: 8 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.94, y: -4 }}
-              transition={VISITED_TRANSITION}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.4 }}
               className="flex flex-col items-center"
             >
               <VisitedPin location={location} />
@@ -342,7 +341,7 @@ export default function ChapterPin({
               key="album"
               initial={{ opacity: 0, scale: 0.94, y: 8 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.88, y: -6 }}
+              exit={{ opacity: 0, scale: 0.5 }}
               transition={SPRING_TRANSITION}
               className="flex flex-col items-center"
             >


### PR DESCRIPTION
## Bug
After album disappears, visited pin had two stages: tiny pin appears → disappears → big pin appears → shrinks. Should be one smooth: big pin → shrinks.

## Cause
Two scale animations stacked:
- Outer div: `scale 1 → 0.72` (correct shrink)
- Inner AnimatePresence: `initial scale 0.94 → animate scale 1` (conflicting grow)

## Fix
Visited inner div: only opacity fade-in, no scale/y animation. Outer div handles all sizing. Album exit: simplified to `scale 0.5` fade-out.