### PR TITLE
fix: correct photo rotation behavior

### DIFF
--- a/src/components/editor/AlbumBook.tsx
+++ b/src/components/editor/AlbumBook.tsx
@@ -138,7 +138,7 @@ function PhotoGrid({
             {showPhotos ? (
               <PhotoFrame
                 frameStyle={photoFrameStyle}
-                photoIndex={index}
+                photoId={photo.id}
                 caption={albumCaptionsEnabled ? photo.caption : undefined}
                 className="h-full w-full"
               >

--- a/src/components/editor/FreeCanvas.tsx
+++ b/src/components/editor/FreeCanvas.tsx
@@ -59,7 +59,7 @@ function bgColorDisplayHex(color: string): string {
 const MIN_PHOTO_SIZE = 0.05;
 const MIN_CAPTION_VISIBLE_PX = 24;
 const ROTATION_SNAP_TARGETS = [0, 90, -90, 180] as const;
-const ROTATION_SNAP_THRESHOLD = 5;
+const ROTATION_SNAP_THRESHOLD = 3;
 const TOOLBAR_MARGIN_PX = 12;
 const TOOLBAR_WIDTH_PX = 320;
 const TOOLBAR_HEIGHT_PX = 132;
@@ -108,8 +108,8 @@ type GestureState =
   | {
       type: "rotate-photo";
       photoId: string;
-      centerX: number;
-      centerY: number;
+      centerClientX: number;
+      centerClientY: number;
       startAngle: number;
       startRotation: number;
     }
@@ -378,12 +378,6 @@ export default function FreeCanvas({
 
   const photoMap = useMemo(
     () => new Map(photos.map((photo) => [photo.id, photo])),
-    [photos],
-  );
-
-  // Stable index per photo id — does not change when zIndex ordering changes
-  const stablePhotoIndex = useMemo(
-    () => new Map(photos.map((photo, i) => [photo.id, i])),
     [photos],
   );
 
@@ -658,14 +652,16 @@ export default function FreeCanvas({
 
   const beginRotate = useCallback((photoId: string, clientX: number, clientY: number) => {
     const transform = transformsRef.current.find((item) => item.photoId === photoId);
-    if (!transform || containerSize.w <= 0 || containerSize.h <= 0) return;
+    const canvasRect = canvasRef.current?.getBoundingClientRect();
+    if (!transform || !canvasRect || containerSize.w <= 0 || containerSize.h <= 0) return;
 
     // Snapshot state before rotation starts
     useHistoryStore.getState().pushState();
 
-    const centerX = (transform.x + transform.width / 2) * containerSize.w;
-    const centerY = (transform.y + transform.height / 2) * containerSize.h;
-    const startAngle = (Math.atan2(clientY - centerY, clientX - centerX) * 180) / Math.PI + 90;
+    const centerClientX = canvasRect.left + (transform.x + transform.width / 2) * containerSize.w;
+    const centerClientY = canvasRect.top + (transform.y + transform.height / 2) * containerSize.h;
+    const startAngle =
+      (Math.atan2(clientY - centerClientY, clientX - centerClientX) * 180) / Math.PI + 90;
 
     setEditingCaptionId(null);
     const nextSelection = createSingleSelection({ kind: "photo", photoId });
@@ -674,8 +670,8 @@ export default function FreeCanvas({
     setActiveGesture({
       type: "rotate-photo",
       photoId,
-      centerX,
-      centerY,
+      centerClientX,
+      centerClientY,
       startAngle,
       startRotation: transform.rotation,
     });
@@ -865,12 +861,15 @@ export default function FreeCanvas({
 
       if (activeGesture.type === "rotate-photo") {
         const currentAngle =
-          (Math.atan2(event.clientY - activeGesture.centerY, event.clientX - activeGesture.centerX) * 180) /
+          (Math.atan2(
+            event.clientY - activeGesture.centerClientY,
+            event.clientX - activeGesture.centerClientX,
+          ) * 180) /
             Math.PI +
           90;
         const angleDelta = currentAngle - activeGesture.startAngle;
         let nextAngle = normalizeRotation(activeGesture.startRotation + angleDelta);
-        if (!event.shiftKey) {
+        if (event.shiftKey) {
           const snapTarget = getRotationSnapTarget(nextAngle);
           if (snapTarget !== undefined) {
             nextAngle = normalizeRotation(snapTarget);
@@ -1169,9 +1168,10 @@ export default function FreeCanvas({
             >
               <PhotoFrame
                 frameStyle={photoFrameStyle}
-                photoIndex={stablePhotoIndex.get(photo.id) ?? 0}
+                photoId={photo.id}
                 className="h-full w-full"
                 mediaStyle={{ borderRadius: `${borderRadius}px` }}
+                disableDecorativeRotation
               >
                 <img
                   src={photo.url}

--- a/src/components/editor/PhotoFrame.tsx
+++ b/src/components/editor/PhotoFrame.tsx
@@ -7,13 +7,14 @@ import type { PhotoFrameStyle } from "@/types";
 
 interface PhotoFrameProps {
   frameStyle: PhotoFrameStyle;
-  photoIndex: number;
+  photoId: string;
   caption?: string;
   className?: string;
   mediaClassName?: string;
   style?: CSSProperties;
   mediaStyle?: CSSProperties;
   footer?: ReactNode;
+  disableDecorativeRotation?: boolean;
   children: ReactNode;
 }
 
@@ -55,17 +56,18 @@ function FilmStripLayer({
 
 export default function PhotoFrame({
   frameStyle,
-  photoIndex,
+  photoId,
   caption,
   className,
   mediaClassName,
   style,
   mediaStyle,
   footer,
+  disableDecorativeRotation = false,
   children,
 }: PhotoFrameProps) {
   const config = getPhotoFrameStyleConfig(frameStyle);
-  const rotation = getPhotoFrameRotation(frameStyle, photoIndex);
+  const rotation = disableDecorativeRotation ? 0 : getPhotoFrameRotation(frameStyle, photoId);
   const trimmedCaption = caption?.trim();
 
   return (

--- a/src/components/editor/PhotoOverlay.tsx
+++ b/src/components/editor/PhotoOverlay.tsx
@@ -756,10 +756,11 @@ export default function PhotoOverlay({
                   >
                     <PhotoFrame
                       frameStyle={photoFrameStyle}
-                      photoIndex={index}
+                      photoId={photo.id}
                       caption={!displayIsFreeMode ? captionDisplay.text : undefined}
                       className="h-full w-full"
                       mediaStyle={{ borderRadius: `${borderRadiusPx}px` }}
+                      disableDecorativeRotation={displayIsFreeMode}
                       footer={
                         !displayIsFreeMode && hasCaption && !frameHandlesCaption ? (
                           <p
@@ -891,10 +892,11 @@ export default function PhotoOverlay({
                 >
                   <PhotoFrame
                     frameStyle={photoFrameStyle}
-                    photoIndex={index}
+                    photoId={photo.id}
                     caption={!displayIsFreeMode ? captionDisplay.text : undefined}
                     className="h-full w-full"
                     mediaStyle={{ borderRadius: `${borderRadiusPx}px` }}
+                    disableDecorativeRotation={displayIsFreeMode}
                     footer={
                       !displayIsFreeMode && hasCaption && !frameHandlesCaption ? (
                         <p
@@ -1048,10 +1050,11 @@ export default function PhotoOverlay({
                   >
                     <PhotoFrame
                       frameStyle={photoFrameStyle}
-                      photoIndex={index}
+                      photoId={photo.id}
                       caption={!incomingIsFreeMode ? captionDisplay.text : undefined}
                       className="h-full w-full"
                       mediaStyle={{ borderRadius: `${incomingBorderRadiusPx}px` }}
+                      disableDecorativeRotation={incomingIsFreeMode}
                       footer={
                         !incomingIsFreeMode && hasCaption && !frameHandlesCaption ? (
                           <p

--- a/src/lib/frameStyles.ts
+++ b/src/lib/frameStyles.ts
@@ -95,12 +95,22 @@ export function frameStyleUsesInlineCaption(style: PhotoFrameStyle): boolean {
   return PHOTO_FRAME_STYLE_CONFIGS[style].inlineCaption;
 }
 
-export function getPhotoFrameRotation(style: PhotoFrameStyle, photoIndex: number): number {
+function hashPhotoId(photoId: string): number {
+  let hash = 0;
+
+  for (let index = 0; index < photoId.length; index += 1) {
+    hash = (hash * 31 + photoId.charCodeAt(index)) >>> 0;
+  }
+
+  return hash;
+}
+
+export function getPhotoFrameRotation(style: PhotoFrameStyle, photoId: string): number {
   if (style !== "polaroid") {
     return 0;
   }
 
-  const seeded = Math.sin((photoIndex + 1) * 12.9898 + 78.233) * 43758.5453;
+  const seeded = Math.sin((hashPhotoId(photoId) + 1) * 12.9898 + 78.233) * 43758.5453;
   const normalized = seeded - Math.floor(seeded);
   return Number((((normalized * 2) - 1) * 2).toFixed(2));
 }


### PR DESCRIPTION
## Summary
- fix FreeCanvas rotation to use a client-space pivot and make Shift enable snapping with a tighter threshold
- disable decorative polaroid tilt in Free mode while keeping it for other layouts
- seed decorative tilt from photo identity so editor and playback stay aligned

## Verification
- npx tsc --noEmit
- npx next build
- npm run build