### PR TITLE
feat: mobile responsive final pass (task-11)

### DIFF
--- a/src/components/editor/BottomSheet.tsx
+++ b/src/components/editor/BottomSheet.tsx
@@ -127,13 +127,13 @@ export default function BottomSheet({
         animate={{ y: currentOffset }}
         onDragEnd={handleDragEnd}
         transition={{ type: "spring", damping: 30, stiffness: 300 }}
-        className="fixed bottom-0 left-0 right-0 z-50 flex flex-col overflow-hidden rounded-t-[24px] border-t bg-background shadow-[0_-8px_32px_rgba(0,0,0,0.12)]"
+        className="fixed bottom-0 left-0 right-0 z-50 flex touch-pan-x flex-col overflow-hidden rounded-t-[24px] border-t bg-background shadow-[0_-8px_32px_rgba(0,0,0,0.12)]"
         style={{ height: maxSheetHeight || "85vh" }}
       >
         <div className="shrink-0 px-4 pb-2 pt-3" style={{ height: collapsedHeight }}>
-          <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-gray-300" />
+          <div className="mx-auto mb-2 h-1.5 w-12 rounded-full bg-gray-300" />
           <div
-            className="mb-2 flex items-center justify-between"
+            className="mb-2 flex min-h-[44px] items-center justify-between"
             onClick={toggleSheet}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
@@ -150,17 +150,19 @@ export default function BottomSheet({
               <MapPin className="h-4 w-4" />
               <span>{stopsLabel}</span>
             </div>
-            <ChevronUp
-              className={`h-5 w-5 text-muted-foreground transition-transform duration-200 ${
-                bottomSheetState === "collapsed" ? "" : "rotate-180"
-              }`}
-            />
+            <span className="flex h-11 w-11 items-center justify-center">
+              <ChevronUp
+                className={`h-5 w-5 text-muted-foreground transition-transform duration-200 ${
+                  bottomSheetState === "collapsed" ? "" : "rotate-180"
+                }`}
+              />
+            </span>
           </div>
           <CitySearch
             className="p-0"
             hintMessage={searchHintMessage}
             onHintDismiss={onDismissSearchHint}
-            inputClassName="h-10"
+            inputClassName="h-11"
           />
         </div>
 

--- a/src/components/landing/FaqSection.tsx
+++ b/src/components/landing/FaqSection.tsx
@@ -52,7 +52,7 @@ export function FaqSection() {
             FAQ
           </p>
           <h2
-            className="mt-4 text-4xl leading-[0.96] font-semibold sm:text-5xl"
+            className="mt-4 text-3xl leading-[0.96] font-semibold sm:text-4xl lg:text-5xl"
             style={{ color: brand.colors.warm[900], fontFamily: brand.fonts.display }}
           >
             The practical questions people ask before they trust a new travel tool.
@@ -98,7 +98,7 @@ export function FaqSection() {
                   <motion.span
                     animate={{ rotate: isOpen ? 180 : 0 }}
                     transition={{ duration: 0.24 }}
-                    className="shrink-0"
+                    className="flex h-11 w-11 shrink-0 items-center justify-center"
                     style={{ color: brand.colors.primary[600] }}
                   >
                     <ChevronDown className="h-5 w-5" />

--- a/src/components/landing/FeatureShowcase.tsx
+++ b/src/components/landing/FeatureShowcase.tsx
@@ -290,7 +290,7 @@ function FeatureVisual({
           </div>
 
           <div
-            className="relative min-h-[320px] overflow-hidden rounded-[28px] border"
+            className="relative min-h-[240px] overflow-hidden rounded-[28px] border sm:min-h-[320px]"
             style={{
               borderColor: brand.colors.warm[200],
               background:
@@ -409,9 +409,9 @@ function FeatureVisual({
           </div>
         </div>
 
-        <div className="relative mt-6 min-h-[340px]">
+        <div className="relative mt-6 min-h-[280px] sm:min-h-[340px]">
           <div
-            className="absolute left-2 top-8 h-56 w-[66%] rounded-[28px] border p-4"
+            className="absolute left-1 top-8 h-48 w-[60%] rounded-[28px] border p-3 sm:left-2 sm:h-56 sm:w-[66%] sm:p-4"
             style={{
               borderColor: brand.colors.warm[200],
               background:
@@ -455,7 +455,7 @@ function FeatureVisual({
           </div>
 
           <div
-            className="absolute right-2 top-2 h-64 w-[54%] rounded-[32px] border p-4"
+            className="absolute right-1 top-2 h-52 w-[50%] rounded-[32px] border p-3 sm:right-2 sm:h-64 sm:w-[54%] sm:p-4"
             style={{
               borderColor: brand.colors.ocean[100],
               background:
@@ -558,7 +558,7 @@ function FeatureVisual({
         <Pill icon={Upload} label="4K ready" teal />
       </div>
 
-      <div className="mt-6 grid gap-4 lg:grid-cols-[minmax(0,0.82fr)_minmax(220px,0.58fr)]">
+      <div className="mt-6 grid gap-4 lg:grid-cols-[minmax(0,0.82fr)_minmax(0,0.58fr)]">
         <div
           className="relative overflow-hidden rounded-[28px] border p-4"
           style={{

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -577,7 +577,7 @@ export function LandingPage() {
                 </form>
               </div>
 
-              <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="grid grid-cols-2 gap-8 lg:grid-cols-4">
                 {footerColumns.map((column) => (
                   <div key={column.title}>
                     <h3
@@ -591,7 +591,7 @@ export function LandingPage() {
                         <Link
                           key={link.label}
                           href={link.href}
-                          className="block text-sm transition-opacity hover:opacity-80"
+                          className="flex min-h-[44px] items-center text-sm transition-opacity hover:opacity-80 sm:min-h-0"
                           style={{ color: brand.colors.warm[600] }}
                         >
                           {link.label}
@@ -682,7 +682,7 @@ function HeroMapDemo() {
           </div>
         </div>
 
-        <div className="relative mt-5 min-h-[560px] overflow-hidden rounded-[28px] border sm:min-h-[640px]">
+        <div className="relative mt-5 min-h-[380px] overflow-hidden rounded-[28px] border sm:min-h-[560px] lg:min-h-[640px]">
           <div
             className="absolute inset-0"
             style={{
@@ -756,7 +756,7 @@ function HeroMapDemo() {
           ].map((city, index) => (
             <span
               key={city.label}
-              className="absolute rounded-full px-3 py-1 text-xs font-medium sm:text-sm"
+              className="absolute hidden rounded-full px-3 py-1 text-xs font-medium min-[480px]:block sm:text-sm"
               style={{
                 ...city,
                 color: brand.colors.warm[700],
@@ -770,7 +770,7 @@ function HeroMapDemo() {
           ))}
 
           <div
-            className="absolute left-[17%] top-[23%] rounded-[18px] border px-3 py-2"
+            className="absolute left-[17%] top-[23%] hidden rounded-[18px] border px-3 py-2 sm:block"
             style={{
               borderColor: brand.colors.primary[100],
               backgroundColor: "rgba(255,247,237,0.94)",
@@ -789,7 +789,7 @@ function HeroMapDemo() {
           </div>
 
           <div
-            className="absolute left-[56%] top-[28%] rounded-[18px] border px-3 py-2"
+            className="absolute left-[56%] top-[28%] hidden rounded-[18px] border px-3 py-2 sm:block"
             style={{
               borderColor: brand.colors.ocean[100],
               backgroundColor: "rgba(240,253,250,0.94)",


### PR DESCRIPTION
## Summary
- **Landing page**: reduced hero map height on mobile (380px→560px→640px breakpoints), hid floating annotation overlays on small screens, hid city labels below 480px, increased footer link tap targets to 44px, made footer columns 2-col grid on mobile
- **Feature showcase**: scaled down photo stories cards on mobile, reduced route map min-height, fixed export grid min-width that could cause overflow
- **FAQ section**: added 44px tap target to chevron toggle, reduced heading font size on mobile (3xl→4xl→5xl)
- **Bottom sheet**: enlarged drag handle, added min-h-[44px] to toggle row, bumped search input to h-11 (44px), wrapped chevron in 44px touch target

## Test plan
- [ ] Verify no horizontal scroll at 375px, 390px, 768px, 1440px
- [ ] Check all tap targets are ≥ 44px on mobile (footer links, FAQ toggles, bottom sheet controls)
- [ ] Confirm landing page hero section scales properly at all breakpoints
- [ ] Confirm bottom sheet drag + toggle works smoothly on mobile
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)