### PR TITLE
fix: playback bar visibility in 9:16 aspect ratio

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -34,6 +34,7 @@ import { computeContainedViewportSize } from "@/lib/viewportRatio";
 
 const ONBOARDING_STORAGE_KEY = "trace-recap-onboarded";
 const ALBUM_VISITED_HOLD_MS = 300;
+const CONSTRAINED_STAGE_PLAYBACK_RESERVE_PX = 72;
 
 type OnboardingHintKey =
   | "searchStart"
@@ -202,8 +203,11 @@ function EditorContent() {
         availableStageSize.width,
         availableStageSize.height,
         viewportRatio,
+        viewportRatio !== "free" && segments.length > 0
+          ? CONSTRAINED_STAGE_PLAYBACK_RESERVE_PX
+          : 0,
       ),
-    [availableStageSize.height, availableStageSize.width, viewportRatio],
+    [availableStageSize.height, availableStageSize.width, segments.length, viewportRatio],
   );
 
   const clearAlbumSequenceTimers = useCallback(() => {

--- a/src/lib/viewportRatio.ts
+++ b/src/lib/viewportRatio.ts
@@ -35,18 +35,21 @@ export function computeContainedViewportSize(
   availableWidth: number,
   availableHeight: number,
   viewportRatio: AspectRatio,
+  reservedHeight = 0,
 ): ViewportDimensions | null {
   const ratio = parseViewportRatio(viewportRatio);
-  if (!ratio || availableWidth <= 0 || availableHeight <= 0) {
+  const usableHeight = Math.max(availableHeight - reservedHeight, 0);
+
+  if (!ratio || availableWidth <= 0 || usableHeight <= 0) {
     return null;
   }
 
   const aspectRatio = ratio.width / ratio.height;
-  let targetWidth = Math.min(availableWidth, availableHeight * aspectRatio);
+  let targetWidth = Math.min(availableWidth, usableHeight * aspectRatio);
   let targetHeight = targetWidth / aspectRatio;
 
-  if (targetHeight > availableHeight) {
-    targetHeight = availableHeight;
+  if (targetHeight > usableHeight) {
+    targetHeight = usableHeight;
     targetWidth = targetHeight * aspectRatio;
   }
 


### PR DESCRIPTION
## Summary
- reserve space for the playback controls when computing constrained aspect-ratio stage sizes
- keep constrained map heights from consuming the full stage when playback controls are present

## Testing
- npx tsc --noEmit
- npm run build
- attempted local editor verification, but this workspace does not have a working Mapbox token so the editor cannot fully mount for interactive playback checks