### PR TITLE
fix: WYSIWYG — layout editor preview matches playback resolution

### DIFF
--- a/src/components/editor/PhotoLayoutEditor.tsx
+++ b/src/components/editor/PhotoLayoutEditor.tsx
@@ -875,9 +875,20 @@ export default function PhotoLayoutEditor({ location, onClose }: PhotoLayoutEdit
     return w / h;
   }, [capturedMapSize, panelSize, viewportRatio]);
 
+  // WYSIWYG: compute layout at playback resolution (capturedMapSize), then scale
+  // down to fit the editor panel. This ensures photo sizes, gaps, and positions
+  // match what the user will see during actual playback.
   const previewSourceSize = useMemo(() => {
-    if (viewportRatio === "free" && capturedMapSize && capturedMapSize.width > 0 && capturedMapSize.height > 0) {
-      return capturedMapSize;
+    if (capturedMapSize && capturedMapSize.width > 0 && capturedMapSize.height > 0) {
+      if (viewportRatio === "free") {
+        return capturedMapSize;
+      }
+      // For fixed ratios, use the captured map width and derive height from aspect
+      const targetRatio = previewAspect;
+      return {
+        width: capturedMapSize.width,
+        height: capturedMapSize.width / targetRatio,
+      };
     }
     if (!panelSize) {
       return { width: 0, height: 0 };


### PR DESCRIPTION
## Summary
The photo layout editor was computing layouts at the small editor panel size, making photos appear much smaller than during playback. This violated the WYSIWYG principle.

**Fix**: Use `capturedMapSize` (actual map container dimensions) as the source size for `computePhotoLayout`, then scale the preview down to fit the panel. Photos, gaps, and proportions now match playback.

## Before/After
- Before: photos at ~45% preview width, small thumbnails
- After: photos at ~75% preview width, matching playback proportions

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Playwright desktop: Alishan layout editor — photos proportionally larger
- [x] iOS Simulator mobile: Alishan layout editor — same improvement
- [x] Desktop before/after screenshot comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)