### PR TITLE
fix: granular undo/redo instead of full reset (#135)

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -1112,7 +1112,6 @@ function EditorContent() {
         const { canUndo, undo } = useHistoryStore.getState();
         if (canUndo) {
           undo();
-          useUIStore.getState().addToast({ title: "Undid", variant: "info" });
         }
         return;
       }
@@ -1121,7 +1120,6 @@ function EditorContent() {
         const { canRedo, redo } = useHistoryStore.getState();
         if (canRedo) {
           redo();
-          useUIStore.getState().addToast({ title: "Redid", variant: "info" });
         }
         return;
       }

--- a/src/stores/historyStore.ts
+++ b/src/stores/historyStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useUIStore } from "@/stores/uiStore";
 import { useProjectStore, invalidateSerializationCache } from "./projectStore";
 import type { Location, Segment, MapStyle, Photo } from "@/types";
 
@@ -40,15 +41,53 @@ interface HistorySnapshot {
   segmentTimingOverrides: Record<string, number>;
 }
 
+interface HistoryRouteState {
+  locations: LightLocation[];
+  segments: Segment[];
+  segmentTimingOverrides: Record<string, number>;
+}
+
+interface RouteHistoryInput {
+  locations: Location[];
+  segments: Segment[];
+  segmentTimingOverrides: Record<string, number>;
+}
+
+interface SnapshotHistoryEntry {
+  kind: "snapshot";
+  snapshot: HistorySnapshot;
+  undoLabel?: string;
+  redoLabel?: string;
+}
+
+interface RouteHistoryEntry {
+  kind: "route";
+  projectId: string | null;
+  before: HistoryRouteState;
+  after: HistoryRouteState;
+  undoLabel: string;
+  redoLabel: string;
+}
+
+type HistoryEntry = SnapshotHistoryEntry | RouteHistoryEntry;
+
+interface RouteHistoryChange {
+  before: RouteHistoryInput;
+  after: RouteHistoryInput;
+  undoLabel: string;
+  redoLabel?: string;
+}
+
 const MAX_HISTORY = 30;
 
 interface HistoryState {
-  undoStack: HistorySnapshot[];
-  redoStack: HistorySnapshot[];
+  undoStack: HistoryEntry[];
+  redoStack: HistoryEntry[];
   canUndo: boolean;
   canRedo: boolean;
   resetHistory: () => void;
   pushState: () => void;
+  pushRouteChange: (change: RouteHistoryChange) => void;
   undo: () => void;
   redo: () => void;
 }
@@ -130,13 +169,41 @@ function captureSnapshot(): HistorySnapshot {
   };
 }
 
+function captureRouteState(
+  state: RouteHistoryInput,
+): HistoryRouteState {
+  registerPhotoUrls(state.locations);
+
+  return {
+    locations: state.locations.map(stripLocation),
+    segments: structuredClone(state.segments),
+    segmentTimingOverrides: { ...state.segmentTimingOverrides },
+  };
+}
+
 function restoreSnapshot(snapshot: HistorySnapshot): void {
   useProjectStore.setState({
     locations: snapshot.locations.map(rehydrateLocation),
-    segments: snapshot.segments,
+    segments: structuredClone(snapshot.segments),
     mapStyle: snapshot.mapStyle,
-    segmentTimingOverrides: snapshot.segmentTimingOverrides,
+    segmentTimingOverrides: { ...snapshot.segmentTimingOverrides },
   });
+}
+
+function restoreRouteState(snapshot: HistoryRouteState): void {
+  useProjectStore.setState({
+    locations: snapshot.locations.map(rehydrateLocation),
+    segments: structuredClone(snapshot.segments),
+    segmentTimingOverrides: { ...snapshot.segmentTimingOverrides },
+  });
+}
+
+function getEntryProjectId(entry: HistoryEntry): string | null {
+  return entry.kind === "snapshot" ? entry.snapshot.projectId : entry.projectId;
+}
+
+function formatToastTitle(prefix: "Undid" | "Redid", label?: string): string {
+  return label ? `${prefix}: ${label}` : prefix;
 }
 
 export const useHistoryStore = create<HistoryState>((set) => ({
@@ -152,62 +219,117 @@ export const useHistoryStore = create<HistoryState>((set) => ({
   pushState: () => {
     const snapshot = captureSnapshot();
     set((state) => {
-      const undoStack = [...state.undoStack, snapshot].slice(-MAX_HISTORY);
+      const entry: SnapshotHistoryEntry = { kind: "snapshot", snapshot };
+      const undoStack = [...state.undoStack, entry].slice(-MAX_HISTORY);
+      return { undoStack, redoStack: [], canUndo: true, canRedo: false };
+    });
+  },
+
+  pushRouteChange: (change) => {
+    const entry: RouteHistoryEntry = {
+      kind: "route",
+      projectId: useProjectStore.getState().currentProjectId,
+      before: captureRouteState(change.before),
+      after: captureRouteState(change.after),
+      undoLabel: change.undoLabel,
+      redoLabel: change.redoLabel ?? change.undoLabel,
+    };
+
+    set((state) => {
+      const undoStack = [...state.undoStack, entry].slice(-MAX_HISTORY);
       return { undoStack, redoStack: [], canUndo: true, canRedo: false };
     });
   },
 
   undo: () => {
+    let toastTitle: string | null = null;
+
     set((state) => {
       if (state.undoStack.length === 0) return state;
 
       const current = captureSnapshot();
       const undoStack = [...state.undoStack];
-      const snapshot = undoStack.pop()!;
+      const entry = undoStack.pop()!;
 
       // Guard against cross-project corruption
-      if (snapshot.projectId !== current.projectId) {
+      if (getEntryProjectId(entry) !== current.projectId) {
         return { undoStack: [], redoStack: [], canUndo: false, canRedo: false };
       }
 
-      const redoStack = [...state.redoStack, current];
+      const redoStack = [...state.redoStack];
+      if (entry.kind === "snapshot") {
+        restoreSnapshot(entry.snapshot);
+        redoStack.push({
+          kind: "snapshot",
+          snapshot: current,
+          undoLabel: entry.redoLabel,
+          redoLabel: entry.undoLabel,
+        });
+        toastTitle = formatToastTitle("Undid", entry.undoLabel);
+      } else {
+        restoreRouteState(entry.before);
+        redoStack.push(entry);
+        toastTitle = formatToastTitle("Undid", entry.undoLabel);
+      }
 
-      restoreSnapshot(snapshot);
       invalidateSerializationCache();
 
       return {
         undoStack,
         redoStack,
         canUndo: undoStack.length > 0,
-        canRedo: true,
+        canRedo: redoStack.length > 0,
       };
     });
+
+    if (toastTitle) {
+      useUIStore.getState().addToast({ title: toastTitle, variant: "info" });
+    }
   },
 
   redo: () => {
+    let toastTitle: string | null = null;
+
     set((state) => {
       if (state.redoStack.length === 0) return state;
 
       const current = captureSnapshot();
       const redoStack = [...state.redoStack];
-      const snapshot = redoStack.pop()!;
+      const entry = redoStack.pop()!;
 
       // Guard against cross-project corruption
-      if (snapshot.projectId !== current.projectId) {
+      if (getEntryProjectId(entry) !== current.projectId) {
         return { undoStack: [], redoStack: [], canUndo: false, canRedo: false };
       }
 
-      const undoStack = [...state.undoStack, current];
+      const undoStack = [...state.undoStack];
+      if (entry.kind === "snapshot") {
+        restoreSnapshot(entry.snapshot);
+        undoStack.push({
+          kind: "snapshot",
+          snapshot: current,
+          undoLabel: entry.redoLabel,
+          redoLabel: entry.undoLabel,
+        });
+        toastTitle = formatToastTitle("Redid", entry.undoLabel);
+      } else {
+        restoreRouteState(entry.after);
+        undoStack.push(entry);
+        toastTitle = formatToastTitle("Redid", entry.redoLabel);
+      }
 
-      restoreSnapshot(snapshot);
       invalidateSerializationCache();
 
       return {
         undoStack,
         redoStack,
-        canUndo: true,
+        canUndo: undoStack.length > 0,
         canRedo: redoStack.length > 0,
       };
     });
+
+    if (toastTitle) {
+      useUIStore.getState().addToast({ title: toastTitle, variant: "info" });
+    }
   },
 }));

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1149,6 +1149,65 @@ async function resolveExistingProjectMeta(
   return getProjectMeta(projectId);
 }
 
+type RouteHistoryState = Pick<
+  ProjectState,
+  "locations" | "segments" | "segmentTimingOverrides"
+>;
+
+type LocationUpdateFields = Partial<
+  Pick<
+    Location,
+    | "name"
+    | "nameZh"
+    | "coordinates"
+    | "chapterTitle"
+    | "chapterNote"
+    | "chapterDate"
+    | "chapterEmoji"
+  >
+>;
+
+function getRouteHistoryState(
+  state: RouteHistoryState,
+): RouteHistoryState {
+  return {
+    locations: state.locations,
+    segments: state.segments,
+    segmentTimingOverrides: state.segmentTimingOverrides,
+  };
+}
+
+function pushRouteHistoryChange(params: {
+  before: RouteHistoryState;
+  after: RouteHistoryState;
+  label: string;
+  redoLabel?: string;
+}): void {
+  useHistoryStore.getState().pushRouteChange({
+    before: getRouteHistoryState(params.before),
+    after: getRouteHistoryState(params.after),
+    undoLabel: params.label,
+    redoLabel: params.redoLabel,
+  });
+}
+
+function formatStopLabel(name: string | undefined): string {
+  const trimmed = name?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : "Untitled stop";
+}
+
+function buildLocationUpdateLabel(
+  previousLocation: Location,
+  nextLocation: Location,
+  changedKeys: Array<keyof LocationUpdateFields>,
+): string {
+  if (changedKeys.length === 1 && changedKeys[0] === "name") {
+    return `Rename ${formatStopLabel(previousLocation.name)} → ${formatStopLabel(nextLocation.name)}`;
+  }
+
+  return `Edit ${formatStopLabel(nextLocation.name)}`;
+}
+
 async function queueProjectSave(
   projectId: string,
   saveVersion: number,
@@ -1318,125 +1377,214 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   segmentColors: {},
 
   addLocation: (loc) => {
-    useHistoryStore.getState().pushState();
-    return set((state) => {
-      const newLocation: Location = {
-        id: generateId(),
-        name: loc.name,
-        nameZh: loc.nameZh,
-        coordinates: loc.coordinates,
-        isWaypoint: false,
-        photos: [],
-      };
-      const locations = insertLocationAtIndex(
-        state.locations,
-        newLocation,
-        state.locations.length,
-      );
-      return {
-        locations,
-        segments: rebuildSegments(locations, state.segments),
-      };
+    const state = get();
+    const newLocation: Location = {
+      id: generateId(),
+      name: loc.name,
+      nameZh: loc.nameZh,
+      coordinates: loc.coordinates,
+      isWaypoint: false,
+      photos: [],
+    };
+    const locations = insertLocationAtIndex(
+      state.locations,
+      newLocation,
+      state.locations.length,
+    );
+    const nextState = {
+      locations,
+      segments: rebuildSegments(locations, state.segments),
+      segmentTimingOverrides: state.segmentTimingOverrides,
+    };
+
+    pushRouteHistoryChange({
+      before: state,
+      after: nextState,
+      label: `Add ${formatStopLabel(newLocation.name)}`,
     });
+    set(nextState);
   },
 
   addLocationAtCoordinates: async (lngLat, options) => {
     const locationData = await resolveLocationFromCoordinates(lngLat.lng, lngLat.lat);
-    useHistoryStore.getState().pushState();
+    const state = get();
+    const shouldBecomeWaypoint =
+      Boolean(options?.isWaypoint) && state.locations.length >= 2;
+    const insertIndex =
+      typeof options?.insertIndex === "number"
+        ? options.insertIndex
+        : shouldBecomeWaypoint
+          ? state.locations.length - 1
+          : state.locations.length;
+    const newLocation: Location = {
+      id: generateId(),
+      ...locationData,
+      isWaypoint: shouldBecomeWaypoint,
+      photos: [],
+    };
+    const locations = insertLocationAtIndex(
+      state.locations,
+      newLocation,
+      insertIndex,
+    );
+    const nextState = {
+      locations,
+      segments: rebuildSegments(locations, state.segments),
+      segmentTimingOverrides: state.segmentTimingOverrides,
+    };
 
-    return set((state) => {
-      const shouldBecomeWaypoint =
-        Boolean(options?.isWaypoint) && state.locations.length >= 2;
-      const insertIndex =
-        typeof options?.insertIndex === "number"
-          ? options.insertIndex
-          : shouldBecomeWaypoint
-            ? state.locations.length - 1
-            : state.locations.length;
-      const newLocation: Location = {
-        id: generateId(),
-        ...locationData,
-        isWaypoint: shouldBecomeWaypoint,
-        photos: [],
-      };
-      const locations = insertLocationAtIndex(
-        state.locations,
-        newLocation,
-        insertIndex,
-      );
-      return {
-        locations,
-        segments: rebuildSegments(locations, state.segments),
-      };
+    pushRouteHistoryChange({
+      before: state,
+      after: nextState,
+      label: `Add ${formatStopLabel(newLocation.name)}`,
     });
+    set(nextState);
   },
 
   duplicateLocation: (locationId) => {
-    useHistoryStore.getState().pushState();
-    return set((state) => {
-      const locationIndex = state.locations.findIndex((location) => location.id === locationId);
-      if (locationIndex < 0) {
-        return state;
-      }
+    const state = get();
+    const locationIndex = state.locations.findIndex((location) => location.id === locationId);
+    if (locationIndex < 0) {
+      return;
+    }
 
-      const locations = insertLocationAtIndex(
-        state.locations,
-        duplicateLocationEntry(state.locations[locationIndex]),
-        locationIndex + 1,
-      );
-      return {
-        locations,
-        segments: rebuildSegments(locations, state.segments),
-      };
+    const sourceLocation = state.locations[locationIndex];
+    const locations = insertLocationAtIndex(
+      state.locations,
+      duplicateLocationEntry(sourceLocation),
+      locationIndex + 1,
+    );
+    const nextState = {
+      locations,
+      segments: rebuildSegments(locations, state.segments),
+      segmentTimingOverrides: state.segmentTimingOverrides,
+    };
+
+    pushRouteHistoryChange({
+      before: state,
+      after: nextState,
+      label: `Duplicate ${formatStopLabel(sourceLocation.name)}`,
     });
+    set(nextState);
   },
 
   removeLocation: (id) => {
-    useHistoryStore.getState().pushState();
-    return set((state) => {
-      const locations = normalizeEdgeWaypoints(
-        state.locations.filter((l) => l.id !== id),
-      );
-      return {
-        locations,
-        segments: rebuildSegments(locations, state.segments),
-      };
+    const state = get();
+    const location = state.locations.find((entry) => entry.id === id);
+    if (!location) {
+      return;
+    }
+
+    const locations = normalizeEdgeWaypoints(
+      state.locations.filter((entry) => entry.id !== id),
+    );
+    const nextState = {
+      locations,
+      segments: rebuildSegments(locations, state.segments),
+      segmentTimingOverrides: state.segmentTimingOverrides,
+    };
+
+    pushRouteHistoryChange({
+      before: state,
+      after: nextState,
+      label: `Remove ${formatStopLabel(location.name)}`,
     });
+    set(nextState);
   },
 
   reorderLocations: (fromIndex, toIndex) => {
-    useHistoryStore.getState().pushState();
-    return set((state) => {
-      const locations = [...state.locations];
-      const [moved] = locations.splice(fromIndex, 1);
-      locations.splice(toIndex, 0, moved);
-      const normalizedLocations = normalizeEdgeWaypoints(locations);
-      return {
-        locations: normalizedLocations,
-        segments: rebuildSegments(normalizedLocations, state.segments),
-      };
+    const state = get();
+    if (
+      fromIndex === toIndex ||
+      fromIndex < 0 ||
+      toIndex < 0 ||
+      fromIndex >= state.locations.length ||
+      toIndex >= state.locations.length
+    ) {
+      return;
+    }
+
+    const locations = [...state.locations];
+    const [moved] = locations.splice(fromIndex, 1);
+    if (!moved) {
+      return;
+    }
+
+    locations.splice(toIndex, 0, moved);
+    const normalizedLocations = normalizeEdgeWaypoints(locations);
+    const nextState = {
+      locations: normalizedLocations,
+      segments: rebuildSegments(normalizedLocations, state.segments),
+      segmentTimingOverrides: state.segmentTimingOverrides,
+    };
+
+    pushRouteHistoryChange({
+      before: state,
+      after: nextState,
+      label: `Move ${formatStopLabel(moved.name)} to stop ${toIndex + 1}`,
     });
+    set(nextState);
   },
 
-  updateLocation: (id, updates) =>
-    set((state) => ({
-      locations: state.locations.map((l) =>
-        l.id === id ? { ...l, ...updates } : l,
-      ),
-    })),
+  updateLocation: (id, updates) => {
+    const state = get();
+    const previousLocation = state.locations.find((location) => location.id === id);
+    if (!previousLocation) {
+      return;
+    }
+
+    const changedKeys = (Object.keys(updates) as Array<keyof LocationUpdateFields>).filter(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(updates, key) &&
+        previousLocation[key] !== updates[key],
+    );
+
+    if (changedKeys.length === 0) {
+      return;
+    }
+
+    const nextLocation = { ...previousLocation, ...updates };
+    const locations = state.locations.map((location) =>
+      location.id === id ? nextLocation : location,
+    );
+
+    pushRouteHistoryChange({
+      before: state,
+      after: {
+        locations,
+        segments: state.segments,
+        segmentTimingOverrides: state.segmentTimingOverrides,
+      },
+      label: buildLocationUpdateLabel(previousLocation, nextLocation, changedKeys),
+    });
+    set({ locations });
+  },
 
   toggleWaypoint: (locationId) => {
-    useHistoryStore.getState().pushState();
-    return set((state) => {
-      const idx = state.locations.findIndex((l) => l.id === locationId);
-      // First and last locations can never be waypoints
-      if (idx <= 0 || idx >= state.locations.length - 1) return state;
-      return {
-        locations: state.locations.map((l) =>
-          l.id === locationId ? { ...l, isWaypoint: !l.isWaypoint } : l,
-        ),
-      };
+    const state = get();
+    const idx = state.locations.findIndex((location) => location.id === locationId);
+    // First and last locations can never be waypoints
+    if (idx <= 0 || idx >= state.locations.length - 1) {
+      return;
+    }
+
+    const targetLocation = state.locations[idx];
+    const locations = state.locations.map((location) =>
+      location.id === locationId
+        ? { ...location, isWaypoint: !location.isWaypoint }
+        : location,
+    );
+
+    pushRouteHistoryChange({
+      before: state,
+      after: {
+        locations,
+        segments: state.segments,
+        segmentTimingOverrides: state.segmentTimingOverrides,
+      },
+      label: `${targetLocation.isWaypoint ? "Mark" : "Convert"} ${formatStopLabel(targetLocation.name)} ${targetLocation.isWaypoint ? "as destination" : "to waypoint"}`,
     });
+    set({ locations });
   },
 
   setTransportMode: (segmentId, mode) => {


### PR DESCRIPTION
## Summary
- add action-level history entries for route edits alongside existing snapshot history
- record granular undo/redo for stop rename, add, remove, reorder, duplicate, and waypoint toggle actions
- move undo/redo toasts into the history store so keyboard and toolbar actions show the specific change that was undone or redone

## Verification
- npx tsc --noEmit
- npm run build
- store-level verification for rename, add, remove, and reorder undo/redo flows via a temporary `tsx` script