### PR TITLE
fix: prevent OOM crash in Free mode (history store photo URL cloning)

### DIFF
--- a/src/stores/historyStore.ts
+++ b/src/stores/historyStore.ts
@@ -1,16 +1,46 @@
 import { create } from "zustand";
 import { useProjectStore, invalidateSerializationCache } from "./projectStore";
-import type { Location, Segment, MapStyle } from "@/types";
+import type { Location, Segment, MapStyle, Photo } from "@/types";
+
+/**
+ * Lightweight photo shape that excludes the heavy `url` field.
+ * Photo URLs (data: or blob:) can be megabytes each; cloning them into
+ * every undo snapshot was the #1 cause of renderer-process OOM crashes
+ * in Free-mode editing (Error code: 5).
+ *
+ * On restore we re-attach URLs from a shared registry that the project
+ * store maintains — the binary data only exists once in memory.
+ */
+interface LightPhoto {
+  id: string;
+  locationId: string;
+  caption?: string;
+  focalPoint?: { x: number; y: number };
+}
+
+interface LightLocation {
+  id: string;
+  name: string;
+  nameZh?: string;
+  coordinates: [number, number];
+  photos: LightPhoto[];
+  isWaypoint: boolean;
+  photoLayout?: Location["photoLayout"];
+  chapterTitle?: string;
+  chapterNote?: string;
+  chapterDate?: string;
+  chapterEmoji?: string;
+}
 
 interface HistorySnapshot {
   projectId: string | null;
-  locations: Location[];
+  locations: LightLocation[];
   segments: Segment[];
   mapStyle: MapStyle;
   segmentTimingOverrides: Record<string, number>;
 }
 
-const MAX_HISTORY = 50;
+const MAX_HISTORY = 30;
 
 interface HistoryState {
   undoStack: HistorySnapshot[];
@@ -23,12 +53,77 @@ interface HistoryState {
   redo: () => void;
 }
 
+/**
+ * Global registry mapping photo id → url.  Populated whenever photos are
+ * loaded, added, or compressed.  Because photo URLs are immutable references
+ * (blob: or data: strings), we never need to clone them — just keep the
+ * latest pointer.  This lets undo/redo restore photos without duplicating
+ * the heavy URL payload.
+ */
+const photoUrlRegistry = new Map<string, string>();
+
+/** Call whenever photo URLs become known (load, add, compress-swap). */
+export function registerPhotoUrl(photoId: string, url: string): void {
+  photoUrlRegistry.set(photoId, url);
+}
+
+/** Bulk-register from a full locations array. */
+export function registerPhotoUrls(locations: Location[]): void {
+  for (const loc of locations) {
+    for (const photo of loc.photos) {
+      photoUrlRegistry.set(photo.id, photo.url);
+    }
+  }
+}
+
+/** Strip the heavy url field from a photo. */
+function stripPhoto(photo: Photo): LightPhoto {
+  return {
+    id: photo.id,
+    locationId: photo.locationId,
+    ...(photo.caption != null ? { caption: photo.caption } : {}),
+    ...(photo.focalPoint ? { focalPoint: { ...photo.focalPoint } } : {}),
+  };
+}
+
+/** Strip photos from a location (shallow clone metadata, strip photo urls). */
+function stripLocation(loc: Location): LightLocation {
+  return {
+    id: loc.id,
+    name: loc.name,
+    ...(loc.nameZh != null ? { nameZh: loc.nameZh } : {}),
+    coordinates: [...loc.coordinates] as [number, number],
+    photos: loc.photos.map(stripPhoto),
+    isWaypoint: loc.isWaypoint,
+    ...(loc.photoLayout ? { photoLayout: structuredClone(loc.photoLayout) } : {}),
+    ...(loc.chapterTitle != null ? { chapterTitle: loc.chapterTitle } : {}),
+    ...(loc.chapterNote != null ? { chapterNote: loc.chapterNote } : {}),
+    ...(loc.chapterDate != null ? { chapterDate: loc.chapterDate } : {}),
+    ...(loc.chapterEmoji != null ? { chapterEmoji: loc.chapterEmoji } : {}),
+  };
+}
+
+/** Rehydrate a light location back into a full Location by restoring photo URLs. */
+function rehydrateLocation(light: LightLocation): Location {
+  return {
+    ...light,
+    photos: light.photos.map((lp) => ({
+      ...lp,
+      url: photoUrlRegistry.get(lp.id) ?? "",
+    })),
+  } as Location;
+}
+
 function captureSnapshot(): HistorySnapshot {
   const { currentProjectId, locations, segments, mapStyle, segmentTimingOverrides } =
     useProjectStore.getState();
+
+  // Ensure the registry is up-to-date before snapshotting
+  registerPhotoUrls(locations);
+
   return {
     projectId: currentProjectId,
-    locations: structuredClone(locations),
+    locations: locations.map(stripLocation),
     segments: structuredClone(segments),
     mapStyle,
     segmentTimingOverrides: { ...segmentTimingOverrides },
@@ -37,7 +132,7 @@ function captureSnapshot(): HistorySnapshot {
 
 function restoreSnapshot(snapshot: HistorySnapshot): void {
   useProjectStore.setState({
-    locations: snapshot.locations,
+    locations: snapshot.locations.map(rehydrateLocation),
     segments: snapshot.segments,
     mapStyle: snapshot.mapStyle,
     segmentTimingOverrides: snapshot.segmentTimingOverrides,

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_TRANSPORT_ICON_STYLE,
   resolveTransportIconStyle,
 } from "@/lib/transportIcons";
-import { useHistoryStore } from "./historyStore";
+import { useHistoryStore, registerPhotoUrl, registerPhotoUrls } from "./historyStore";
 import {
   saveProject,
   getProjectData,
@@ -390,6 +390,8 @@ async function runBackgroundPhotoCompression(): Promise<void> {
           console.log(`[compress] ${photo.id}: URL changed during compression, discarded`);
         } else {
           compressed++;
+          // Update the URL registry so undo/redo uses the compressed version
+          registerPhotoUrl(photo.id, compressedUrl);
           console.log(`[compress] ✅ ${photo.id} replaced`);
         }
 
@@ -1288,12 +1290,15 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   addPhoto: (locationId, photo) => {
     useHistoryStore.getState().pushState();
     markLocationDirty(locationId);
+    const newId = generateId();
+    // Register the photo URL so undo/redo can restore it without cloning
+    registerPhotoUrl(newId, photo.url);
     return set((state) => ({
       locations: state.locations.map((l) =>
         l.id === locationId
           ? {
               ...l,
-              photos: [...l.photos, { ...photo, id: generateId(), locationId }],
+              photos: [...l.photos, { ...photo, id: newId, locationId }],
             }
           : l,
       ),
@@ -1404,6 +1409,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       segmentTimingOverrides: parsed.segmentTimingOverrides,
       segmentColors: {},
     });
+
+    // Register photo URLs for undo/redo
+    registerPhotoUrls(parsed.locations);
   },
 
   loadRouteData: async (data) => {
@@ -1501,6 +1509,9 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         projects,
       });
       tryUpdateLastSavedJson(data);
+
+      // Register all photo URLs so undo/redo can restore them without cloning
+      registerPhotoUrls(parsed.locations);
 
       useHistoryStore.getState().resetHistory();
       await get().regenerateSegmentGeometries();
@@ -1634,6 +1645,10 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
         segmentColors: {},
       });
       tryUpdateLastSavedJson(data);
+
+      // Register photo URLs for undo/redo
+      registerPhotoUrls(parsed.locations);
+
       useHistoryStore.getState().resetHistory();
 
       await get().regenerateSegmentGeometries();


### PR DESCRIPTION
## Problem

Free mode editing in Chrome crashes with **"Aw, Snap!" Error code: 5** (renderer process OOM).

## Root Cause

`historyStore.captureSnapshot()` used `structuredClone(locations)` which **deep-copied every photo's data URL string** into every undo snapshot.

**Math:**
- 10 photos × ~300KB per data URL = 3MB per snapshot
- MAX_HISTORY = 50 snapshots = **150MB** in undo stack alone
- JS UTF-16 encoding doubles string memory → **~300MB**
- Free mode operations (drag, rotate, resize) each call `pushState()`
- Combined with Zustand immutable updates → exceeds Chrome's ~1-2GB renderer limit

## Fix

### History Store (`historyStore.ts`)
- Snapshots now store **`LightPhoto`** objects (id, caption, focalPoint) — **no url field**
- A `photoUrlRegistry` (`Map<photoId, url>`) maintains the single source of truth
- On undo/redo, photos are **rehydrated** from the registry
- `MAX_HISTORY` reduced from 50 → 30

### Project Store (`projectStore.ts`)
- Calls `registerPhotoUrl()` / `registerPhotoUrls()` on:
  - Project restore/load
  - Photo add
  - Background compression (URL swap)
  - Project switch
  - Route import

### Memory Savings
| Metric | Before | After |
|---|---|---|
| Per-snapshot photo data | ~3MB (10 photos) | ~1KB (metadata only) |
| 30 snapshots total | ~90MB | ~30KB |
| With JS string overhead | ~180MB+ | ~30KB |

**~95%+ reduction in history store memory.**

## Testing
- TypeScript: ✅ zero errors
- Build: ✅ successful
- Undo/redo: photos restore correctly via registry lookup