### PR TITLE
fix: maximize photo area in 9:16 portrait overlay

### DIFF
--- a/src/components/editor/PhotoFrame.tsx
+++ b/src/components/editor/PhotoFrame.tsx
@@ -15,6 +15,8 @@ interface PhotoFrameProps {
   mediaStyle?: CSSProperties;
   footer?: ReactNode;
   disableDecorativeRotation?: boolean;
+  /** Reduce frame padding for compact viewports (e.g. 9:16 portrait) */
+  compact?: boolean;
   children: ReactNode;
 }
 
@@ -64,9 +66,10 @@ export default function PhotoFrame({
   mediaStyle,
   footer,
   disableDecorativeRotation = false,
+  compact = false,
   children,
 }: PhotoFrameProps) {
-  const config = getPhotoFrameStyleConfig(frameStyle);
+  const config = getPhotoFrameStyleConfig(frameStyle, compact);
   const rotation = disableDecorativeRotation ? 0 : getPhotoFrameRotation(frameStyle, photoId);
   const trimmedCaption = caption?.trim();
 

--- a/src/components/editor/PhotoOverlay.tsx
+++ b/src/components/editor/PhotoOverlay.tsx
@@ -489,6 +489,7 @@ export default function PhotoOverlay({
   const captionH = captionFontSizePx * 2;
   const captionFontFamily = displayLayout?.captionFontFamily ?? "system-ui";
   const displayIsFreeMode = displayLayout?.mode === "free";
+  const compactFrames = viewportRatio === "9:16";
   const incomingCaptionFontSizePx = (incomingPhotoLayout?.captionFontSize ?? 14) * captionScale;
   const incomingCaptionH = incomingCaptionFontSizePx * 2;
   const incomingCaptionFontFamily = incomingPhotoLayout?.captionFontFamily ?? "system-ui";
@@ -747,6 +748,7 @@ export default function PhotoOverlay({
                       className="h-full w-full"
                       mediaStyle={{ borderRadius: `${borderRadiusPx}px` }}
                       disableDecorativeRotation={displayIsFreeMode}
+                      compact={compactFrames}
                       footer={
                         !displayIsFreeMode && hasCaption && !frameHandlesCaption ? (
                           <p
@@ -883,6 +885,7 @@ export default function PhotoOverlay({
                     className="h-full w-full"
                     mediaStyle={{ borderRadius: `${borderRadiusPx}px` }}
                     disableDecorativeRotation={displayIsFreeMode}
+                    compact={compactFrames}
                     footer={
                       !displayIsFreeMode && hasCaption && !frameHandlesCaption ? (
                         <p
@@ -1041,6 +1044,7 @@ export default function PhotoOverlay({
                       className="h-full w-full"
                       mediaStyle={{ borderRadius: `${incomingBorderRadiusPx}px` }}
                       disableDecorativeRotation={incomingIsFreeMode}
+                      compact={compactFrames}
                       footer={
                         !incomingIsFreeMode && hasCaption && !frameHandlesCaption ? (
                           <p

--- a/src/lib/demoProject.ts
+++ b/src/lib/demoProject.ts
@@ -28,10 +28,10 @@ export const demoProject: ImportRouteData = {
       photoLayout: {
         mode: "auto",
         template: "hero",
-        gap: 8,
-        borderRadius: 8,
+        gap: 4,
+        borderRadius: 6,
         photoStyle: "kenburns",
-        enterAnimation: "fade",
+        enterAnimation: "scale",
         sceneTransition: "dissolve",
         captionFontSize: 16,
       },

--- a/src/lib/frameStyles.ts
+++ b/src/lib/frameStyles.ts
@@ -87,8 +87,32 @@ export const PHOTO_FRAME_STYLE_CONFIGS: Record<PhotoFrameStyle, PhotoFrameStyleC
   },
 };
 
-export function getPhotoFrameStyleConfig(style: PhotoFrameStyle): PhotoFrameStyleConfig {
-  return PHOTO_FRAME_STYLE_CONFIGS[style];
+export function getPhotoFrameStyleConfig(style: PhotoFrameStyle, compact?: boolean): PhotoFrameStyleConfig {
+  const config = PHOTO_FRAME_STYLE_CONFIGS[style];
+  if (!compact) return config;
+
+  // Compact mode: reduce frame padding for 9:16 portrait viewports
+  const compactOverrides: Partial<Record<PhotoFrameStyle, Partial<PhotoFrameStyleConfig>>> = {
+    polaroid: {
+      framePadding: "2% 2% 10% 2%",
+      inlineCaptionMinHeight: "10%",
+      inlineCaptionPadding: "0.2rem 0.5rem 0.1rem",
+    },
+    "film-strip": {
+      framePadding: "6% 3%",
+      filmStripHeight: "6%",
+    },
+    "classic-border": {
+      framePadding: "2%",
+    },
+    "rounded-card": {
+      framePadding: "2%",
+    },
+  };
+
+  const overrides = compactOverrides[style];
+  if (!overrides) return config;
+  return { ...config, ...overrides };
 }
 
 export function frameStyleUsesInlineCaption(style: PhotoFrameStyle): boolean {

--- a/src/lib/photoLayout.ts
+++ b/src/lib/photoLayout.ts
@@ -263,12 +263,48 @@ function layoutPortraitReadableGallery(
 ): PhotoRect[] {
   const n = photos.length;
   if (n === 0) return [];
-  if (n === 1) return layoutOne(photos, containerAspect, gap);
 
   const innerWidth = 1 - gap * 2;
   const innerHeight = 1 - gap * 2;
 
+  // Single photo: landscape photos get a generous cover-crop slot (full width, 55% height)
+  if (n === 1) {
+    if (photos[0].aspect > 1.2) {
+      const heroHeight = innerHeight * 0.55;
+      return [{ x: gap, y: gap + (innerHeight - heroHeight) / 2, width: innerWidth, height: heroHeight }];
+    }
+    return layoutOne(photos, containerAspect, gap);
+  }
+
   if (n === 2) {
+    const landscapeCount = photos.filter((p) => p.aspect > 1.2).length;
+
+    // Both landscape: stack vertically, each gets full width + cover-crop height
+    if (landscapeCount === 2) {
+      const slotHeight = (innerHeight - gap) / 2;
+      return [
+        { x: gap, y: gap, width: innerWidth, height: slotHeight },
+        { x: gap, y: gap + slotHeight + gap, width: innerWidth, height: slotHeight },
+      ];
+    }
+
+    // Mixed or both portrait: one landscape on top (hero), one below
+    if (landscapeCount === 1) {
+      const landscapeIndex = photos[0].aspect > 1.2 ? 0 : 1;
+      const portraitIndex = landscapeIndex === 0 ? 1 : 0;
+      const heroHeight = innerHeight * 0.45;
+      const bottomHeight = innerHeight - heroHeight - gap;
+      const rects: PhotoRect[] = [];
+      rects[landscapeIndex] = { x: gap, y: gap, width: innerWidth, height: heroHeight };
+      rects[portraitIndex] = fitPhotoToSlot(
+        { x: gap, y: gap + heroHeight + gap, width: innerWidth, height: bottomHeight },
+        photos[portraitIndex],
+        containerAspect,
+      );
+      return rects;
+    }
+
+    // Both portrait: side by side (original behavior)
     const columnWidth = (innerWidth - gap) / 2;
     return fillSlots(
       photos,


### PR DESCRIPTION
## Summary
- **Compact frames**: Adds `compact` mode to `PhotoFrame` that reduces padding for 9:16 viewports (polaroid: 6%→2% sides, 18%→10% caption; film-strip: 10%→6% strips; classic-border/rounded-card: 5%/4%→2%)
- **Landscape cover-crop**: Fixes landscape photos appearing as thin strips in portrait layout — single landscape gets centered 55%-height slot, two landscapes stack vertically with full-width cover-crop, mixed orientations use hero-top layout
- **Seattle hook**: Changes opening city entrance from subtle `fade` to dramatic `scale` animation (zoom+blur entrance) with tighter gap for a punchier reel-worthy opening beat

## Test plan
- [ ] Play demo in 9:16 (402×874) viewport — verify photos fill most of the screen area
- [ ] Check polaroid/film-strip/classic-border frame styles have minimal padding in 9:16
- [ ] Verify landscape photos (Honolulu, Taipei skylines) show as tall cover-cropped slots, not thin strips
- [ ] Confirm Seattle opening has dramatic scale-in animation
- [ ] Verify 16:9 and 1:1 modes are unchanged
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)