### PR TITLE
fix: default stopovers to collapsed in bottom sheet

### DIFF
--- a/src/components/editor/RouteList.tsx
+++ b/src/components/editor/RouteList.tsx
@@ -439,7 +439,7 @@ export default memo(function RouteList({
       const totalDistance = groupSegments.reduce((sum, segment) => sum + (getSegmentDistance(segment) ?? 0), 0);
       const summaryDistance = formatDistance(totalDistance || null);
       const groupKey = `${location.id}-stopovers`;
-      const isCollapsed = collapsedGroups[groupKey] ?? false;
+      const isCollapsed = collapsedGroups[groupKey] ?? true;
 
       timelineItems.push(
         <div key={groupKey} className="relative">


### PR DESCRIPTION
## Summary
- Stopovers section in the route list bottom sheet now defaults to collapsed instead of expanded

## Test plan
- [ ] Open editor, check stopovers group is collapsed by default
- [ ] Click to expand, verify it still works
- [ ] Close and reopen bottom sheet, confirm still defaults to collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)