### PR TITLE
fix: playback hint overlay no longer blocks controls (#139)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -152,13 +152,6 @@
   }
 }
 
-/* Hide Mapbox navigation controls during playback */
-.hide-map-controls .mapboxgl-ctrl-top-right {
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-}
-
 @layer utilities {
   /* Warm travel-inspired mesh gradient */
   .gradient-mesh {

--- a/src/components/editor/MapCanvas.tsx
+++ b/src/components/editor/MapCanvas.tsx
@@ -547,14 +547,13 @@ export default memo(function MapCanvas() {
     });
   }, [segmentColors, moodColorsEnabled, segments]);
 
-  const isActive = playbackState === "playing" || playbackState === "paused";
   const citySearchInput = typeof document !== "undefined"
     ? document.querySelector<HTMLInputElement>('[data-city-search-input="true"]')
     : null;
 
   return (
     <div className="relative w-full h-full">
-      <div ref={containerRef} className={`w-full h-full ${isActive ? "hide-map-controls" : ""}`} />
+      <div ref={containerRef} className="h-full w-full" />
       <AnimatePresence>
         {!mapLoaded && (
           <motion.div

--- a/src/components/editor/OnboardingHint.tsx
+++ b/src/components/editor/OnboardingHint.tsx
@@ -9,6 +9,8 @@ interface OnboardingHintProps {
   onDismiss: () => void;
   className?: string;
   arrowClassName?: string;
+  interactive?: boolean;
+  dismissLabel?: string;
 }
 
 export default function OnboardingHint({
@@ -16,38 +18,11 @@ export default function OnboardingHint({
   onDismiss,
   className,
   arrowClassName,
+  interactive = true,
+  dismissLabel = "Click to dismiss",
 }: OnboardingHintProps) {
-  return (
-    <motion.button
-      type="button"
-      onClick={onDismiss}
-      initial={{ opacity: 0, y: 10, scale: 0.97 }}
-      animate={{
-        opacity: 1,
-        y: 0,
-        scale: [1, 1.01, 1],
-      }}
-      exit={{ opacity: 0, y: 6, scale: 0.98 }}
-      transition={{
-        opacity: { duration: 0.22, ease: "easeOut" },
-        y: { duration: 0.22, ease: "easeOut" },
-        scale: {
-          duration: 2.2,
-          ease: "easeInOut",
-          repeat: Number.POSITIVE_INFINITY,
-          repeatDelay: 1.1,
-        },
-      }}
-      className={cn(
-        "absolute z-[80] max-w-xs overflow-visible rounded-2xl border px-3.5 py-3 text-left backdrop-blur-sm",
-        className,
-      )}
-      style={{
-        background: `linear-gradient(180deg, ${brand.colors.primary[50]} 0%, rgba(255, 251, 245, 0.96) 100%)`,
-        borderColor: `${brand.colors.primary[200]}`,
-        boxShadow: brand.shadows.lg,
-      }}
-    >
+  const content = (
+    <>
       <motion.span
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 rounded-[inherit]"
@@ -90,7 +65,7 @@ export default function OnboardingHint({
             {message}
           </span>
           <span className="mt-1.5 block text-[11px] text-stone-500">
-            Click to dismiss
+            {dismissLabel}
           </span>
         </span>
       </span>
@@ -106,6 +81,78 @@ export default function OnboardingHint({
         }}
         aria-hidden="true"
       />
-    </motion.button>
+    </>
+  );
+
+  if (interactive) {
+    return (
+      <motion.button
+        type="button"
+        onClick={onDismiss}
+        initial={{ opacity: 0, y: 10, scale: 0.97 }}
+        animate={{
+          opacity: 1,
+          y: 0,
+          scale: [1, 1.01, 1],
+        }}
+        exit={{ opacity: 0, y: 6, scale: 0.98 }}
+        transition={{
+          opacity: { duration: 0.22, ease: "easeOut" as const },
+          y: { duration: 0.22, ease: "easeOut" as const },
+          scale: {
+            duration: 2.2,
+            ease: "easeInOut" as const,
+            repeat: Number.POSITIVE_INFINITY,
+            repeatDelay: 1.1,
+          },
+        }}
+        className={cn(
+          "absolute z-[80] max-w-xs overflow-visible rounded-2xl border px-3.5 py-3 text-left backdrop-blur-sm",
+          className,
+        )}
+        style={{
+          background: `linear-gradient(180deg, ${brand.colors.primary[50]} 0%, rgba(255, 251, 245, 0.96) 100%)`,
+          borderColor: `${brand.colors.primary[200]}`,
+          boxShadow: brand.shadows.lg,
+        }}
+      >
+        {content}
+      </motion.button>
+    );
+  }
+
+  return (
+    <motion.div
+      role="status"
+      aria-live="polite"
+      initial={{ opacity: 0, y: 10, scale: 0.97 }}
+      animate={{
+        opacity: 1,
+        y: 0,
+        scale: [1, 1.01, 1],
+      }}
+      exit={{ opacity: 0, y: 6, scale: 0.98 }}
+      transition={{
+        opacity: { duration: 0.22, ease: "easeOut" as const },
+        y: { duration: 0.22, ease: "easeOut" as const },
+        scale: {
+          duration: 2.2,
+          ease: "easeInOut" as const,
+          repeat: Number.POSITIVE_INFINITY,
+          repeatDelay: 1.1,
+        },
+      }}
+      className={cn(
+        "absolute z-[80] max-w-xs overflow-visible rounded-2xl border px-3.5 py-3 text-left backdrop-blur-sm",
+        className,
+      )}
+      style={{
+        background: `linear-gradient(180deg, ${brand.colors.primary[50]} 0%, rgba(255, 251, 245, 0.96) 100%)`,
+        borderColor: `${brand.colors.primary[200]}`,
+        boxShadow: brand.shadows.lg,
+      }}
+    >
+      {content}
+    </motion.div>
   );
 }

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -102,6 +102,7 @@ export default memo(function PlaybackControls({
 
   const progress = totalDuration > 0 ? (currentTime / totalDuration) * 100 : 0;
   const isPlaying = playbackState === "playing";
+  const showPlaybackHint = Boolean(hintMessage && onHintDismiss);
   const thumbLeft = Math.min(Math.max(progress, 0.5), 99.5);
   const activeTimelineEntry = timeline[currentSegmentIndex];
   const activeSegment =
@@ -226,6 +227,24 @@ export default memo(function PlaybackControls({
     }
   }, [hoveredTickId, scrubberTicks]);
 
+  useEffect(() => {
+    if (!showPlaybackHint || typeof window === "undefined" || !onHintDismiss) {
+      return;
+    }
+
+    const dismissHint = () => {
+      onHintDismiss();
+    };
+
+    const timeoutId = window.setTimeout(dismissHint, 3000);
+    window.addEventListener("pointerdown", dismissHint, true);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.removeEventListener("pointerdown", dismissHint, true);
+    };
+  }, [onHintDismiss, showPlaybackHint]);
+
   // Hide controls when export dialog is open
   if (exportDialogOpen) return null;
 
@@ -301,11 +320,13 @@ export default memo(function PlaybackControls({
               <Play className="ml-0.5 h-5 w-5" />
             )}
           </button>
-          {hintMessage && onHintDismiss && (
+          {showPlaybackHint && (
             <OnboardingHint
-              message={hintMessage}
-              onDismiss={onHintDismiss}
-              className="bottom-[calc(100%+0.75rem)] left-1/2 w-56 -translate-x-1/2"
+              message={hintMessage!}
+              onDismiss={onHintDismiss!}
+              interactive={false}
+              dismissLabel="Dismisses after a moment"
+              className="pointer-events-none bottom-[calc(100%+0.75rem)] left-1/2 w-56 -translate-x-1/2"
               arrowClassName="left-1/2 -bottom-[7px] -translate-x-1/2 border-l-0 border-t-0"
             />
           )}


### PR DESCRIPTION
## Summary
- make the playback hint non-blocking by rendering it without pointer events
- auto-dismiss the play hint after 3 seconds and dismiss it on the first user click anywhere
- keep Mapbox navigation controls available during playback by removing the playback-only control disabling CSS

## Verification
- npx tsc --noEmit
- npm run build