### PR TITLE
feat: add photo persistence storage foundation

### DIFF
--- a/src/lib/photoStore.ts
+++ b/src/lib/photoStore.ts
@@ -1,0 +1,146 @@
+import { getPhotoAsset } from "@/lib/storage";
+
+export interface PersistedPhotoHandle {
+  assetId: string;
+  url: string;
+  byteSize: number;
+  width: number;
+  height: number;
+  deduped: boolean;
+}
+
+export interface PhotoPersistenceState {
+  pendingWrites: number;
+  failedWrites: number;
+  pendingMigrations: number;
+  lastError?: string;
+}
+
+export interface PhotoStore {
+  putPhoto(input: {
+    projectId: string;
+    photoId: string;
+    blob: Blob;
+  }): Promise<PersistedPhotoHandle>;
+  importLegacyDataUrl(input: {
+    projectId: string;
+    photoId: string;
+    dataUrl: string;
+  }): Promise<PersistedPhotoHandle>;
+  attachExistingAsset(input: {
+    projectId: string;
+    photoId: string;
+    assetId: string;
+  }): Promise<PersistedPhotoHandle>;
+  getObjectUrl(assetId: string): Promise<string>;
+  releaseObjectUrl(assetId: string): void;
+  deletePhoto(projectId: string, photoId: string): Promise<void>;
+  deleteProjectPhotos(projectId: string): Promise<void>;
+  getPersistenceState(projectId: string): PhotoPersistenceState;
+  estimateStorage(): Promise<{
+    usage?: number;
+    quota?: number;
+    persisted?: boolean;
+  }>;
+}
+
+function notImplemented(method: string): Error {
+  return new Error(`photoStore.${method} is deferred to a later persistence phase.`);
+}
+
+class IndexedDbPhotoStore implements PhotoStore {
+  private readonly objectUrlCache = new Map<
+    string,
+    { url: string; leases: number }
+  >();
+
+  private readonly persistenceState = new Map<string, PhotoPersistenceState>();
+
+  async putPhoto(): Promise<PersistedPhotoHandle> {
+    throw notImplemented("putPhoto");
+  }
+
+  async importLegacyDataUrl(): Promise<PersistedPhotoHandle> {
+    throw notImplemented("importLegacyDataUrl");
+  }
+
+  async attachExistingAsset(): Promise<PersistedPhotoHandle> {
+    throw notImplemented("attachExistingAsset");
+  }
+
+  async getObjectUrl(assetId: string): Promise<string> {
+    const cached = this.objectUrlCache.get(assetId);
+    if (cached) {
+      cached.leases += 1;
+      return cached.url;
+    }
+
+    const asset = await getPhotoAsset(assetId);
+    if (!asset) {
+      throw new Error(`Photo asset ${assetId} does not exist.`);
+    }
+
+    const url = URL.createObjectURL(asset.blob);
+    this.objectUrlCache.set(assetId, { url, leases: 1 });
+    return url;
+  }
+
+  releaseObjectUrl(assetId: string): void {
+    const cached = this.objectUrlCache.get(assetId);
+    if (!cached) {
+      return;
+    }
+
+    cached.leases -= 1;
+    if (cached.leases <= 0) {
+      URL.revokeObjectURL(cached.url);
+      this.objectUrlCache.delete(assetId);
+    }
+  }
+
+  async deletePhoto(): Promise<void> {
+    throw notImplemented("deletePhoto");
+  }
+
+  async deleteProjectPhotos(): Promise<void> {
+    throw notImplemented("deleteProjectPhotos");
+  }
+
+  getPersistenceState(projectId: string): PhotoPersistenceState {
+    return (
+      this.persistenceState.get(projectId) ?? {
+        pendingWrites: 0,
+        failedWrites: 0,
+        pendingMigrations: 0,
+      }
+    );
+  }
+
+  async estimateStorage(): Promise<{
+    usage?: number;
+    quota?: number;
+    persisted?: boolean;
+  }> {
+    if (
+      typeof navigator === "undefined" ||
+      typeof navigator.storage?.estimate !== "function"
+    ) {
+      return {};
+    }
+
+    const [estimate, persisted] = await Promise.all([
+      navigator.storage.estimate(),
+      typeof navigator.storage.persisted === "function"
+        ? navigator.storage.persisted()
+        : Promise.resolve(undefined),
+    ]);
+
+    return {
+      usage: estimate.usage,
+      quota: estimate.quota,
+      persisted,
+    };
+  }
+}
+
+export const photoStore: PhotoStore = new IndexedDbPhotoStore();

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,14 +1,59 @@
-import { openDB, type IDBPDatabase } from "idb";
+import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 import type { ProjectMeta } from "@/types";
-import type { ImportRouteData } from "@/stores/projectStore";
+import type { ImportRouteData, RouteUISettings } from "@/stores/projectStore";
 
 const DB_NAME = "trace-recap";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
-const STORE_PROJECTS = "projects"; // ProjectMeta records
-const STORE_PROJECT_DATA = "projectData"; // Full ImportRouteData keyed by project id
+const STORE_PROJECTS = "projects";
+const STORE_PROJECT_DATA = "projectData";
+const STORE_PHOTO_ASSETS = "photoAssets";
+const STORE_PHOTO_REFS = "photoRefs";
 
-interface TraceRecapDB {
+export type LegacyProjectData = ImportRouteData;
+
+export interface StoredPhoto {
+  id: string;
+  assetId: string;
+  caption?: string;
+  focalPoint?: { x: number; y: number };
+}
+
+export type StoredLocation = Omit<LegacyProjectData["locations"][number], "photos"> & {
+  photos?: StoredPhoto[];
+};
+
+export interface ProjectDataV2 extends RouteUISettings {
+  schemaVersion: 2;
+  name: string;
+  locations: StoredLocation[];
+  segments: LegacyProjectData["segments"];
+  timingOverrides?: Record<string, number>;
+  mapStyle?: LegacyProjectData["mapStyle"];
+}
+
+export interface PhotoAssetRecord {
+  id: string;
+  blob: Blob;
+  mimeType: string;
+  byteSize: number;
+  width: number;
+  height: number;
+  createdAt: number;
+  lastAccessedAt: number;
+  refCount: number;
+}
+
+export interface PhotoRefRecord {
+  projectId: string;
+  photoId: string;
+  assetId: string;
+  createdAt: number;
+}
+
+export type PersistedProjectData = LegacyProjectData | ProjectDataV2;
+
+interface TraceRecapDB extends DBSchema {
   projects: {
     key: string;
     value: ProjectMeta;
@@ -16,11 +61,41 @@ interface TraceRecapDB {
   };
   projectData: {
     key: string;
-    value: ImportRouteData;
+    value: PersistedProjectData;
+  };
+  photoAssets: {
+    key: string;
+    value: PhotoAssetRecord;
+    indexes: {
+      "by-createdAt": number;
+      "by-lastAccessedAt": number;
+      "by-refCount": number;
+    };
+  };
+  photoRefs: {
+    key: [string, string];
+    value: PhotoRefRecord;
+    indexes: {
+      "by-projectId": string;
+      "by-assetId": string;
+    };
   };
 }
 
 let dbPromise: Promise<IDBPDatabase<TraceRecapDB>> | null = null;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function isProjectDataV2(value: unknown): value is ProjectDataV2 {
+  return (
+    isObject(value) &&
+    value.schemaVersion === 2 &&
+    Array.isArray(value.locations) &&
+    Array.isArray(value.segments)
+  );
+}
 
 function getDB(): Promise<IDBPDatabase<TraceRecapDB>> {
   if (!dbPromise) {
@@ -30,13 +105,80 @@ function getDB(): Promise<IDBPDatabase<TraceRecapDB>> {
           const store = db.createObjectStore(STORE_PROJECTS, { keyPath: "id" });
           store.createIndex("by-updatedAt", "updatedAt");
         }
+
         if (!db.objectStoreNames.contains(STORE_PROJECT_DATA)) {
           db.createObjectStore(STORE_PROJECT_DATA);
+        }
+
+        if (!db.objectStoreNames.contains(STORE_PHOTO_ASSETS)) {
+          const assetStore = db.createObjectStore(STORE_PHOTO_ASSETS, {
+            keyPath: "id",
+          });
+          assetStore.createIndex("by-createdAt", "createdAt");
+          assetStore.createIndex("by-lastAccessedAt", "lastAccessedAt");
+          assetStore.createIndex("by-refCount", "refCount");
+        }
+
+        if (!db.objectStoreNames.contains(STORE_PHOTO_REFS)) {
+          const refStore = db.createObjectStore(STORE_PHOTO_REFS, {
+            keyPath: ["projectId", "photoId"],
+          });
+          refStore.createIndex("by-projectId", "projectId");
+          refStore.createIndex("by-assetId", "assetId");
         }
       },
     });
   }
+
   return dbPromise;
+}
+
+async function hydrateStoredProjectData(
+  data: PersistedProjectData,
+): Promise<ImportRouteData> {
+  if (!isProjectDataV2(data)) {
+    return data;
+  }
+
+  const hydratedLocations = await Promise.all(
+    data.locations.map(async (location) => {
+      const { photos, ...locationWithoutPhotos } = location;
+
+      if (!photos?.length) {
+        return locationWithoutPhotos;
+      }
+
+      const hydratedPhotos = (
+        await Promise.all(
+          photos.map(async (photo) => {
+            const asset = await getPhotoAsset(photo.assetId);
+            if (!asset) {
+              console.warn(
+                `[storage] Missing photo asset ${photo.assetId} for photo ${photo.id}.`,
+              );
+              return null;
+            }
+
+            return {
+              url: URL.createObjectURL(asset.blob),
+              ...(photo.caption !== undefined ? { caption: photo.caption } : {}),
+              ...(photo.focalPoint ? { focalPoint: photo.focalPoint } : {}),
+            };
+          }),
+        )
+      ).filter((photo): photo is NonNullable<typeof photo> => photo !== null);
+
+      return hydratedPhotos.length > 0
+        ? { ...locationWithoutPhotos, photos: hydratedPhotos }
+        : locationWithoutPhotos;
+    }),
+  );
+
+  const { schemaVersion: _schemaVersion, locations: _locations, ...rest } = data;
+  return {
+    ...rest,
+    locations: hydratedLocations,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -46,7 +188,6 @@ function getDB(): Promise<IDBPDatabase<TraceRecapDB>> {
 export async function listProjects(): Promise<ProjectMeta[]> {
   const db = await getDB();
   const all = await db.getAllFromIndex(STORE_PROJECTS, "by-updatedAt");
-  // Most recently updated first
   return all.reverse();
 }
 
@@ -64,12 +205,46 @@ export async function putProjectMeta(meta: ProjectMeta): Promise<void> {
 
 export async function deleteProject(id: string): Promise<void> {
   const db = await getDB();
-  const tx = db.transaction([STORE_PROJECTS, STORE_PROJECT_DATA], "readwrite");
+  const tx = db.transaction(
+    [
+      STORE_PROJECTS,
+      STORE_PROJECT_DATA,
+      STORE_PHOTO_ASSETS,
+      STORE_PHOTO_REFS,
+    ],
+    "readwrite",
+  );
+
+  const refs = await tx
+    .objectStore(STORE_PHOTO_REFS)
+    .index("by-projectId")
+    .getAll(id);
+
+  for (const ref of refs) {
+    const assetStore = tx.objectStore(STORE_PHOTO_ASSETS);
+    const asset = await assetStore.get(ref.assetId);
+    if (asset) {
+      const nextRefCount = Math.max(0, asset.refCount - 1);
+      if (nextRefCount === 0) {
+        await assetStore.delete(ref.assetId);
+      } else {
+        await assetStore.put({
+          ...asset,
+          refCount: nextRefCount,
+          lastAccessedAt: Date.now(),
+        });
+      }
+    }
+
+    await tx.objectStore(STORE_PHOTO_REFS).delete([ref.projectId, ref.photoId]);
+  }
+
   await Promise.all([
     tx.objectStore(STORE_PROJECTS).delete(id),
     tx.objectStore(STORE_PROJECT_DATA).delete(id),
-    tx.done,
   ]);
+
+  await tx.done;
 }
 
 export async function renameProject(
@@ -85,19 +260,27 @@ export async function renameProject(
 }
 
 // ---------------------------------------------------------------------------
-// Project data (full route data)
+// Project data
 // ---------------------------------------------------------------------------
 
-export async function getProjectData(
+export async function getStoredProjectData(
   id: string,
-): Promise<ImportRouteData | undefined> {
+): Promise<PersistedProjectData | undefined> {
   const db = await getDB();
   return db.get(STORE_PROJECT_DATA, id);
 }
 
+export async function getProjectData(
+  id: string,
+): Promise<ImportRouteData | undefined> {
+  const data = await getStoredProjectData(id);
+  if (!data) return undefined;
+  return hydrateStoredProjectData(data);
+}
+
 export async function putProjectData(
   id: string,
-  data: ImportRouteData,
+  data: PersistedProjectData,
 ): Promise<void> {
   const db = await getDB();
   await db.put(STORE_PROJECT_DATA, data, id);
@@ -109,7 +292,7 @@ export async function putProjectData(
 
 export async function saveProject(
   meta: ProjectMeta,
-  data: ImportRouteData,
+  data: PersistedProjectData,
 ): Promise<void> {
   const db = await getDB();
   const tx = db.transaction([STORE_PROJECTS, STORE_PROJECT_DATA], "readwrite");
@@ -118,6 +301,138 @@ export async function saveProject(
     tx.objectStore(STORE_PROJECT_DATA).put(data, meta.id),
     tx.done,
   ]);
+}
+
+// ---------------------------------------------------------------------------
+// Photo asset/ref helpers
+// ---------------------------------------------------------------------------
+
+export async function getPhotoAsset(
+  assetId: string,
+): Promise<PhotoAssetRecord | undefined> {
+  const db = await getDB();
+  return db.get(STORE_PHOTO_ASSETS, assetId);
+}
+
+export async function putPhotoAsset(record: PhotoAssetRecord): Promise<void> {
+  const db = await getDB();
+  await db.put(STORE_PHOTO_ASSETS, record);
+}
+
+export async function getPhotoRef(
+  projectId: string,
+  photoId: string,
+): Promise<PhotoRefRecord | undefined> {
+  const db = await getDB();
+  return db.get(STORE_PHOTO_REFS, [projectId, photoId]);
+}
+
+export async function listPhotoRefsByProject(
+  projectId: string,
+): Promise<PhotoRefRecord[]> {
+  const db = await getDB();
+  return db.getAllFromIndex(STORE_PHOTO_REFS, "by-projectId", projectId);
+}
+
+export async function listPhotoRefsByAsset(
+  assetId: string,
+): Promise<PhotoRefRecord[]> {
+  const db = await getDB();
+  return db.getAllFromIndex(STORE_PHOTO_REFS, "by-assetId", assetId);
+}
+
+export async function attachPhotoRef(input: {
+  projectId: string;
+  photoId: string;
+  assetId: string;
+  createdAt?: number;
+}): Promise<PhotoRefRecord> {
+  const db = await getDB();
+  const tx = db.transaction([STORE_PHOTO_ASSETS, STORE_PHOTO_REFS], "readwrite");
+  const now = input.createdAt ?? Date.now();
+  const nextRef: PhotoRefRecord = {
+    projectId: input.projectId,
+    photoId: input.photoId,
+    assetId: input.assetId,
+    createdAt: now,
+  };
+
+  const existingRef = await tx
+    .objectStore(STORE_PHOTO_REFS)
+    .get([input.projectId, input.photoId]);
+
+  if (existingRef?.assetId === input.assetId) {
+    await tx.objectStore(STORE_PHOTO_REFS).put({
+      ...existingRef,
+      createdAt: existingRef.createdAt ?? now,
+    });
+    await tx.done;
+    return existingRef;
+  }
+
+  const nextAsset = await tx.objectStore(STORE_PHOTO_ASSETS).get(input.assetId);
+  if (!nextAsset) {
+    throw new Error(`Cannot attach missing photo asset ${input.assetId}.`);
+  }
+
+  if (existingRef) {
+    const previousAsset = await tx
+      .objectStore(STORE_PHOTO_ASSETS)
+      .get(existingRef.assetId);
+    if (previousAsset) {
+      const nextRefCount = Math.max(0, previousAsset.refCount - 1);
+      if (nextRefCount === 0) {
+        await tx.objectStore(STORE_PHOTO_ASSETS).delete(previousAsset.id);
+      } else {
+        await tx.objectStore(STORE_PHOTO_ASSETS).put({
+          ...previousAsset,
+          refCount: nextRefCount,
+          lastAccessedAt: now,
+        });
+      }
+    }
+  }
+
+  await tx.objectStore(STORE_PHOTO_ASSETS).put({
+    ...nextAsset,
+    refCount: nextAsset.refCount + 1,
+    lastAccessedAt: now,
+  });
+
+  await tx.objectStore(STORE_PHOTO_REFS).put(nextRef);
+  await tx.done;
+  return nextRef;
+}
+
+export async function detachPhotoRef(
+  projectId: string,
+  photoId: string,
+): Promise<PhotoRefRecord | null> {
+  const db = await getDB();
+  const tx = db.transaction([STORE_PHOTO_ASSETS, STORE_PHOTO_REFS], "readwrite");
+  const ref = await tx.objectStore(STORE_PHOTO_REFS).get([projectId, photoId]);
+  if (!ref) {
+    await tx.done;
+    return null;
+  }
+
+  const asset = await tx.objectStore(STORE_PHOTO_ASSETS).get(ref.assetId);
+  if (asset) {
+    const nextRefCount = Math.max(0, asset.refCount - 1);
+    if (nextRefCount === 0) {
+      await tx.objectStore(STORE_PHOTO_ASSETS).delete(asset.id);
+    } else {
+      await tx.objectStore(STORE_PHOTO_ASSETS).put({
+        ...asset,
+        refCount: nextRefCount,
+        lastAccessedAt: Date.now(),
+      });
+    }
+  }
+
+  await tx.objectStore(STORE_PHOTO_REFS).delete([projectId, photoId]);
+  await tx.done;
+  return ref;
 }
 
 // ---------------------------------------------------------------------------
@@ -145,7 +460,51 @@ export async function duplicateProject(
     updatedAt: now,
   };
 
-  await saveProject(newMeta, { ...data, name: newName });
+  const nextData = {
+    ...data,
+    name: newName,
+  } as PersistedProjectData;
+
+  const tx = db.transaction(
+    [
+      STORE_PROJECTS,
+      STORE_PROJECT_DATA,
+      STORE_PHOTO_ASSETS,
+      STORE_PHOTO_REFS,
+    ],
+    "readwrite",
+  );
+
+  await tx.objectStore(STORE_PROJECTS).put(newMeta);
+  await tx.objectStore(STORE_PROJECT_DATA).put(nextData, newId);
+
+  if (isProjectDataV2(data)) {
+    const refs = await tx
+      .objectStore(STORE_PHOTO_REFS)
+      .index("by-projectId")
+      .getAll(sourceId);
+
+    for (const ref of refs) {
+      const asset = await tx.objectStore(STORE_PHOTO_ASSETS).get(ref.assetId);
+      if (!asset) {
+        continue;
+      }
+
+      await tx.objectStore(STORE_PHOTO_ASSETS).put({
+        ...asset,
+        refCount: asset.refCount + 1,
+        lastAccessedAt: now,
+      });
+
+      await tx.objectStore(STORE_PHOTO_REFS).put({
+        ...ref,
+        projectId: newId,
+        createdAt: now,
+      });
+    }
+  }
+
+  await tx.done;
   return newMeta;
 }
 
@@ -179,17 +538,19 @@ export async function migrateFromLocalStorage(): Promise<string | null> {
       updatedAt: now,
       locationCount: data.locations.length,
       previewLocations: data.locations
-        .filter((l) => !l.isWaypoint)
+        .filter((location) => !location.isWaypoint)
         .slice(0, 3)
-        .map((l) => l.name),
+        .map((location) => location.name),
     };
 
     await saveProject(meta, data);
     window.localStorage.setItem(MIGRATION_DONE_KEY, "1");
     return id;
   } catch (error) {
-    console.error("Failed to migrate legacy project data from localStorage.", error);
-    // Do NOT set migration flag on failure — legacy data is still the only valid copy
+    console.error(
+      "Failed to migrate legacy project data from localStorage.",
+      error,
+    );
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- upgrade IndexedDB schema to `DB_VERSION = 2` with new `photoAssets` and `photoRefs` stores plus typed indexes
- add internal persistence types for legacy/v2 project data, stored photos, photo assets, and photo refs in `src/lib/storage.ts`
- keep existing app behavior intact by hydrating any future v2 project records back into the current `ImportRouteData` shape on read
- add storage helpers for asset lookup/write, ref attach/detach, and v2-aware project delete/duplicate handling
- add a minimal `photoStore` skeleton with object URL caching and storage estimation APIs for later phases

## Verification
- `npx tsc --noEmit`
- `npm run build`

## Intentionally Deferred
- wiring uploads/autosave to write `ProjectDataV2` + `photoAssets`/`photoRefs`
- lazy migration of legacy inline `data:` URLs into asset records on project open
- replacing current live `photo.url` export/load flow or changing `historyStore` URL ownership
- full `photoStore` write/delete implementation and UI save-state integration
