### PR TITLE
fix: enforce 44px minimum touch targets on mobile (#140)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -204,4 +204,32 @@
   .shadow-ocean-glow {
     box-shadow: 0 0 30px rgba(20, 184, 166, 0.15);
   }
+
+  @media (max-width: 767px) {
+    .touch-target-mobile {
+      min-width: 44px;
+      min-height: 44px;
+    }
+
+    .touch-target-mobile-hitbox {
+      position: relative;
+    }
+
+    .touch-target-mobile-hitbox::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 44px;
+      height: 44px;
+      transform: translate(-50%, -50%);
+    }
+
+    .touch-target-mobile-scope button,
+    .touch-target-mobile-scope [role="button"],
+    .touch-target-mobile-scope [data-slot="button"] {
+      min-width: 44px;
+      min-height: 44px;
+    }
+  }
 }

--- a/src/components/editor/BottomSheet.tsx
+++ b/src/components/editor/BottomSheet.tsx
@@ -133,7 +133,7 @@ export default function BottomSheet({
         <div className="shrink-0 px-4 pb-2 pt-3" style={{ height: collapsedHeight }}>
           <div className="mx-auto mb-2 h-1.5 w-12 rounded-full bg-gray-300" />
           <div
-            className="mb-2 flex min-h-[44px] items-center justify-between"
+            className="touch-target-mobile mb-2 flex min-h-[44px] items-center justify-between"
             onClick={toggleSheet}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {

--- a/src/components/editor/ExportDialog.tsx
+++ b/src/components/editor/ExportDialog.tsx
@@ -319,7 +319,7 @@ export default function ExportDialog() {
   if (downloadUrl) {
     return (
       <Dialog open={open} onOpenChange={handleClose}>
-        <DialogContent className="sm:max-w-md overflow-hidden">
+        <DialogContent className="touch-target-mobile-scope overflow-hidden sm:max-w-md">
           <motion.div
             className="flex flex-col items-center py-6 space-y-5"
             initial={{ opacity: 0, scale: 0.95 }}
@@ -402,7 +402,7 @@ export default function ExportDialog() {
   if (isExporting && progress) {
     return (
       <Dialog open={open} onOpenChange={handleClose}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="touch-target-mobile-scope sm:max-w-md">
           <motion.div
             className="flex flex-col items-center py-8 space-y-6"
             initial={{ opacity: 0 }}
@@ -436,7 +436,7 @@ export default function ExportDialog() {
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="touch-target-mobile-scope sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Sparkles className="h-5 w-5" style={{ color: brand.colors.primary[500] }} />

--- a/src/components/editor/LocationCard.tsx
+++ b/src/components/editor/LocationCard.tsx
@@ -207,7 +207,7 @@ function EmojiPicker({
     <div ref={ref} className="relative" data-no-seek>
       <button
         onClick={() => setOpen((openState) => !openState)}
-        className="flex h-8 w-11 items-center justify-center rounded-xl border transition-colors"
+        className="touch-target-mobile flex h-8 w-11 items-center justify-center rounded-xl border transition-colors"
         style={{
           borderColor: brand.colors.warm[200],
           backgroundColor: "rgba(255,255,255,0.86)",
@@ -230,7 +230,7 @@ function EmojiPicker({
               boxShadow: brand.shadows.lg,
             }}
           >
-            <div className="grid max-h-[180px] grid-cols-10 gap-0.5 overflow-y-auto">
+            <div className="grid max-h-[260px] grid-cols-5 gap-1 overflow-y-auto sm:max-h-[180px] sm:grid-cols-10 sm:gap-0.5">
               {TRAVEL_EMOJIS.map((emoji) => (
                 <button
                   key={emoji}
@@ -238,7 +238,7 @@ function EmojiPicker({
                     onSelect(emoji);
                     setOpen(false);
                   }}
-                  className="flex h-6 w-6 items-center justify-center rounded text-sm transition-colors hover:bg-white"
+                  className="touch-target-mobile flex h-6 w-6 items-center justify-center rounded text-sm transition-colors hover:bg-white"
                   style={{
                     boxShadow: value === emoji ? `inset 0 0 0 1px ${brand.colors.primary[400]}` : undefined,
                     backgroundColor: value === emoji ? brand.colors.primary[100] : "transparent",
@@ -252,12 +252,12 @@ function EmojiPicker({
               className="mt-1.5 flex items-center gap-1.5 border-t pt-1.5"
               style={{ borderColor: brand.colors.warm[200] }}
             >
-              <Input
-                ref={customInputRef}
-                placeholder="Type or paste emoji"
-                className="h-6 flex-1 bg-white/85 px-1 py-0 text-center text-sm"
-                maxLength={2}
-                onKeyDown={(e) => {
+                <Input
+                  ref={customInputRef}
+                  placeholder="Type or paste emoji"
+                  className="h-11 flex-1 bg-white/85 px-2 py-0 text-center text-sm sm:h-6 sm:px-1"
+                  maxLength={2}
+                  onKeyDown={(e) => {
                   if (e.key === "Enter") {
                     const nextValue = customInputRef.current?.value.trim();
                     if (nextValue) {
@@ -280,7 +280,7 @@ function EmojiPicker({
                     onSelect("");
                     setOpen(false);
                   }}
-                  className="shrink-0 rounded-md px-2 py-0.5 text-[10px] transition-colors hover:bg-white"
+                  className="touch-target-mobile shrink-0 rounded-md px-2 py-0.5 text-[10px] transition-colors hover:bg-white"
                   style={{ color: brand.colors.warm[500] }}
                 >
                   Clear
@@ -304,7 +304,9 @@ function WaypointSwitch({
   return (
     <button
       onClick={onToggle}
-      className="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors"
+      type="button"
+      aria-label={isWaypoint ? "Switch to destination" : "Switch to stop by"}
+      className="touch-target-mobile-hitbox relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors"
       style={{
         backgroundColor: isWaypoint ? brand.colors.warm[300] : brand.colors.primary[500],
       }}
@@ -503,7 +505,7 @@ export default memo(function LocationCard({
         >
           <div
             data-drag-handle
-            className={`flex shrink-0 cursor-grab items-center justify-center border transition-colors active:cursor-grabbing touch-none ${
+            className={`touch-target-mobile flex shrink-0 cursor-grab items-center justify-center border transition-colors active:cursor-grabbing touch-none ${
               isWaypoint ? "h-8 w-8 rounded-xl" : "h-10 w-9 rounded-2xl"
             } max-[420px]:h-8 max-[420px]:w-8 max-[420px]:rounded-xl`}
             style={{
@@ -632,7 +634,7 @@ export default memo(function LocationCard({
           </div>
 
           <button
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-white"
+            className="touch-target-mobile flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-white"
             data-no-seek
             onClick={(e) => {
               e.stopPropagation();
@@ -651,7 +653,7 @@ export default memo(function LocationCard({
 
           <button
             data-delete-btn
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[#fff1f2]"
+            className="touch-target-mobile flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-[#fff1f2]"
             onClick={(e) => {
               e.stopPropagation();
               handleRemove();

--- a/src/components/editor/PlaybackControls.tsx
+++ b/src/components/editor/PlaybackControls.tsx
@@ -256,7 +256,7 @@ export default memo(function PlaybackControls({
     "overflow-hidden transition-all duration-300 ease-in-out",
     isPlaying
       ? "pointer-events-none w-0 -mr-2 opacity-0 md:-mr-3"
-      : "w-8 opacity-100",
+      : "w-11 opacity-100 md:w-8",
   ].join(" ");
   const timeContainerClassName = [
     "overflow-hidden whitespace-nowrap text-right transition-all duration-300 ease-in-out",
@@ -273,7 +273,7 @@ export default memo(function PlaybackControls({
           <Button
             variant="ghost"
             size="icon"
-            className="h-8 w-8 shrink-0 text-stone-500 hover:text-stone-700"
+            className="touch-target-mobile h-8 w-8 shrink-0 text-stone-500 hover:text-stone-700"
             onClick={onReset}
             aria-label="Reset playback"
             disabled={isPlaying}
@@ -284,7 +284,7 @@ export default memo(function PlaybackControls({
         <div className="relative">
           <button
             className={[
-              "flex items-center justify-center rounded-full text-white transition-all duration-200 ease-in-out",
+              "touch-target-mobile flex items-center justify-center rounded-full text-white transition-all duration-200 ease-in-out",
               "hover:scale-105 active:scale-95",
               isPlaying ? "h-10 w-10 md:h-8 md:w-8" : "h-14 w-14 md:h-12 md:w-12",
             ].join(" ")}

--- a/src/components/editor/RouteList.tsx
+++ b/src/components/editor/RouteList.tsx
@@ -387,7 +387,7 @@ export default memo(function RouteList({
           <div className="pl-11 sm:pl-12">
             <button
               type="button"
-              className="flex w-full items-center gap-3 rounded-[24px] border px-3.5 py-3 text-left transition-colors"
+              className="touch-target-mobile flex w-full items-center gap-3 rounded-[24px] border px-3.5 py-3 text-left transition-colors"
               onClick={() =>
                 setCollapsedGroups((current) => ({
                   ...current,

--- a/src/components/editor/TopToolbar.tsx
+++ b/src/components/editor/TopToolbar.tsx
@@ -292,7 +292,7 @@ export default function TopToolbar() {
             <span className="text-xs select-none" style={{ color: "#d6d3d1" }}>/</span>
 
             <button
-              className="flex items-center gap-1 rounded-md px-1.5 py-1 text-sm transition-colors max-w-[140px] md:max-w-[200px] hover:bg-stone-100"
+              className="touch-target-mobile flex items-center gap-1 rounded-md px-1.5 py-1 text-sm transition-colors max-w-[140px] md:max-w-[200px] hover:bg-stone-100"
               onClick={() => setProjectListOpen(true)}
               disabled={isSwitchingProject}
               style={{ color: "#78716c" }}
@@ -447,7 +447,7 @@ export default function TopToolbar() {
                     <p className="text-sm font-semibold" style={{ color: "#1c1917" }}>Settings</p>
                     <button
                       onClick={() => setSettingsOpen(false)}
-                      className="h-6 w-6 flex items-center justify-center rounded-md hover:bg-stone-100 transition-colors"
+                      className="touch-target-mobile flex h-6 w-6 items-center justify-center rounded-md transition-colors hover:bg-stone-100"
                       style={{ color: "#78716c" }}
                     >
                       <X className="h-3.5 w-3.5" />
@@ -499,7 +499,7 @@ export default function TopToolbar() {
           <div className="flex md:hidden items-center gap-1.5">
             {/* Export — always visible on mobile */}
             <button
-              className="flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white"
+              className="touch-target-mobile flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white"
               style={{ backgroundColor: "#f97316" }}
               onClick={() => setExportDialogOpen(true)}
             >
@@ -511,7 +511,7 @@ export default function TopToolbar() {
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8"
+              className="touch-target-mobile h-8 w-8"
               onClick={() => setMobileMenuOpen(true)}
               aria-label="Menu"
               style={{ color: "#78716c" }}
@@ -540,7 +540,7 @@ export default function TopToolbar() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-7 w-7"
+                  className="touch-target-mobile h-7 w-7"
                   onClick={() => setMobileMenuOpen(false)}
                   aria-label="Close menu"
                   style={{ color: "#78716c" }}
@@ -549,7 +549,7 @@ export default function TopToolbar() {
                 </Button>
               </div>
             </div>
-            <div className="px-4 pb-6 space-y-1">
+            <div className="touch-target-mobile-scope space-y-1 px-4 pb-6">
               <MobileActionButton
                 icon={<Undo2 className="h-4 w-4" />}
                 label="Undo"
@@ -610,7 +610,7 @@ export default function TopToolbar() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-7 w-7"
+                  className="touch-target-mobile h-7 w-7"
                   onClick={() => setSettingsOpen(false)}
                   aria-label="Close settings"
                   style={{ color: "#78716c" }}
@@ -658,7 +658,7 @@ export default function TopToolbar() {
       />
 
       <Dialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
-        <DialogContent showCloseButton={false}>
+        <DialogContent showCloseButton={false} className="touch-target-mobile-scope">
           <DialogHeader>
             <DialogTitle>Clear Route</DialogTitle>
             <DialogDescription>
@@ -709,7 +709,7 @@ function MobileActionButton({
 }) {
   return (
     <button
-      className="w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors hover:bg-stone-100 disabled:opacity-40 disabled:pointer-events-none"
+      className="touch-target-mobile flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors hover:bg-stone-100 disabled:pointer-events-none disabled:opacity-40"
       onClick={onClick}
       disabled={disabled}
       style={{ color: destructive ? "#ef4444" : "#1c1917" }}
@@ -785,7 +785,7 @@ function SettingsContent({
   ratioLabels,
 }: SettingsContentProps) {
   return (
-    <>
+    <div className="touch-target-mobile-scope">
       {/* Aspect Ratio */}
       <div className="space-y-2.5">
         <SectionHeader>Aspect Ratio</SectionHeader>
@@ -1050,6 +1050,6 @@ function SettingsContent({
           ))}
         </div>
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add mobile-only 44px touch target utilities below 768px
- apply the utility to undersized editor controls in the toolbar, playback bar, export dialog, route list, bottom sheet, and location cards
- expand small mobile route card actions and emoji picker controls without changing desktop sizing

## Verification
- npx tsc --noEmit
- npm run build