### PR TITLE
feat: Mini Route Preview in sidebar (task-06)

### DIFF
--- a/src/components/editor/LeftPanel.tsx
+++ b/src/components/editor/LeftPanel.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { useMemo, type RefObject } from "react";
-import { lineString } from "@turf/helpers";
-import { length } from "@turf/length";
+import { type RefObject } from "react";
 import { Camera, MapPinned, Route } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { brand } from "@/lib/brand";
 import { useProjectStore } from "@/stores/projectStore";
 import { useUIStore } from "@/stores/uiStore";
 import CitySearch, { type CitySearchHandle } from "./CitySearch";
+import MiniRoutePreview from "./MiniRoutePreview";
 import RouteList from "./RouteList";
 
 interface LeftPanelProps {
@@ -17,12 +16,6 @@ interface LeftPanelProps {
   searchHintMessage?: string;
   onDismissSearchHint?: () => void;
   searchRef?: RefObject<CitySearchHandle | null>;
-}
-
-function formatDistance(distanceKm: number): string {
-  if (distanceKm < 1) return `${Math.round(distanceKm * 1000)} m`;
-  if (distanceKm < 100) return `${distanceKm.toFixed(1)} km`;
-  return `${Math.round(distanceKm)} km`;
 }
 
 export default function LeftPanel({
@@ -38,25 +31,6 @@ export default function LeftPanel({
 
   const nonWaypointLocations = locations.filter((location) => !location.isWaypoint);
   const totalPhotos = locations.reduce((sum, location) => sum + location.photos.length, 0);
-
-  const distanceEstimate = useMemo(() => {
-    const locationLookup = new Map(locations.map((location) => [location.id, location]));
-
-    return segments.reduce((sum, segment) => {
-      if (segment.geometry && segment.geometry.coordinates.length > 1) {
-        return sum + length(lineString(segment.geometry.coordinates), { units: "kilometers" });
-      }
-
-      const fromLocation = locationLookup.get(segment.fromId);
-      const toLocation = locationLookup.get(segment.toId);
-      if (!fromLocation || !toLocation) return sum;
-
-      return sum + length(
-        lineString([fromLocation.coordinates, toLocation.coordinates]),
-        { units: "kilometers" },
-      );
-    }, 0);
-  }, [locations, segments]);
 
   if (!leftPanelOpen) return null;
 
@@ -127,7 +101,7 @@ export default function LeftPanel({
           </div>
         </div>
 
-        <div className="mt-5 grid grid-cols-2 gap-3">
+        <div className="mt-5 grid grid-cols-[128px_minmax(0,1fr)] gap-3">
           <div
             className="rounded-[20px] border px-4 py-3"
             style={{
@@ -156,33 +130,11 @@ export default function LeftPanel({
             </p>
           </div>
 
-          <div
-            className="rounded-[20px] border px-4 py-3"
-            style={{
-              backgroundColor: "rgba(255,255,255,0.76)",
-              borderColor: brand.colors.ocean[200],
-              boxShadow: brand.shadows.sm,
-            }}
-          >
-            <div
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full"
-              style={{ backgroundColor: brand.colors.ocean[100] }}
-            >
-              <MapPinned
-                className="h-4 w-4"
-                style={{ color: brand.colors.ocean[700] }}
-              />
-            </div>
-            <p
-              className="mt-3 text-[11px] font-medium uppercase tracking-[0.18em]"
-              style={{ color: brand.colors.warm[500] }}
-            >
-              Distance
-            </p>
-            <p className="mt-1 text-2xl font-semibold" style={{ color: brand.colors.warm[900] }}>
-              {formatDistance(distanceEstimate)}
-            </p>
-          </div>
+          <MiniRoutePreview
+            locations={locations}
+            segments={segments}
+            className="min-w-0 overflow-hidden"
+          />
         </div>
 
         <div

--- a/src/components/editor/MiniRoutePreview.tsx
+++ b/src/components/editor/MiniRoutePreview.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useMemo } from "react";
+import { brand } from "@/lib/brand";
+import type { Location, Segment, TransportMode } from "@/types";
+
+interface MiniRoutePreviewProps {
+  locations: Location[];
+  segments: Segment[];
+  className?: string;
+}
+
+interface ProjectedPoint {
+  id: string;
+  name: string;
+  isWaypoint: boolean;
+  x: number;
+  y: number;
+  accent: string;
+}
+
+interface RouteSegment {
+  key: string;
+  from: ProjectedPoint;
+  to: ProjectedPoint;
+  color: string;
+}
+
+const VIEWBOX_WIDTH = 320;
+const VIEWBOX_HEIGHT = 80;
+const INNER_PADDING_X = 16;
+const INNER_PADDING_Y = 12;
+const MIN_LONGITUDE_SPAN = 0.18;
+const MIN_MERCATOR_SPAN = 0.12;
+
+const MODE_COLORS: Record<TransportMode, string> = {
+  flight: brand.colors.primary[500],
+  car: brand.colors.sand[500],
+  train: brand.colors.ocean[500],
+  bus: "#8b5cf6",
+  ferry: "#0891b2",
+  walk: "#ec4899",
+  bicycle: "#14b8a6",
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function mercatorY(latitude: number): number {
+  const clampedLatitude = clamp(latitude, -85, 85);
+  const radians = (clampedLatitude * Math.PI) / 180;
+  return Math.log(Math.tan(Math.PI / 4 + radians / 2));
+}
+
+function truncateLabel(label: string): string {
+  if (label.length <= 16) return label;
+  return `${label.slice(0, 15)}…`;
+}
+
+function getLocationAccent(locationId: string, segments: Segment[]): string {
+  const outgoing = segments.find((segment) => segment.fromId === locationId);
+  if (outgoing) return MODE_COLORS[outgoing.transportMode];
+
+  const incoming = [...segments].reverse().find((segment) => segment.toId === locationId);
+  if (incoming) return MODE_COLORS[incoming.transportMode];
+
+  return brand.colors.primary[400];
+}
+
+export default function MiniRoutePreview({
+  locations,
+  segments,
+  className,
+}: MiniRoutePreviewProps) {
+  const preview = useMemo(() => {
+    const routeLocations = locations.filter(
+      (location) =>
+        Array.isArray(location.coordinates) &&
+        location.coordinates.length === 2 &&
+        Number.isFinite(location.coordinates[0]) &&
+        Number.isFinite(location.coordinates[1]),
+    );
+
+    if (routeLocations.length < 2) {
+      return {
+        points: [] as ProjectedPoint[],
+        segments: [] as RouteSegment[],
+        labels: [] as ProjectedPoint[],
+      };
+    }
+
+    const sourcePoints = routeLocations.map((location) => ({
+      ...location,
+      lng: location.coordinates[0],
+      mercator: mercatorY(location.coordinates[1]),
+    }));
+
+    const longitudes = sourcePoints.map((point) => point.lng);
+    const mercators = sourcePoints.map((point) => point.mercator);
+
+    const minLng = Math.min(...longitudes);
+    const maxLng = Math.max(...longitudes);
+    const minMercator = Math.min(...mercators);
+    const maxMercator = Math.max(...mercators);
+
+    const rawLongitudeSpan = maxLng - minLng;
+    const rawMercatorSpan = maxMercator - minMercator;
+
+    const longitudePadding = Math.max(rawLongitudeSpan * 0.1, MIN_LONGITUDE_SPAN / 2);
+    const mercatorPadding = Math.max(rawMercatorSpan * 0.1, MIN_MERCATOR_SPAN / 2);
+
+    const paddedMinLng = minLng - longitudePadding;
+    const paddedMaxLng = maxLng + longitudePadding;
+    const paddedMinMercator = minMercator - mercatorPadding;
+    const paddedMaxMercator = maxMercator + mercatorPadding;
+
+    const longitudeSpan = Math.max(paddedMaxLng - paddedMinLng, MIN_LONGITUDE_SPAN);
+    const mercatorSpan = Math.max(paddedMaxMercator - paddedMinMercator, MIN_MERCATOR_SPAN);
+
+    const compactness = 1 - Math.min(
+      1,
+      Math.max(rawLongitudeSpan / MIN_LONGITUDE_SPAN, rawMercatorSpan / MIN_MERCATOR_SPAN),
+    );
+
+    const projectedPoints = sourcePoints.map((point, index) => {
+      const baseX =
+        INNER_PADDING_X +
+        ((point.lng - paddedMinLng) / longitudeSpan) * (VIEWBOX_WIDTH - INNER_PADDING_X * 2);
+      const baseY =
+        INNER_PADDING_Y +
+        (1 - (point.mercator - paddedMinMercator) / mercatorSpan) *
+          (VIEWBOX_HEIGHT - INNER_PADDING_Y * 2);
+
+      // When several stops are nearly co-located, introduce a gentle route-order spread.
+      const routePosition = sourcePoints.length === 1 ? 0.5 : index / (sourcePoints.length - 1);
+      const spreadX = (routePosition - 0.5) * 42 * compactness;
+      const spreadY = Math.sin(routePosition * Math.PI) * 12 * compactness - 6 * compactness;
+
+      return {
+        id: point.id,
+        name: point.name,
+        isWaypoint: point.isWaypoint,
+        x: clamp(baseX + spreadX, INNER_PADDING_X, VIEWBOX_WIDTH - INNER_PADDING_X),
+        y: clamp(baseY + spreadY, INNER_PADDING_Y, VIEWBOX_HEIGHT - INNER_PADDING_Y),
+        accent: getLocationAccent(point.id, segments),
+      };
+    });
+
+    const pointById = new Map(projectedPoints.map((point) => [point.id, point]));
+    const routeSegments = projectedPoints.slice(0, -1).flatMap((point, index) => {
+      const nextPoint = projectedPoints[index + 1];
+      if (!nextPoint) return [];
+
+      const matchedSegment = segments.find(
+        (segment) => segment.fromId === point.id && segment.toId === nextPoint.id,
+      );
+
+      return [
+        {
+          key: `${point.id}-${nextPoint.id}`,
+          from: point,
+          to: nextPoint,
+          color: matchedSegment ? MODE_COLORS[matchedSegment.transportMode] : point.accent,
+        },
+      ];
+    });
+
+    const labels = routeLocations
+      .filter((location) => !location.isWaypoint)
+      .map((location) => pointById.get(location.id))
+      .filter((point): point is ProjectedPoint => Boolean(point));
+
+    return {
+      points: projectedPoints,
+      segments: routeSegments,
+      labels: labels.length > 1 ? [labels[0], labels[labels.length - 1]] : labels,
+    };
+  }, [locations, segments]);
+
+  const hasRoute = preview.points.length > 1;
+
+  return (
+    <div
+      className={className}
+      style={{
+        borderRadius: 20,
+        border: `1px solid ${brand.colors.ocean[200]}`,
+        background:
+          "linear-gradient(180deg, rgba(255,251,245,0.92) 0%, rgba(255,247,237,0.84) 100%)",
+        boxShadow: brand.shadows.sm,
+      }}
+    >
+      <svg
+        width="100%"
+        height="80"
+        viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+        role="img"
+        aria-label="Trip route preview"
+        preserveAspectRatio="none"
+      >
+        <defs>
+          <linearGradient id="mini-route-bg" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop
+              offset="0%"
+              stopColor="rgba(255,251,245,0.96)"
+            />
+            <stop
+              offset="100%"
+              stopColor="rgba(255,247,237,0.82)"
+            />
+          </linearGradient>
+        </defs>
+
+        <rect
+          x="0.5"
+          y="0.5"
+          width={VIEWBOX_WIDTH - 1}
+          height={VIEWBOX_HEIGHT - 1}
+          rx="20"
+          fill="url(#mini-route-bg)"
+          stroke={brand.colors.ocean[200]}
+        />
+
+        {hasRoute ? (
+          <>
+            {preview.segments.map((segment) => (
+              <line
+                key={segment.key}
+                x1={segment.from.x}
+                y1={segment.from.y}
+                x2={segment.to.x}
+                y2={segment.to.y}
+                stroke={segment.color}
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            ))}
+
+            {preview.points.map((point) =>
+              point.isWaypoint ? (
+                <circle
+                  key={point.id}
+                  cx={point.x}
+                  cy={point.y}
+                  r="3.5"
+                  fill="rgba(255,255,255,0.9)"
+                  stroke={point.accent}
+                  strokeWidth="1.5"
+                  vectorEffect="non-scaling-stroke"
+                />
+              ) : (
+                <circle
+                  key={point.id}
+                  cx={point.x}
+                  cy={point.y}
+                  r="6"
+                  fill={point.accent}
+                  stroke="rgba(255,255,255,0.96)"
+                  strokeWidth="1.5"
+                  vectorEffect="non-scaling-stroke"
+                />
+              ),
+            )}
+
+            {preview.labels.map((label, index) => {
+              const placeAbove = label.y > VIEWBOX_HEIGHT / 2;
+              const anchor = label.x > VIEWBOX_WIDTH - 72 ? "end" : "start";
+              const dx = anchor === "end" ? -10 : 10;
+              const dy = placeAbove ? -10 : 16;
+
+              return (
+                <text
+                  key={`${label.id}-${index}`}
+                  x={label.x + dx}
+                  y={label.y + dy}
+                  fill={brand.colors.warm[600]}
+                  fontFamily={brand.fonts.mono}
+                  fontSize="10"
+                  textAnchor={anchor}
+                >
+                  {truncateLabel(label.name)}
+                </text>
+              );
+            })}
+          </>
+        ) : (
+          <text
+            x="50%"
+            y="50%"
+            fill={brand.colors.warm[500]}
+            fontFamily={brand.fonts.mono}
+            fontSize="10"
+            textAnchor="middle"
+            dominantBaseline="middle"
+          >
+            Add stops to sketch your route
+          </text>
+        )}
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🎯 Changes
New MiniRoutePreview SVG in LeftPanel header:
- Approximate route shape with transport-colored segments
- Location dots positioned by projected coordinates
- Polyline connecting stops in route order
- Replaces Distance stat card

**Files:** MiniRoutePreview.tsx (new), LeftPanel.tsx (+312/-56)
**Flow:** ux-v2 | task-06 | Wave 1

⚠️ DO NOT MERGE — awaiting L1 review