### PR TITLE
fix: handle broken avatar image gracefully

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,7 +25,7 @@ const nextConfig: NextConfig = {
               "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.posthog.com https://va.vercel-scripts.com",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.mapbox.com",
               "font-src 'self' https://fonts.gstatic.com",
-              "img-src 'self' blob: data: https://*.mapbox.com https://*.googleapis.com https://*.googleusercontent.com https://*.supabase.co https://tile.openstreetmap.org",
+              "img-src 'self' blob: data: https://*.mapbox.com https://*.googleapis.com https://*.googleusercontent.com https://*.ggpht.com https://*.supabase.co https://tile.openstreetmap.org",
               "connect-src 'self' https://*.mapbox.com https://*.supabase.co https://*.posthog.com https://va.vercel-scripts.com https://vitals.vercel-insights.com",
               "worker-src 'self' blob:",
               "frame-ancestors 'none'",

--- a/src/components/editor/AuthButton.tsx
+++ b/src/components/editor/AuthButton.tsx
@@ -23,6 +23,7 @@ export default function AuthButton() {
   const [authDialogOpen, setAuthDialogOpen] = useState(false);
   const [myFeedbackOpen, setMyFeedbackOpen] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [avatarError, setAvatarError] = useState(false);
   const user = useAuthStore((s) => s.user);
   const initialized = useAuthStore((s) => s.initialized);
   const signOut = useAuthStore((s) => s.signOut);
@@ -79,12 +80,13 @@ export default function AuthButton() {
             />
           }
         >
-          {avatarUrl ? (
+          {avatarUrl && !avatarError ? (
             <img
               src={avatarUrl}
               alt={displayName}
               className="h-6 w-6 rounded-full"
               referrerPolicy="no-referrer"
+              onError={() => setAvatarError(true)}
             />
           ) : (
             <User className="h-4 w-4" style={{ color: "#78716c" }} />


### PR DESCRIPTION
## Summary
- Avatar `<img>` now has `onError` fallback — shows User icon when image fails to load
- Added `*.ggpht.com` to CSP `img-src` for Google avatar alternate domain

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Sign in with Google — avatar shows or gracefully falls back to icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)