### PR TITLE
feat: export dialog + playback controls polish (task-08)

### DIFF
--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -6,7 +6,13 @@ import {
   X,
   AlertTriangle,
   Check,
+  Film,
+  Monitor,
+  Smartphone,
+  Sparkles,
+  RotateCcw,
 } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -22,15 +28,19 @@ import { VideoExporter, type ExportProgress } from "@/engine/VideoExporter";
 import { getExportViewportSize } from "@/lib/viewportRatio";
 import { FPS } from "@/lib/constants";
 import { cn } from "@/lib/utils";
+import { brand } from "@/lib/brand";
 import type { ExportResolution, ExportSettings } from "@/types";
 
 const RESOLUTION_OPTIONS: Array<{
   value: ExportResolution;
   label: string;
+  subtitle: string;
+  pixels: string;
+  icon: typeof Monitor;
 }> = [
-  { value: "720p", label: "720p" },
-  { value: "1080p", label: "1080p" },
-  { value: "4K", label: "4K" },
+  { value: "720p", label: "HD", subtitle: "720p", pixels: "1280 × 720", icon: Smartphone },
+  { value: "1080p", label: "Full HD", subtitle: "1080p", pixels: "1920 × 1080", icon: Monitor },
+  { value: "4K", label: "Ultra HD", subtitle: "4K", pixels: "3840 × 2160", icon: Monitor },
 ];
 
 function estimateExportSizeBytes(
@@ -56,38 +66,68 @@ function formatEstimatedSize(bytes: number): string {
   return `~${megabytes.toFixed(1)} MB`;
 }
 
-function CircularProgress({ percent }: { percent: number }) {
-  const r = 45;
-  const circumference = 2 * Math.PI * r;
-  const offset = circumference - (percent / 100) * circumference;
+function WarmProgressBar({ percent }: { percent: number }) {
+  return (
+    <div className="w-full space-y-3">
+      <div className="relative h-3 w-full overflow-hidden rounded-full bg-orange-100">
+        <motion.div
+          className="absolute inset-y-0 left-0 rounded-full"
+          style={{
+            background: `linear-gradient(90deg, ${brand.colors.primary[400]}, ${brand.colors.primary[500]}, ${brand.colors.primary[600]})`,
+          }}
+          initial={{ width: "0%" }}
+          animate={{ width: `${percent}%` }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
+        />
+        <div
+          className="absolute inset-0 rounded-full opacity-30"
+          style={{
+            background: "linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.4) 50%, transparent 100%)",
+            animation: "shimmer 2s infinite",
+          }}
+        />
+      </div>
+      <div className="flex items-center justify-center">
+        <span
+          className="text-3xl font-bold tabular-nums"
+          style={{ color: brand.colors.primary[600] }}
+        >
+          {percent}%
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CelebrationBurst() {
+  const particles = Array.from({ length: 12 }, (_, i) => {
+    const angle = (i / 12) * 360;
+    const distance = 40 + Math.random() * 20;
+    const x = Math.cos((angle * Math.PI) / 180) * distance;
+    const y = Math.sin((angle * Math.PI) / 180) * distance;
+    const colors = [brand.colors.primary[400], brand.colors.ocean[400], brand.colors.sand[400]];
+    const color = colors[i % colors.length];
+    return { x, y, color, delay: i * 0.03, size: 3 + Math.random() * 4 };
+  });
 
   return (
-    <div className="relative w-32 h-32 mx-auto">
-      <svg viewBox="0 0 100 100" className="w-full h-full -rotate-90">
-        <circle
-          cx="50"
-          cy="50"
-          r={r}
-          fill="none"
-          stroke="#e5e7eb"
-          strokeWidth="6"
+    <div className="absolute inset-0 pointer-events-none">
+      {particles.map((p, i) => (
+        <motion.div
+          key={i}
+          className="absolute rounded-full"
+          style={{
+            width: p.size,
+            height: p.size,
+            backgroundColor: p.color,
+            left: "50%",
+            top: "50%",
+          }}
+          initial={{ x: 0, y: 0, opacity: 1, scale: 0 }}
+          animate={{ x: p.x, y: p.y, opacity: 0, scale: 1 }}
+          transition={{ duration: 0.8, delay: p.delay, ease: "easeOut" }}
         />
-        <circle
-          cx="50"
-          cy="50"
-          r={r}
-          fill="none"
-          stroke="#6366f1"
-          strokeWidth="6"
-          strokeLinecap="round"
-          strokeDasharray={circumference}
-          strokeDashoffset={offset}
-          className="transition-all duration-300"
-        />
-      </svg>
-      <div className="absolute inset-0 flex items-center justify-center">
-        <span className="text-2xl font-bold text-gray-900">{percent}%</span>
-      </div>
+      ))}
     </div>
   );
 }
@@ -265,36 +305,72 @@ export default function ExportDialog() {
   if (downloadUrl) {
     return (
       <Dialog open={open} onOpenChange={handleClose}>
-        <DialogContent className="sm:max-w-md">
-          <div className="flex flex-col items-center py-6 space-y-4">
-            <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center">
-              <Check className="h-8 w-8 text-green-600" />
+        <DialogContent className="sm:max-w-md overflow-hidden">
+          <motion.div
+            className="flex flex-col items-center py-6 space-y-5"
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.3 }}
+          >
+            <div className="relative">
+              <motion.div
+                className="w-20 h-20 rounded-full flex items-center justify-center"
+                style={{
+                  background: `linear-gradient(135deg, ${brand.colors.primary[50]}, ${brand.colors.ocean[50]})`,
+                  boxShadow: brand.shadows.glow,
+                }}
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                transition={{ type: "spring", stiffness: 300, damping: 20, delay: 0.1 }}
+              >
+                <Check className="h-10 w-10" style={{ color: brand.colors.primary[500] }} />
+              </motion.div>
+              <CelebrationBurst />
             </div>
-            <div className="text-center">
-              <h3 className="text-lg font-semibold">Export Complete!</h3>
+            <motion.div
+              className="text-center"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+            >
+              <h3 className="text-xl font-semibold" style={{ color: brand.colors.warm[800] }}>
+                Your video is ready!
+              </h3>
               {downloadSize && (
-                <p className="text-sm text-muted-foreground mt-1">
-                  File size: {downloadSize}
+                <p className="text-sm mt-1" style={{ color: brand.colors.warm[500] }}>
+                  {downloadSize}
                 </p>
               )}
-            </div>
-            <div className="flex gap-2 w-full">
+            </motion.div>
+            <motion.div
+              className="flex gap-3 w-full"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3 }}
+            >
               <a href={downloadUrl} download={`trace-recap.${downloadExt}`} className="flex-1">
-                <Button className="w-full bg-indigo-500 hover:bg-indigo-600">
-                  <Download className="h-4 w-4 mr-2" />
+                <Button
+                  className="w-full h-12 text-base font-medium text-white"
+                  style={{
+                    background: `linear-gradient(135deg, ${brand.colors.primary[500]}, ${brand.colors.primary[600]})`,
+                    boxShadow: `0 4px 14px 0 rgba(249, 115, 22, 0.3)`,
+                  }}
+                >
+                  <Download className="h-5 w-5 mr-2" />
                   Download {downloadExt.toUpperCase()}
                 </Button>
               </a>
               <Button
                 variant="outline"
-                className="flex-1"
+                className="h-12 px-5"
+                style={{ borderColor: brand.colors.warm[200] }}
                 onClick={() => handleClose(false)}
               >
                 Close
               </Button>
-            </div>
+            </motion.div>
             {encodingMethod && (
-              <p className="text-xs text-muted-foreground text-center">
+              <p className="text-xs" style={{ color: brand.colors.warm[400] }}>
                 {encodingMethod === "webcodecs"
                   ? "Encoded locally with WebCodecs"
                   : encodingMethod === "mediarecorder"
@@ -302,31 +378,43 @@ export default function ExportDialog() {
                   : "Encoded on server"}
               </p>
             )}
-          </div>
+          </motion.div>
         </DialogContent>
       </Dialog>
     );
   }
 
-  // Exporting state with circular progress
+  // Exporting state with warm progress bar
   if (isExporting && progress) {
     return (
       <Dialog open={open} onOpenChange={handleClose}>
         <DialogContent className="sm:max-w-md">
-          <div className="flex flex-col items-center py-6 space-y-4">
-            <CircularProgress percent={progressPercent} />
-            <p className="text-sm text-muted-foreground">
+          <motion.div
+            className="flex flex-col items-center py-8 space-y-6"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+          >
+            <motion.div
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: "spring", stiffness: 200 }}
+            >
+              <Film className="h-8 w-8" style={{ color: brand.colors.primary[500] }} />
+            </motion.div>
+            <WarmProgressBar percent={progressPercent} />
+            <p className="text-sm font-medium" style={{ color: brand.colors.warm[600] }}>
               {phaseLabel(progress.phase)}
             </p>
             <Button
-              variant="destructive"
+              variant="outline"
               className="w-full"
+              style={{ borderColor: brand.colors.warm[300], color: brand.colors.warm[600] }}
               onClick={handleCancel}
             >
               <X className="h-4 w-4 mr-2" />
-              Cancel
+              Cancel Export
             </Button>
-          </div>
+          </motion.div>
         </DialogContent>
       </Dialog>
     );
@@ -336,65 +424,137 @@ export default function ExportDialog() {
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Export Video</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5" style={{ color: brand.colors.primary[500] }} />
+            <span>Export Your Recap</span>
+          </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
-          <p className="text-sm text-muted-foreground">
-            Exports exactly what you see — the viewport ratio controls the video dimensions.
+        <div className="space-y-5 py-1">
+          <p className="text-sm" style={{ color: brand.colors.warm[500] }}>
+            Choose a resolution and export your travel video.
           </p>
 
-          <div className="space-y-3">
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">Resolution</p>
-              <div className="grid grid-cols-3 gap-2">
-                {RESOLUTION_OPTIONS.map((option) => (
-                  <button
+          {/* Resolution cards */}
+          <div className="space-y-2">
+            <p className="text-sm font-medium" style={{ color: brand.colors.warm[700] }}>
+              Resolution
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {RESOLUTION_OPTIONS.map((option) => {
+                const isSelected = resolution === option.value;
+                const Icon = option.icon;
+                return (
+                  <motion.button
                     key={option.value}
                     type="button"
-                    aria-pressed={resolution === option.value}
+                    aria-pressed={isSelected}
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
                     className={cn(
-                      "rounded-lg border px-3 py-2 text-sm font-medium transition-colors",
-                      resolution === option.value
-                        ? "border-indigo-500 bg-indigo-50 text-indigo-700"
-                        : "border-border bg-background text-foreground hover:bg-muted/60",
+                      "relative flex flex-col items-center gap-1 rounded-xl border-2 px-3 py-3 transition-colors",
+                      isSelected
+                        ? "border-orange-400 bg-orange-50"
+                        : "border-stone-200 bg-white hover:border-stone-300 hover:bg-stone-50",
                     )}
+                    style={isSelected ? { boxShadow: `0 0 0 1px ${brand.colors.primary[200]}, ${brand.shadows.sm}` } : undefined}
                     onClick={() => setResolution(option.value)}
                   >
-                    {option.label}
-                  </button>
-                ))}
-              </div>
+                    <Icon
+                      className="h-5 w-5"
+                      style={{ color: isSelected ? brand.colors.primary[500] : brand.colors.warm[400] }}
+                    />
+                    <span
+                      className="text-sm font-semibold"
+                      style={{ color: isSelected ? brand.colors.primary[700] : brand.colors.warm[700] }}
+                    >
+                      {option.label}
+                    </span>
+                    <span
+                      className="text-[11px]"
+                      style={{ color: isSelected ? brand.colors.primary[500] : brand.colors.warm[400] }}
+                    >
+                      {option.pixels}
+                    </span>
+                  </motion.button>
+                );
+              })}
             </div>
-
-            <p className="text-sm text-muted-foreground">
-              Estimated size:{" "}
-              <span className="font-medium text-foreground">
-                {estimatedSizeLabel}
-              </span>
-            </p>
-
-            {resolution === "4K" && (
-              <p className="text-xs text-amber-600">
-                4K export may be slow on some devices
-              </p>
-            )}
           </div>
 
-          <Button
-            className="w-full h-12 bg-indigo-500 hover:bg-indigo-600 text-base font-medium"
-            onClick={handleQuickExport}
-            disabled={segments.length === 0}
+          {/* Estimated info */}
+          <div
+            className="flex items-center justify-between rounded-lg px-4 py-3"
+            style={{ backgroundColor: brand.colors.primary[50] }}
           >
-            Export Video
-          </Button>
+            <span className="text-sm" style={{ color: brand.colors.warm[600] }}>
+              Estimated size
+            </span>
+            <span className="text-sm font-semibold" style={{ color: brand.colors.primary[700] }}>
+              {estimatedSizeLabel}
+            </span>
+          </div>
 
-          {exportError && (
-            <div className="flex items-start gap-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
-              <span>{exportError}</span>
-            </div>
-          )}
+          <AnimatePresence>
+            {resolution === "4K" && (
+              <motion.p
+                className="text-xs flex items-center gap-1.5 px-1"
+                style={{ color: brand.colors.sand[700] }}
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+              >
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" style={{ color: brand.colors.sand[600] }} />
+                4K export may be slow on some devices
+              </motion.p>
+            )}
+          </AnimatePresence>
+
+          {/* Export button */}
+          <motion.div whileHover={{ scale: 1.01 }} whileTap={{ scale: 0.99 }}>
+            <Button
+              className="w-full h-12 text-base font-medium text-white"
+              style={{
+                background: `linear-gradient(135deg, ${brand.colors.primary[500]}, ${brand.colors.primary[600]})`,
+                boxShadow: `0 4px 14px 0 rgba(249, 115, 22, 0.25)`,
+              }}
+              onClick={handleQuickExport}
+              disabled={segments.length === 0}
+            >
+              <Film className="h-5 w-5 mr-2" />
+              Export Video
+            </Button>
+          </motion.div>
+
+          {/* Error state */}
+          <AnimatePresence>
+            {exportError && (
+              <motion.div
+                className="flex flex-col gap-3 rounded-xl p-4"
+                style={{
+                  backgroundColor: "rgba(239, 68, 68, 0.06)",
+                  border: "1px solid rgba(239, 68, 68, 0.15)",
+                }}
+                initial={{ opacity: 0, y: -8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -8 }}
+              >
+                <div className="flex items-start gap-2 text-sm text-red-700">
+                  <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-red-500" />
+                  <span>{exportError}</span>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="self-end text-red-600 border-red-200 hover:bg-red-50"
+                  onClick={handleQuickExport}
+                >
+                  <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+                  Retry
+                </Button>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { useAnimationStore } from "@/stores/animationStore";
 import { useUIStore } from "@/stores/uiStore";
+import { brand } from "@/lib/brand";
 import OnboardingHint from "./OnboardingHint";
 
 interface PlaybackControlsProps {
@@ -109,10 +110,13 @@ export default memo(function PlaybackControls({
       : "md:absolute md:bottom-4 md:left-1/2 md:right-auto md:w-auto md:-translate-x-1/2 md:z-10",
   ].join(" ");
   const barClassName = [
-    "flex items-center overflow-hidden rounded-none border border-white/50 shadow-xl transition-all duration-300 ease-in-out md:rounded-2xl",
+    "flex items-center overflow-hidden border shadow-xl transition-all duration-300 ease-in-out rounded-none md:rounded-2xl",
     isPlaying
-      ? "w-full gap-2 bg-white/30 px-3 py-1 backdrop-blur-sm md:gap-3 md:px-4"
-      : "w-full gap-2 bg-white/90 px-3 py-2 backdrop-blur-xl md:w-auto md:gap-3 md:px-4",
+      ? "w-full gap-2 px-3 py-1.5 backdrop-blur-md md:gap-3 md:px-4"
+      : "w-full gap-2 px-3 py-2.5 backdrop-blur-xl md:w-auto md:gap-3 md:px-5",
+    isPlaying
+      ? "bg-stone-900/70 border-white/20"
+      : "bg-white/95 border-stone-200/80",
   ].join(" ");
   const resetContainerClassName = [
     "overflow-hidden transition-all duration-300 ease-in-out",
@@ -124,19 +128,8 @@ export default memo(function PlaybackControls({
     "overflow-hidden whitespace-nowrap text-right transition-all duration-300 ease-in-out",
     isPlaying
       ? "pointer-events-none w-0 -ml-2 opacity-0 md:-ml-3"
-      : "w-[70px] opacity-100",
+      : "w-[82px] opacity-100",
   ].join(" ");
-  const playButtonClassName = [
-    "flex items-center justify-center rounded-full bg-indigo-500 text-white shadow-lg shadow-indigo-500/25 transition-all duration-300 ease-in-out hover:scale-105 hover:bg-indigo-600 active:scale-95",
-    isPlaying ? "h-10 w-10 md:h-7 md:w-7" : "h-14 w-14 md:h-12 md:w-12",
-  ].join(" ");
-  const sliderContainerClassName = [
-    "min-w-0 transition-all duration-300 ease-in-out",
-    isPlaying ? "flex-1" : "flex-1 md:w-96 md:flex-none",
-  ].join(" ");
-  const sliderClassName = isPlaying
-    ? "h-4 [&>div:first-child]:h-1 md:[&>div:first-child]:h-1"
-    : "h-5 [&>div:first-child]:h-2 md:[&>div:first-child]:h-1.5";
 
   return (
     <div ref={containerRef} className={containerClassName}>
@@ -146,7 +139,7 @@ export default memo(function PlaybackControls({
           <Button
             variant="ghost"
             size="icon"
-            className="h-8 w-8 shrink-0"
+            className="h-8 w-8 shrink-0 text-stone-500 hover:text-stone-700"
             onClick={onReset}
             aria-label="Reset playback"
             disabled={isPlaying}
@@ -156,7 +149,15 @@ export default memo(function PlaybackControls({
         </div>
         <div className="relative">
           <button
-            className={playButtonClassName}
+            className={[
+              "flex items-center justify-center rounded-full text-white transition-all duration-200 ease-in-out",
+              "hover:scale-105 active:scale-95",
+              isPlaying ? "h-10 w-10 md:h-8 md:w-8" : "h-14 w-14 md:h-12 md:w-12",
+            ].join(" ")}
+            style={{
+              background: `linear-gradient(135deg, ${brand.colors.primary[400]}, ${brand.colors.primary[600]})`,
+              boxShadow: `0 4px 14px 0 rgba(249, 115, 22, 0.35)`,
+            }}
             onClick={isPlaying ? onPause : onPlay}
             aria-label={isPlaying ? "Pause" : "Play"}
           >
@@ -175,9 +176,20 @@ export default memo(function PlaybackControls({
             />
           )}
         </div>
-        <div className={sliderContainerClassName}>
+        <div
+          className={[
+            "min-w-0 transition-all duration-300 ease-in-out",
+            isPlaying ? "flex-1" : "flex-1 md:w-96 md:flex-none",
+          ].join(" ")}
+        >
           <Slider
-            className={sliderClassName}
+            className={[
+              isPlaying
+                ? "h-4 [&>div:first-child]:h-1 md:[&>div:first-child]:h-1"
+                : "h-5 [&>div:first-child]:h-2 md:[&>div:first-child]:h-1.5",
+              "[&_[data-slot=slider-range]]:bg-orange-500",
+              "[&_[data-slot=slider-thumb]]:border-orange-500",
+            ].join(" ")}
             value={[progress]}
             min={0}
             max={100}
@@ -189,7 +201,13 @@ export default memo(function PlaybackControls({
           />
         </div>
         <div className={timeContainerClassName} aria-hidden={isPlaying}>
-          <span className="text-sm text-muted-foreground md:text-xs">
+          <span
+            className="text-xs tabular-nums tracking-tight"
+            style={{
+              fontFamily: brand.fonts.mono,
+              color: brand.colors.warm[500],
+            }}
+          >
             {formatTime(currentTime)} / {formatTime(totalDuration)}
           </span>
         </div>


### PR DESCRIPTION
## Summary
- **ExportDialog**: Redesigned with visual resolution cards (HD/Full HD/4K with icons and pixel dimensions), warm orange progress bar with shimmer animation, celebration burst micro-animation on completion, brand-colored estimated size display, error state with retry button, framer-motion transitions throughout
- **PlaybackControls**: Warm orange gradient play/pause button with glow shadow, orange-tinted slider track, monospace time display using brand font, dark backdrop-blur bar during playback for better contrast against map, refined spacing

## Test plan
- [ ] Open export dialog — verify resolution cards display with icons and pixel sizes
- [ ] Select each resolution (720p, 1080p, 4K) — verify estimated size updates, 4K shows warning
- [ ] Start an export — verify warm orange progress bar animates with shimmer
- [ ] Complete an export — verify celebration burst animation and "Your video is ready!" state
- [ ] Download exported video — verify download works
- [ ] Verify playback controls show warm orange play button with glow
- [ ] Play animation — verify dark backdrop bar, orange slider fill, controls transition smoothly
- [ ] Check time display uses monospace font
- [ ] `npm run build` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)