### PR TITLE
feat: share/copy link button (#136)

### DIFF
--- a/src/components/editor/TopToolbar.tsx
+++ b/src/components/editor/TopToolbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import {
   Download,
   Save,
+  Share2,
   Upload,
   PanelLeftClose,
   PanelLeft,
@@ -59,6 +60,7 @@ export default function TopToolbar() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const setExportDialogOpen = useUIStore((s) => s.setExportDialogOpen);
+  const addToast = useUIStore((s) => s.addToast);
   const leftPanelOpen = useUIStore((s) => s.leftPanelOpen);
   const setLeftPanelOpen = useUIStore((s) => s.setLeftPanelOpen);
   const saveStatus = useUIStore((s) => s.saveStatus);
@@ -246,6 +248,40 @@ export default function TopToolbar() {
     a.download = `${routeData.name || "trace-recap"}.zip`;
     a.click();
     URL.revokeObjectURL(url);
+  };
+
+  const handleShareLink = async () => {
+    const url = window.location.href;
+
+    try {
+      if (typeof navigator.share === "function") {
+        await navigator.share({ url, title: currentProjectName });
+        addToast({
+          title: "Link shared",
+          description: "The current project link is ready to send.",
+          variant: "success",
+        });
+        return;
+      }
+
+      await navigator.clipboard.writeText(url);
+      addToast({
+        title: "Link copied",
+        description: "The current project URL was copied to your clipboard.",
+        variant: "success",
+      });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+
+      console.error("Failed to share the current project link.", error);
+      addToast({
+        title: "Could not share link",
+        description: "Try copying the URL from your browser address bar.",
+        variant: "error",
+      });
+    }
   };
 
   const saveStatusConfig = {
@@ -484,6 +520,24 @@ export default function TopToolbar() {
             {/* Divider */}
             <div className="mx-2 h-5 w-px" style={{ backgroundColor: "#e7e5e4" }} />
 
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => void handleShareLink()}
+                    aria-label="Share project link"
+                    style={{ color: "#78716c" }}
+                  />
+                }
+              >
+                <Share2 className="h-4 w-4" />
+              </TooltipTrigger>
+              <TooltipContent>Share link</TooltipContent>
+            </Tooltip>
+
             {/* Export — primary CTA */}
             <button
               className="flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-sm font-semibold text-white transition-all hover:brightness-110 active:scale-[0.97]"
@@ -497,6 +551,17 @@ export default function TopToolbar() {
 
           {/* Right side — mobile */}
           <div className="flex md:hidden items-center gap-1.5">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => void handleShareLink()}
+              aria-label="Share project link"
+              style={{ color: "#78716c" }}
+            >
+              <Share2 className="h-4 w-4" />
+            </Button>
+
             {/* Export — always visible on mobile */}
             <button
               className="flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white"


### PR DESCRIPTION
## Summary
- add a Share button to the editor toolbar on desktop and mobile
- use the Web Share API when available and fall back to copying the current URL
- show toast feedback for share/copy success and share failure

## Verification
- npm run build