### PR TITLE
feat: widen panel to 400px and clean up location cards

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -1298,11 +1298,11 @@ function EditorContent() {
       <div className="relative flex flex-1 overflow-hidden">
         <div
           className={`hidden shrink-0 overflow-hidden transition-[width] duration-300 ease-in-out md:block ${
-            showDesktopSidebar ? "w-[360px]" : "w-0"
+            showDesktopSidebar ? "w-[400px]" : "w-0"
           }`}
         >
           <div
-            className={`h-full w-[360px] transition-transform duration-300 ease-in-out ${
+            className={`h-full w-[400px] transition-transform duration-300 ease-in-out ${
               showDesktopSidebar ? "translate-x-0" : "-translate-x-full"
             }`}
           >
@@ -1321,7 +1321,7 @@ function EditorContent() {
             onClick={handleImmersiveToggle}
             className="absolute top-1/2 z-30 hidden h-11 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-white/15 bg-slate-950/65 text-white/80 shadow-[0_16px_40px_-24px_rgba(15,23,42,0.9)] backdrop-blur-sm transition-all duration-300 ease-in-out hover:border-white/30 hover:bg-slate-900/80 hover:text-white disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-white/15 disabled:hover:bg-slate-950/65 disabled:hover:text-white/80 md:flex"
             style={{
-              left: showDesktopSidebar ? "332px" : "12px",
+              left: showDesktopSidebar ? "372px" : "12px",
             }}
             aria-label={showDesktopSidebar ? "Collapse sidebar" : "Expand sidebar"}
             aria-pressed={showDesktopSidebar}

--- a/src/components/editor/LeftPanel.tsx
+++ b/src/components/editor/LeftPanel.tsx
@@ -106,7 +106,7 @@ export default function LeftPanel({
 
   return (
     <aside
-      className="relative hidden h-full w-[360px] flex-col overflow-hidden border-r md:flex"
+      className="relative hidden h-full w-[400px] flex-col overflow-hidden border-r md:flex"
       style={{
         background: brand.gradients.cardWarm,
         borderColor: brand.colors.warm[200],

--- a/src/components/editor/LocationCard.tsx
+++ b/src/components/editor/LocationCard.tsx
@@ -5,7 +5,6 @@ import {
   Bike,
   Bus,
   Car,
-  ChevronRight,
   Copy,
   Footprints,
   Image as ImageIcon,
@@ -708,14 +707,22 @@ export default memo(function LocationCard({
             )}
           </div>
 
-          <div className="shrink-0">
+          <div
+            className={`relative shrink-0 overflow-hidden ${
+              isWaypoint ? "h-12 w-12 rounded-[16px]" : "h-14 w-14 rounded-[18px]"
+            } max-[420px]:h-11 max-[420px]:w-11 max-[420px]:rounded-[14px]`}
+            style={{
+              boxShadow: brand.shadows.sm,
+              ...(coverPhoto
+                ? {}
+                : {
+                    border: `1px solid ${brand.colors.warm[200]}`,
+                    background: `linear-gradient(160deg, ${brand.colors.sand[100]} 0%, ${brand.colors.primary[50]} 100%)`,
+                  }),
+            }}
+          >
             {coverPhoto ? (
-              <div
-                className={`relative overflow-hidden ${
-                  isWaypoint ? "h-12 w-12 rounded-[16px]" : "h-14 w-14 rounded-[18px]"
-                } max-[420px]:h-11 max-[420px]:w-11 max-[420px]:rounded-[14px]`}
-                style={{ boxShadow: brand.shadows.sm }}
-              >
+              <>
                 <img
                   src={coverPhoto.url}
                   alt={location.name ? `${location.name} photo` : "Location photo"}
@@ -729,17 +736,9 @@ export default memo(function LocationCard({
                     +{photoCount - 1}
                   </div>
                 )}
-              </div>
+              </>
             ) : (
-              <div
-                className={`flex items-center justify-center border ${
-                  isWaypoint ? "h-12 w-12 rounded-[16px]" : "h-14 w-14 rounded-[18px]"
-                } max-[420px]:h-11 max-[420px]:w-11 max-[420px]:rounded-[14px]`}
-                style={{
-                  borderColor: brand.colors.warm[200],
-                  background: `linear-gradient(160deg, ${brand.colors.sand[100]} 0%, ${brand.colors.primary[50]} 100%)`,
-                }}
-              >
+              <div className="flex h-full w-full items-center justify-center">
                 <ImageIcon
                   className="h-4 w-4"
                   style={{ color: brand.colors.warm[400] }}
@@ -747,24 +746,6 @@ export default memo(function LocationCard({
               </div>
             )}
           </div>
-
-          <button
-            className="touch-target-mobile flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-white"
-            data-no-seek
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsExpanded((expanded) => !expanded);
-              onClick?.(index);
-            }}
-            aria-label={isExpanded ? "Collapse location details" : "Expand location details"}
-          >
-            <ChevronRight
-              className={`h-4 w-4 shrink-0 transition-transform duration-200 ${
-                isExpanded ? "rotate-90" : ""
-              }`}
-              style={{ color: brand.colors.warm[500] }}
-            />
-          </button>
 
           <button
             data-delete-btn


### PR DESCRIPTION
## Summary
- widen the desktop editor sidebar from 360px to 400px and reposition the immersive toggle
- remove the redundant location-card expand chevron and keep card click for expand/collapse
- unify the location thumbnail container so fallback framing only appears when no photo exists

## Verification
- npx tsc --noEmit
- npm run build