### PR TITLE
fix: Honolulu photo collapse + template-aware portrait layouts

### DIFF
--- a/src/lib/demoProject.ts
+++ b/src/lib/demoProject.ts
@@ -52,7 +52,7 @@ export const demoProject: ImportRouteData = {
         template: "full",
         gap: 0,
         borderRadius: 0,
-        photoStyle: "kenburns",
+        photoStyle: "classic",
         enterAnimation: "scale",
         sceneTransition: "blur-dissolve",
         captionFontSize: 18,

--- a/src/lib/photoLayout.ts
+++ b/src/lib/photoLayout.ts
@@ -259,7 +259,8 @@ function getPortraitHeroHeight(innerHeight: number, photoCount: number): number 
 function layoutPortraitReadableGallery(
   photos: PhotoMeta[],
   containerAspect: number,
-  gap: number
+  gap: number,
+  template?: LayoutTemplate
 ): PhotoRect[] {
   const n = photos.length;
   if (n === 0) return [];
@@ -282,6 +283,27 @@ function layoutPortraitReadableGallery(
   }
 
   if (n === 2) {
+    // Polaroid template: side-by-side cards with slight rotation for personality
+    if (template === "polaroid") {
+      const cardW = (innerWidth - gap) * 0.46;
+      const cardH = innerHeight * 0.72;
+      const yCenter = gap + (innerHeight - cardH) / 2;
+      return [
+        { x: gap + innerWidth * 0.02, y: yCenter - innerHeight * 0.02, width: cardW, height: cardH, rotation: -3 },
+        { x: gap + innerWidth - cardW - innerWidth * 0.02, y: yCenter + innerHeight * 0.02, width: cardW, height: cardH, rotation: 2.5 },
+      ];
+    }
+
+    // Hero template: dominant first photo (78%) + small strip (17%)
+    if (template === "hero") {
+      const heroHeight = innerHeight * 0.78;
+      const bottomHeight = innerHeight * 0.17;
+      return [
+        { x: gap, y: gap, width: innerWidth, height: heroHeight },
+        { x: gap + innerWidth * 0.15, y: gap + heroHeight + gap, width: innerWidth * 0.7, height: bottomHeight },
+      ];
+    }
+
     const landscapeCount = photos.filter((p) => p.aspect > 1.2).length;
 
     // Both landscape: stack vertically, each full width
@@ -571,7 +593,7 @@ export function computePhotoLayout(
   const gap = gapPx / widthPx;
 
   if (shouldUsePortraitFriendlyLayout(viewportRatio)) {
-    return layoutPortraitReadableGallery(photos, containerAspect, gap);
+    return layoutPortraitReadableGallery(photos, containerAspect, gap, layout?.template);
   }
 
   if (layout?.mode === "manual" && layout.template) {


### PR DESCRIPTION
## Round 4 Fixes

### P0: Honolulu Photo Collapse (was 2.2/10)
- Root cause: `photoStyle: 'kenburns'` triggered portal/bloom render path → photos collapsed into tiny AlbumBook
- Fix: Changed to `photoStyle: 'classic'` — photos now render in full PhotoOverlay

### Template-Aware Portrait Layouts
- `layoutPortraitReadableGallery` now accepts template parameter
- **Polaroid**: Side-by-side rotated cards (46% width each, 72% height, ±3° rotation)
- **Hero**: 78% dominant photo + 17% strip below (strong hierarchy)

### Visual Rhythm
Sequence now: hero → full → magazine → rows → polaroid → hero
No two adjacent cities use the same layout pattern.

tsc passes ✅