### PR TITLE
fix: WYSIWYG — editor preview matches playback layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,112 +1,81 @@
-# CLAUDE.md — TraceRecap P0 Fixes
+# CLAUDE.md — Fix WYSIWYG: Edit Preview Must Match Playback
 
-## Current Task
+## Two Bugs Reported by User
 
-Fix **two P0 issues** for the TraceRecap demo:
+### Bug 1: Layout edit preview ≠ playback preview (NOT WYSIWYG)
 
-### P0-1: Replace alishan-1.jpg ✅ ALREADY DONE
-The file `public/demo-photos/alishan-1.jpg` has been replaced with a realistic Alishan mountain sunrise photo. No code change needed.
+**What user sees:**
+- In the **photo layout editing dialog** (the modal with undo/redo/close): Photos are shown as large, beautifully arranged polaroid cards on the map
+- In the **playback view** (pressing Play): Same photos become tiny thumbnail clusters on the map
 
-### P0-2: Photo Card 竖屏布局重构 — 9:16 改为全屏单图模式
+**Expected:** What you see in the edit dialog is what you get during playback. The photo sizes, positions, and layout should be identical.
 
-**Problem:** When `viewportRatio === "9:16"`, the current masonry layout shows photos at ~130×80px each — completely unreadable. Tokyo Tower photos get compressed into tiny strips.
+**Root cause investigation:**
+The edit dialog likely renders photos using `PhotoOverlay` component with the full layout engine, but during playback the photos might be rendered differently — possibly through `ChapterPin` / `AlbumBook` (which uses tiny thumbnails) instead of the full `PhotoOverlay`.
 
-**Expected behavior in 9:16:**
-- Show **one photo at a time** (single photo, full-width, or full-height in the photo card area)
-- When there are 2+ photos, show them **side by side** (2-column) instead of masonry grid
-- Photos should be **large and readable** — at least 200px wide in 9:16 portrait
-- City label, chapter emoji, date, and caption text must be clearly legible
+Look at:
+- How the layout editing dialog renders photos (likely `src/components/editor/PhotoLayoutEditor.tsx` or similar)
+- How playback renders photos during ARRIVE phase (`src/components/editor/EditorLayout.tsx` → `PhotoOverlay`)
+- Are they using the same layout computation? Same container size? Same component?
+- The edit dialog might use `containerMode="parent"` while playback uses `containerMode="viewport"` — check if this causes different sizing
 
-**NOT this (current broken behavior):**
-```
-┌────┬────┬────┐  ← 3 tiny photos, ~130px wide each, unreadable captions
-│ p1 │ p2 │ p3 │
-└────┴────┴────┘
-```
+### Bug 2: Free ratio edit preview uses wrong aspect ratio
 
-**DO this instead (9:16 portrait):**
-```
-┌────────────────────┐
-│                    │
-│     photo 1       │  ← Single large photo, full container width
-│                    │
-│  🗼 Tokyo          │  ← City label
-│  Tokyo Tower 🌆    │  ← Caption
-└────────────────────┘
-OR for 2 photos:
-┌──────────┬──────────┐
-│  photo1  │  photo2  │  ← 2-column layout, both clearly visible
-│  caption │  caption │
-└──────────┴──────────┘
-```
+**What user sees:**
+- When the map is in "free" aspect ratio mode (not 16:9/9:16/1:1)
+- The photo layout edit dialog preview area has its OWN fixed aspect ratio
+- Instead, it should match the ACTUAL aspect ratio of the map viewport behind it
 
-## Files to Modify
+**Expected:** In free ratio mode, the edit dialog preview should mirror the current map container's aspect ratio, not use a hardcoded ratio.
 
-1. **`src/lib/photoLayout.ts`** — Modify the `computePhotoLayout` function to accept `viewportRatio` and return a 9:16-friendly layout
-2. **`src/components/editor/PhotoOverlay.tsx`** — Pass `viewportRatio` to the layout computation and adjust rendering logic
+**Root cause investigation:**
+The layout editing dialog probably has a hardcoded preview container aspect ratio (like 4:3 or 16:10). In free mode, it should:
+1. Read the actual map container dimensions
+2. Set the preview to match that aspect ratio
+3. So the layout computation produces the same result as playback
 
-## Implementation Hints
+Look at:
+- The layout editor component — how does it set its preview container size?
+- Does it receive the current viewportRatio prop?
+- In free mode, does it use the actual canvas dimensions?
 
-### In `photoLayout.ts`:
-```typescript
-// Add viewportRatio parameter to computePhotoLayout
-export function computePhotoLayout(
-  photos: PhotoMeta[],
-  containerWidth: number,
-  containerHeight: number,
-  template: LayoutTemplate,
-  viewportRatio?: AspectRatio, // NEW PARAM
-): PhotoLayout { ... }
-```
+## How to Investigate
 
-### In `PhotoOverlay.tsx`:
-```typescript
-// Line 319 already has: const viewportRatio = useUIStore((s) => s.viewportRatio);
-// Pass it to computePhotoLayout:
-const photoLayout = computePhotoLayout(
-  displayMetas,
-  containerSize.w,
-  containerSize.h,
-  template,
-  viewportRatio, // NEW — pass viewportRatio
-);
-```
+1. Start dev server: `npm install && npm run dev -- --port 3006`
+2. Open in Playwright at desktop size (1280×800)
+3. Load demo: `http://localhost:3006/editor?demo=true`
+4. Click on Tokyo's photo area to open the layout editor
+5. Screenshot the edit dialog — note photo sizes and arrangement
+6. Close dialog, press Play, pause at Tokyo ARRIVE
+7. Screenshot playback — compare photo sizes and arrangement
+8. Identify the code difference causing the mismatch
 
-### Layout logic for 9:16:
-```typescript
-const isPortraitViewport = viewportRatio === "9:16" || viewportRatio === "3:4";
+## Files to Investigate
 
-if (isPortraitViewport) {
-  // Single column, photos stacked or in 2-column grid
-  if (photos.length <= 2) {
-    return computeTwoColumnLayout(photos, containerWidth, containerHeight);
-  } else {
-    // For 3+ photos in portrait: show 2-column, first photo spans full width on top
-    return computePortraitGalleryLayout(photos, containerWidth, containerHeight);
-  }
-}
-// For 16:9, 4:3, 1:1: use existing masonry logic unchanged
-```
+- `src/components/editor/PhotoLayoutEditor.tsx` (or similar — the layout editing dialog)
+- `src/components/editor/PhotoOverlay.tsx` — playback photo display
+- `src/components/editor/EditorLayout.tsx` — how playback triggers photo display
+- `src/components/editor/AlbumBook.tsx` — if playback uses this instead of PhotoOverlay
+- `src/lib/photoLayout.ts` — layout computation (should be same for both!)
 
-## Acceptance Criteria
+## Fix Approach
 
-1. In 9:16 viewport, each photo is clearly visible (min 200px wide)
-2. Photo captions and city labels are readable
-3. The 9:16 layout is distinctly different from the 16:9 layout
-4. Existing 16:9/4:3/1:1 behavior is unchanged
-5. No TypeScript errors, no console errors
+### For Bug 1 (WYSIWYG):
+- Both edit dialog and playback MUST use the same layout computation
+- Same container aspect ratio → same `computePhotoLayout()` call → same photo rects
+- If the edit dialog uses a different container mode, fix it to match playback
+- The playback PhotoOverlay should render photos at the same relative sizes/positions as the edit dialog
+
+### For Bug 2 (Free ratio):
+- In free mode, the edit dialog preview should read the actual map container dimensions
+- Pass the real aspect ratio to the layout computation
+- Don't hardcode a preview aspect ratio
 
 ## Testing
+- Open edit dialog, note layout
+- Play, pause at same city
+- Screenshots should look identical (same photo sizes, positions, proportions)
+- Test in 9:16, 16:9, AND free mode
 
-After making changes:
-1. Start the dev server: `cd /home/kaike/.openclaw/workspace/trace-recap && npx next start -p 3005 &`
-2. Open http://localhost:3005/editor?demo=true
-3. Click 9:16 aspect ratio button
-4. Play the animation to a location with photos (e.g., Tokyo)
-5. Verify photos are large and readable
-
-## Constraints
-- Do NOT change any 16:9 or other aspect ratio behavior
-- Do NOT add new dependencies
-- Keep the code clean and type-safe
-- Write no new tests (MVP budget)
+## Verification
+`npx tsc --noEmit` must pass.

--- a/src/components/editor/PhotoLayoutEditor.tsx
+++ b/src/components/editor/PhotoLayoutEditor.tsx
@@ -811,12 +811,7 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
       return { width: 0, height: 0 };
     }
 
-    if (viewportRatio === "free") {
-      return { width: panelSize.width, height: panelSize.height };
-    }
-
-    // Always fit to viewport aspect ratio — both normal and expanded modes
-    // This ensures 0-1 normalized coords render identically in editor and playback
+    // Always fit to viewport aspect ratio (including free mode) for WYSIWYG fidelity
     const { width: pw, height: ph } = panelSize;
     const targetRatio = previewAspect;
     const panelRatio = pw / ph;
@@ -830,34 +825,18 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
       w = ph * targetRatio;
     }
     return { width: w, height: h };
-  }, [panelSize, previewAspect, viewportRatio]);
+  }, [panelSize, previewAspect]);
 
   // Compute fitted preview container style — always preserve aspect ratio for WYSIWYG
   const previewContainerStyle = useMemo<React.CSSProperties>(() => {
-    if (viewportRatio === "free") {
-      return { width: "100%", height: "100%" };
-    }
-
     const pw = previewPixelSize.width;
     const ph = previewPixelSize.height;
     if (!pw || !ph) {
       return { width: "100%", height: "100%" };
     }
 
-    // Fit the target aspect ratio within the available panel, whether expanded or not
-    const targetRatio = previewAspect;
-    const panelRatio = pw / ph;
-
-    let w: number, h: number;
-    if (targetRatio > panelRatio) {
-      w = pw;
-      h = pw / targetRatio;
-    } else {
-      h = ph;
-      w = ph * targetRatio;
-    }
-    return { width: `${w}px`, height: `${h}px` };
-  }, [previewAspect, previewPixelSize.height, previewPixelSize.width, viewportRatio]);
+    return { width: `${pw}px`, height: `${ph}px` };
+  }, [previewPixelSize.height, previewPixelSize.width]);
 
   const orderedPhotos = useMemo(
     () => getOrderedPhotos(location.photos, photoOrder),
@@ -1248,7 +1227,6 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
           visible={true}
           photoLayout={layout}
           opacity={previewOpacity}
-          containerMode="parent"
           originCoordinates={location.coordinates}
           portalAccentColor={portalAccentColor}
           portalProgressOverride={1}

--- a/src/components/editor/PhotoOverlay.tsx
+++ b/src/components/editor/PhotoOverlay.tsx
@@ -216,7 +216,7 @@ interface PhotoOverlayProps {
   photoLayout?: PhotoLayout;
   opacity?: number; // 0-1, for fade-out transition
   bottomInsetPx?: number;
-  containerMode?: "viewport" | "parent"; // 'parent' uses 100% sizing instead of vw/vh
+  containerMode?: "viewport" | "parent"; // deprecated — always uses viewport-based sizing now
   originCoordinates?: [number, number];
   incomingOriginCoordinates?: [number, number];
   portalAccentColor?: string;
@@ -351,10 +351,6 @@ export default function PhotoOverlay({
     if (usesPortalLayout) {
       return { width: "100%", height: "100%" };
     }
-    if (containerMode === "parent") {
-      // Match the same inset as viewport mode for WYSIWYG fidelity
-      return { width: "95%", height: "88%" };
-    }
     if (viewportRatio === "9:16") {
       return { width: "98%", height: "92%" };
     }
@@ -368,7 +364,7 @@ export default function PhotoOverlay({
       };
     }
     return { width: "95%", height: "88%" };
-  }, [bottomInsetPx, viewportRatio, containerMode, usesPortalLayout]);
+  }, [bottomInsetPx, viewportRatio, usesPortalLayout]);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerSize, setContainerSize] = useState({ w: 0, h: 0 });


### PR DESCRIPTION
## Summary
- **Bug 1 (WYSIWYG):** Editor used `containerMode="parent"` (always 95%/88% insets) while playback used viewport-based sizing (98%/92% for 9:16, dynamic bottom inset for free mode). Removed the separate "parent" code path so both editor and playback use the identical container sizing logic from PhotoOverlay.
- **Bug 2 (Free ratio):** In free ratio mode, the editor preview filled 100% of the panel instead of letterboxing to the actual map canvas aspect ratio. Now the preview always letterboxes to match the viewport aspect, ensuring `computePhotoLayout()` produces identical rects in both editor and playback.

## Test plan
- [ ] Open layout editor for any city, note photo sizes and arrangement
- [ ] Close editor, press Play, pause at same city's ARRIVE phase
- [ ] Compare — photo sizes, positions, and proportions should be identical
- [ ] Test in 16:9, 9:16, and free aspect ratio modes
- [ ] Verify `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)