### PR TITLE
fix: WYSIWYG — template layout matches playback exactly

### DIFF
--- a/src/components/editor/PhotoLayoutEditor.tsx
+++ b/src/components/editor/PhotoLayoutEditor.tsx
@@ -847,13 +847,16 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
     () => orderedPhotoMetas.map((photo) => ({ id: photo.id, aspect: photo.aspect })),
     [orderedPhotoMetas],
   );
+  // Use the same 95%×88% inset dimensions that PhotoOverlay measures internally,
+  // so drag targets align with the actual photo positions.
+  const insetW = previewPixelSize.width * 0.95;
+  const insetH = previewPixelSize.height * 0.88;
   const computedRects = useMemo(() => {
-    if (!previewPixelSize.width || !previewPixelSize.height || layoutMetas.length === 0) {
+    if (!insetW || !insetH || layoutMetas.length === 0) {
       return [];
     }
 
-    const containerAspect = previewPixelSize.width / previewPixelSize.height;
-    const width = previewPixelSize.width;
+    const containerAspect = insetW / insetH;
     const gapPx = layout.gap ?? 8;
 
     if (layout.mode === "manual" && layout.template) {
@@ -862,13 +865,13 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
         containerAspect,
         layout.template,
         gapPx,
-        width,
+        insetW,
         layout.customProportions,
         layout.layoutSeed,
       );
     }
 
-    return computeAutoLayout(layoutMetas, containerAspect, gapPx, width);
+    return computeAutoLayout(layoutMetas, containerAspect, gapPx, insetW);
   }, [
     layout.customProportions,
     layout.gap,
@@ -876,16 +879,16 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
     layout.mode,
     layout.template,
     layoutMetas,
-    previewPixelSize.height,
-    previewPixelSize.width,
+    insetH,
+    insetW,
   ]);
   const fallbackFreeTransforms = useMemo(
     () => computedRectsToFreeTransforms(orderedPhotos, computedRects, {
-      containerWidthPx: previewPixelSize.width,
-      containerHeightPx: previewPixelSize.height,
+      containerWidthPx: insetW,
+      containerHeightPx: insetH,
       captionFontSizePx: layout.captionFontSize ?? 14,
     }),
-    [computedRects, layout.captionFontSize, orderedPhotos, previewPixelSize.height, previewPixelSize.width],
+    [computedRects, layout.captionFontSize, orderedPhotos, insetH, insetW],
   );
   const effectiveFreeTransforms = useMemo(
     () => reconcileFreeTransforms(orderedPhotos, fallbackFreeTransforms, layout.freeTransforms),

--- a/src/components/editor/PhotoOverlay.tsx
+++ b/src/components/editor/PhotoOverlay.tsx
@@ -481,7 +481,7 @@ export default function PhotoOverlay({
   // Caption sizing: scale proportionally based on container width (reference: 1000px)
   const captionScale = containerSize.w > 0 ? containerSize.w / 1000 : 1;
   const rawCaptionFontSizePx = (displayLayout?.captionFontSize ?? 14) * captionScale;
-  const captionFontSizePx = viewportRatio === "9:16" ? Math.max(rawCaptionFontSizePx, 14) : rawCaptionFontSizePx;
+  const captionFontSizePx = viewportRatio === "9:16" ? Math.max(rawCaptionFontSizePx, 14) : Math.max(rawCaptionFontSizePx, 7);
   const captionH = captionFontSizePx * 2;
   const captionFontFamily = displayLayout?.captionFontFamily ?? "system-ui";
   const displayIsFreeMode = displayLayout?.mode === "free";

--- a/src/lib/photoLayout.ts
+++ b/src/lib/photoLayout.ts
@@ -1,5 +1,13 @@
 import type { AspectRatio, FreePhotoTransform, LayoutTemplate, PhotoLayout as LayoutConfig } from "@/types";
 
+/**
+ * Reference width for gap normalization.
+ * Gap is always computed as gapPx / GAP_REFERENCE_WIDTH so layout proportions
+ * are identical regardless of the actual container pixel size (critical for
+ * WYSIWYG fidelity between the small editor preview and full-size playback).
+ */
+const GAP_REFERENCE_WIDTH = 1000;
+
 export interface PhotoRect {
   /** All values as fractions of container (0-1) */
   x: number;
@@ -528,8 +536,8 @@ export function computeAutoLayout(
   const n = photos.length;
   if (n === 0) return [];
 
-  // Gap as fraction of container width
-  const gap = gapPx / containerWidthPx;
+  // Gap as fraction of reference width (resolution-independent for WYSIWYG)
+  const gap = gapPx / GAP_REFERENCE_WIDTH;
   let rects: PhotoRect[];
 
   switch (n) {
@@ -590,7 +598,7 @@ export function computePhotoLayout(
     containerWidthPx > 0 && containerHeightPx > 0
       ? containerWidthPx / containerHeightPx
       : 16 / 9;
-  const gap = gapPx / widthPx;
+  const gap = gapPx / GAP_REFERENCE_WIDTH;
 
   if (shouldUsePortraitFriendlyLayout(viewportRatio)) {
     return layoutPortraitReadableGallery(photos, containerAspect, gap, layout?.template);
@@ -991,8 +999,7 @@ export function computeTemplateLayout(
   layoutSeed?: number
 ): PhotoRect[] {
   const gapPx = gap ?? 8;
-  const widthPx = containerWidthPx ?? 1000;
-  const g = gapPx / widthPx; // gap as fraction
+  const g = gapPx / GAP_REFERENCE_WIDTH; // gap as fraction (resolution-independent)
 
   switch (template) {
     case "grid":
@@ -1018,7 +1025,7 @@ export function computeTemplateLayout(
     case "magazine":
       return layoutMagazine(photos, containerAspect, g);
     default:
-      return computeAutoLayout(photos, containerAspect, gapPx, widthPx);
+      return computeAutoLayout(photos, containerAspect, gapPx);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Gap normalization**: Template layouts computed gap as `gapPx / containerWidthPx`, producing a ~4x larger proportional gap in the small editor preview (~285px) vs playback (~1216px). Now uses a fixed 1000px reference width so layout proportions are identical at any container size.
- **Drag target alignment**: Editor's `computedRects` now uses the same 95%×88% inset dimensions that PhotoOverlay measures internally, so hit targets match the actual photo positions.
- **Caption readability**: Added 7px minimum caption font size so `captionFontFamily`/`captionFontSize` changes are visible in the editor preview (previously scaled to ~4px, making all fonts look identical).

## Test plan
- [ ] Open editor demo, click Tokyo photos (magazine template) — editor preview arrangement should match playback
- [ ] Change captionFontFamily in editor — preview should visually update
- [ ] Change captionFontSize — preview caption size should change
- [ ] Test other templates: grid, hero, polaroid, scatter, rows
- [ ] Verify free layout still works correctly (no changes to free mode)
- [ ] `npx tsc --noEmit` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)