### PR TITLE
feat: collapsible compact header for side panel

### DIFF
--- a/src/components/editor/LeftPanel.tsx
+++ b/src/components/editor/LeftPanel.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { type RefObject } from "react";
-import { Camera, MapPinned, Route } from "lucide-react";
+import { useEffect, useRef, type RefObject } from "react";
+import { lineString } from "@turf/helpers";
+import { length } from "@turf/length";
+import { Camera, ChevronDown, MapPinned, Route } from "lucide-react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { brand } from "@/lib/brand";
 import { useProjectStore } from "@/stores/projectStore";
 import { useUIStore } from "@/stores/uiStore";
+import type { Segment } from "@/types";
 import CitySearch, { type CitySearchHandle } from "./CitySearch";
 import MiniRoutePreview from "./MiniRoutePreview";
 import RouteList from "./RouteList";
@@ -18,6 +21,26 @@ interface LeftPanelProps {
   searchRef?: RefObject<CitySearchHandle | null>;
 }
 
+function getSegmentDistanceKm(segment: Segment): number {
+  if (!segment.geometry || segment.geometry.coordinates.length < 2) {
+    return 0;
+  }
+
+  try {
+    return length(lineString(segment.geometry.coordinates), { units: "kilometers" });
+  } catch {
+    return 0;
+  }
+}
+
+function formatCompactDistance(distanceKm: number): string {
+  if (!Number.isFinite(distanceKm) || distanceKm <= 0) {
+    return "0 km";
+  }
+
+  return `${Math.round(distanceKm).toLocaleString()} km`;
+}
+
 export default function LeftPanel({
   onLocationClick,
   onEditLayout,
@@ -26,13 +49,60 @@ export default function LeftPanel({
   searchRef,
 }: LeftPanelProps) {
   const leftPanelOpen = useUIStore((s) => s.leftPanelOpen);
+  const headerCollapsed = useUIStore((s) => s.headerCollapsed);
+  const setHeaderCollapsed = useUIStore((s) => s.setHeaderCollapsed);
+  const toggleHeaderCollapsed = useUIStore((s) => s.toggleHeaderCollapsed);
   const locations = useProjectStore((s) => s.locations);
   const segments = useProjectStore((s) => s.segments);
+  const routeScrollRegionRef = useRef<HTMLDivElement | null>(null);
 
   const nonWaypointLocations = locations.filter((location) => !location.isWaypoint);
   const totalPhotos = locations.reduce((sum, location) => sum + location.photos.length, 0);
+  const totalDistanceKm = segments.reduce((sum, segment) => sum + getSegmentDistanceKm(segment), 0);
+
+  useEffect(() => {
+    const region = routeScrollRegionRef.current;
+    const viewport = region?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+    if (!viewport) return;
+
+    const handleScroll = () => {
+      if (viewport.scrollTop > 0) {
+        setHeaderCollapsed(true);
+      }
+    };
+
+    viewport.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      viewport.removeEventListener("scroll", handleScroll);
+    };
+  }, [setHeaderCollapsed]);
 
   if (!leftPanelOpen) return null;
+
+  const compactStats = [
+    {
+      key: "stops",
+      icon: MapPinned,
+      label: `${nonWaypointLocations.length} stop${nonWaypointLocations.length === 1 ? "" : "s"}`,
+    },
+    {
+      key: "photos",
+      icon: Camera,
+      label: `${totalPhotos} photo${totalPhotos === 1 ? "" : "s"}`,
+    },
+    {
+      key: "distance",
+      icon: Route,
+      label: formatCompactDistance(totalDistanceKm),
+    },
+  ];
+
+  const handleRouteAreaInteract = () => {
+    if (!headerCollapsed) {
+      setHeaderCollapsed(true);
+    }
+  };
 
   return (
     <aside
@@ -50,106 +120,195 @@ export default function LeftPanel({
       />
 
       <div
-        className="border-b px-5 pb-5 pt-6"
+        className="border-b px-4 py-3"
         style={{
           borderColor: brand.colors.warm[200],
           background: `linear-gradient(180deg, rgba(255,247,237,0.96) 0%, rgba(255,251,245,0.82) 100%)`,
         }}
       >
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <p
-              className="text-2xl leading-none"
-              style={{
-                color: brand.colors.primary[600],
-                fontFamily: brand.fonts.handwritten,
-              }}
-            >
-              Your Journey
-            </p>
-            <h2
-              className="mt-2 text-[28px] font-semibold leading-[1.05]"
-              style={{
-                color: brand.colors.warm[900],
-                fontFamily: brand.fonts.display,
-              }}
-            >
-              {nonWaypointLocations.length > 0
-                ? `${nonWaypointLocations.length} stops waiting`
-                : "Map out your first stop"}
-            </h2>
-            <p
-              className="mt-2 max-w-[18rem] text-sm leading-5"
-              style={{ color: brand.colors.warm[500] }}
-            >
-              Warm up the route with cities, quick stopovers, and the photos that make it feel like yours.
-            </p>
-          </div>
-
-          <div
-            className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[18px] border"
-            style={{
-              backgroundColor: "rgba(255,255,255,0.7)",
-              borderColor: brand.colors.primary[200],
-              boxShadow: brand.shadows.md,
-            }}
-          >
-            <MapPinned
-              className="h-6 w-6"
-              style={{ color: brand.colors.primary[500] }}
-            />
-          </div>
-        </div>
-
-        <div className="mt-5 grid grid-cols-[128px_minmax(0,1fr)] gap-3">
-          <div
-            className="rounded-[20px] border px-4 py-3"
-            style={{
-              backgroundColor: "rgba(255,255,255,0.76)",
-              borderColor: brand.colors.primary[200],
-              boxShadow: brand.shadows.sm,
-            }}
-          >
-            <div
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full"
-              style={{ backgroundColor: brand.colors.primary[100] }}
-            >
-              <Route
-                className="h-4 w-4"
-                style={{ color: brand.colors.primary[600] }}
-              />
-            </div>
-            <p
-              className="mt-3 text-[11px] font-medium uppercase tracking-[0.18em]"
-              style={{ color: brand.colors.warm[500] }}
-            >
-              Stops
-            </p>
-            <p className="mt-1 text-2xl font-semibold" style={{ color: brand.colors.warm[900] }}>
-              {nonWaypointLocations.length}
-            </p>
-          </div>
-
-          <MiniRoutePreview
-            locations={locations}
-            segments={segments}
-            className="min-w-0 overflow-hidden"
-          />
-        </div>
-
         <div
-          className="mt-4 flex items-center justify-between rounded-full border px-3 py-2 text-xs"
+          className="rounded-[22px] border px-3 py-2"
           style={{
             borderColor: brand.colors.warm[200],
-            backgroundColor: "rgba(255,251,245,0.86)",
-            color: brand.colors.warm[600],
+            backgroundColor: "rgba(255,251,245,0.92)",
           }}
         >
-          <span className="inline-flex items-center gap-1.5">
-            <Camera className="h-3.5 w-3.5" />
-            {totalPhotos} photo{totalPhotos === 1 ? "" : "s"} attached
-          </span>
-          <span>{segments.length} leg{segments.length === 1 ? "" : "s"} planned</span>
+          <button
+            type="button"
+            aria-expanded={!headerCollapsed}
+            aria-controls="left-panel-expanded-header"
+            aria-label={headerCollapsed ? "Expand journey header" : "Collapse journey header"}
+            onClick={toggleHeaderCollapsed}
+            className="flex w-full items-center justify-between gap-3 text-left"
+          >
+            <div className="min-w-0 overflow-hidden">
+              <div
+                className="flex items-center gap-2 overflow-hidden whitespace-nowrap text-sm"
+                style={{
+                  color: brand.colors.warm[700],
+                  fontFamily: brand.fonts.body,
+                }}
+              >
+                {compactStats.map(({ key, icon: Icon, label }, index) => (
+                  <div
+                    key={key}
+                    className="inline-flex min-w-0 shrink-0 items-center gap-1.5"
+                  >
+                    <Icon
+                      className="h-3.5 w-3.5 shrink-0"
+                      style={{
+                        color: key === "distance"
+                          ? brand.colors.ocean[600]
+                          : brand.colors.primary[500],
+                      }}
+                    />
+                    <span className="truncate">{label}</span>
+                    {index < compactStats.length - 1 ? (
+                      <span
+                        aria-hidden
+                        className="ml-0.5 text-xs"
+                        style={{ color: brand.colors.warm[400] }}
+                      >
+                        ·
+                      </span>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <span
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border"
+              style={{
+                borderColor: brand.colors.warm[200],
+                backgroundColor: "rgba(255,255,255,0.88)",
+                color: brand.colors.warm[700],
+              }}
+            >
+              <ChevronDown
+                className={`h-4 w-4 transition-transform duration-300 ${
+                  headerCollapsed ? "" : "rotate-180"
+                }`}
+                style={{ transitionTimingFunction: brand.animation.easeInOut }}
+              />
+            </span>
+          </button>
+
+          <div
+            id="left-panel-expanded-header"
+            className="grid overflow-hidden"
+            style={{
+              gridTemplateRows: headerCollapsed ? "0fr" : "1fr",
+              opacity: headerCollapsed ? 0 : 1,
+              marginTop: headerCollapsed ? 0 : 12,
+              transitionDuration: "260ms",
+              transitionProperty: "grid-template-rows, opacity, margin-top",
+              transitionTimingFunction: brand.animation.easeInOut,
+            }}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <div className="px-1 pb-2">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <p
+                      className="text-2xl leading-none"
+                      style={{
+                        color: brand.colors.primary[600],
+                        fontFamily: brand.fonts.handwritten,
+                      }}
+                    >
+                      Your Journey
+                    </p>
+                    <h2
+                      className="mt-2 text-[28px] font-semibold leading-[1.05]"
+                      style={{
+                        color: brand.colors.warm[900],
+                        fontFamily: brand.fonts.display,
+                      }}
+                    >
+                      {nonWaypointLocations.length > 0
+                        ? `${nonWaypointLocations.length} stops waiting`
+                        : "Map out your first stop"}
+                    </h2>
+                    <p
+                      className="mt-2 max-w-[18rem] text-sm leading-5"
+                      style={{ color: brand.colors.warm[500] }}
+                    >
+                      Warm up the route with cities, quick stopovers, and the photos that make it feel like yours.
+                    </p>
+                  </div>
+
+                  <div
+                    className="flex h-14 w-14 shrink-0 items-center justify-center rounded-[18px] border"
+                    style={{
+                      backgroundColor: "rgba(255,255,255,0.7)",
+                      borderColor: brand.colors.primary[200],
+                      boxShadow: brand.shadows.sm,
+                    }}
+                  >
+                    <MapPinned
+                      className="h-6 w-6"
+                      style={{ color: brand.colors.primary[500] }}
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-5 grid grid-cols-[128px_minmax(0,1fr)] gap-3">
+                  <div
+                    className="rounded-[20px] border px-4 py-3"
+                    style={{
+                      backgroundColor: "rgba(255,255,255,0.76)",
+                      borderColor: brand.colors.primary[200],
+                      boxShadow: brand.shadows.sm,
+                    }}
+                  >
+                    <div
+                      className="inline-flex h-8 w-8 items-center justify-center rounded-full"
+                      style={{ backgroundColor: brand.colors.primary[100] }}
+                    >
+                      <Route
+                        className="h-4 w-4"
+                        style={{ color: brand.colors.primary[600] }}
+                      />
+                    </div>
+                    <p
+                      className="mt-3 text-[11px] font-medium uppercase tracking-[0.18em]"
+                      style={{ color: brand.colors.warm[500] }}
+                    >
+                      Stops
+                    </p>
+                    <p
+                      className="mt-1 text-2xl font-semibold"
+                      style={{ color: brand.colors.warm[900] }}
+                    >
+                      {nonWaypointLocations.length}
+                    </p>
+                  </div>
+
+                  <MiniRoutePreview
+                    locations={locations}
+                    segments={segments}
+                    className="min-w-0 overflow-hidden"
+                  />
+                </div>
+
+                <div
+                  className="mt-4 flex items-center justify-between rounded-full border px-3 py-2 text-xs"
+                  style={{
+                    borderColor: brand.colors.warm[200],
+                    backgroundColor: "rgba(255,251,245,0.86)",
+                    color: brand.colors.warm[600],
+                  }}
+                >
+                  <span className="inline-flex items-center gap-1.5">
+                    <Camera className="h-3.5 w-3.5" />
+                    {totalPhotos} photo{totalPhotos === 1 ? "" : "s"} attached
+                  </span>
+                  <span>{segments.length} leg{segments.length === 1 ? "" : "s"} planned</span>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -169,12 +328,19 @@ export default function LeftPanel({
         />
       </div>
 
-      <ScrollArea className="min-h-0 flex-1">
-        <RouteList
-          onLocationClick={onLocationClick}
-          onEditLayout={onEditLayout}
-        />
-      </ScrollArea>
+      <div
+        ref={routeScrollRegionRef}
+        className="min-h-0 flex-1"
+        onWheelCapture={handleRouteAreaInteract}
+        onTouchStartCapture={handleRouteAreaInteract}
+      >
+        <ScrollArea className="h-full">
+          <RouteList
+            onLocationClick={onLocationClick}
+            onEditLayout={onEditLayout}
+          />
+        </ScrollArea>
+      </div>
     </aside>
   );
 }

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -79,6 +79,7 @@ interface ToastItem {
 
 interface UIState {
   leftPanelOpen: boolean;
+  headerCollapsed: boolean;
   immersiveMode: boolean;
   exportDialogOpen: boolean;
   aiPanelOpen: boolean;
@@ -109,6 +110,8 @@ interface UIState {
   removeToast: (id: string) => void;
   setSaveStatus: (status: SaveStatus) => void;
   setLeftPanelOpen: (open: boolean) => void;
+  setHeaderCollapsed: (collapsed: boolean) => void;
+  toggleHeaderCollapsed: () => void;
   setImmersiveMode: (immersive: boolean) => void;
   setExportDialogOpen: (open: boolean) => void;
   setAIPanelOpen: (open: boolean) => void;
@@ -136,6 +139,7 @@ interface UIState {
 
 export const useUIStore = create<UIState>((set) => ({
   leftPanelOpen: true,
+  headerCollapsed: true,
   immersiveMode: false,
   exportDialogOpen: false,
   aiPanelOpen: false,
@@ -171,6 +175,9 @@ export const useUIStore = create<UIState>((set) => ({
   },
   setSaveStatus: (saveStatus) => set({ saveStatus }),
   setLeftPanelOpen: (leftPanelOpen) => set({ leftPanelOpen }),
+  setHeaderCollapsed: (headerCollapsed) => set({ headerCollapsed }),
+  toggleHeaderCollapsed: () =>
+    set((state) => ({ headerCollapsed: !state.headerCollapsed })),
   setImmersiveMode: (immersiveMode) => set({ immersiveMode }),
   setExportDialogOpen: (exportDialogOpen) => set({ exportDialogOpen }),
   setAIPanelOpen: (aiPanelOpen) => set({ aiPanelOpen }),


### PR DESCRIPTION
## Summary
- add collapsible left panel header state to the UI store
- replace the large default header with a compact summary bar and animated expandable details
- auto-collapse the expanded header when the route area starts scrolling

## Verification
- npx tsc --noEmit
- npm run build